### PR TITLE
Readme and Example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Checks if an input element contains a certain value.
 
 ```js
 const myInput = $('input')
-expect(myInput).toHaveValue('us')
+expect(myInput).toHaveValueContaining('us')
 ```
 
 ### toBeClickable

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -36,6 +36,14 @@ describe('suite', () => {
         expect($$('button')).toBeElementsArrayOfSize(3)
     })
 
+    it('checks text values', () => {
+        // assert certain text accurate
+        const repoTitle = $('expect-webdriverio')
+        expect(repoTitle).toHaveText('expect-webdriverio')
+        // or ignore the case and only check that a substring is present
+        expect(repoTitle).toHaveTextContaining('webdriverio', { ignoreCase: true })
+    })
+
     it('advanced', () => {
         const myInput = $('input')
 


### PR DESCRIPTION
- updated potential typo in the Readme API for `HasValueContaining()`
- added example that uses `toHaveText` and `toHaveTextContaining()`