### PR TITLE
fix .not types

### DIFF
--- a/test-types/types.ts
+++ b/test-types/types.ts
@@ -1,3 +1,4 @@
 expect({}).toBeDisabled()
 expect({}).toHaveAttr('test')
+expect({}).not.toHaveAttr('test')
 expect('foo').toBe('bar')

--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="expect-webdriverio/types/expect-webdriverio"/>
 
 declare namespace ExpectWebdriverIO {
-    interface Matchers <R,T> extends Readonly<import('expect/build/types').Matchers<R>> {}
+    interface Matchers <R,T> extends Readonly<import('expect/build/types').Matchers<R>> {
+        not: Matchers <R,T>
+        resolves: Matchers<Promise<R>, T>
+        rejects: Matchers<Promise<R>, T>
+    }
     type Expect = {
         <T = unknown>(actual: T): Matchers<T, T>;
     }


### PR DESCRIPTION
Fix types for `.not` matchers like `expect(section).not.toHaveClass('page2')`

fixes #171