### PR TITLE
fix toBeRequested message

### DIFF
--- a/src/matchers/mock/toBeRequested.ts
+++ b/src/matchers/mock/toBeRequested.ts
@@ -1,25 +1,8 @@
-import { waitUntil, enhanceError } from '../../utils'
+import { toBeRequestedTimes } from './toBeRequestedTimes'
 import { runExpect } from '../../util/expectAdapter'
 
 function toBeRequestedFn(received: WebdriverIO.Mock, options: ExpectWebdriverIO.CommandOptions = {}): any {
-    const isNot = this.isNot || false
-    const { expectation = `called`, verb = 'be' } = this
-
-    return browser.call(async () => {
-        let actual
-
-        const pass = await waitUntil(async () => {
-            actual = received.calls.length
-            return actual > 0
-        }, isNot, options)
-
-        const message = enhanceError('mock', 0, actual, this, verb, expectation, '', options)
-
-        return {
-            pass,
-            message: (): string => message
-        }
-    })
+    return toBeRequestedTimes.call({ ...(this || {}), expectation: 'called' }, received, { ...options, gte: 1 })
 }
 
 export function toBeRequested(...args: any): any {

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -2,13 +2,20 @@ import { waitUntil, enhanceError, compareNumbers } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 import { numberError } from '../../util/formatMessage'
 
-function toBeRequestedTimesFn(received: WebdriverIO.Mock, times: number | ExpectWebdriverIO.NumberOptions = {}, options: ExpectWebdriverIO.CommandOptions = {}): any {
+export function toBeRequestedTimesFn(received: WebdriverIO.Mock, times: number | ExpectWebdriverIO.NumberOptions = {}, options: ExpectWebdriverIO.NumberOptions = {}): any {
     const isNot = this.isNot || false
     const { expectation = `called${typeof times === 'number' ? ' ' + times : '' } time${times !== 1 ? 's' : ''}`, verb = 'be' } = this
 
-    const eq = typeof times === 'number' ? times : times.eq
-    const gte = typeof times === 'number' ? 1 : (times.gte || 1)
-    const lte = typeof times === 'number' ? 0 : (times.lte || 0)
+    // type check
+    if (typeof times === 'number') {
+        options.eq = times
+    } else if (typeof times === 'object') {
+        options = { ...options, ...times }
+    }
+
+    const eq = options.eq
+    const gte = options.gte || 1
+    const lte = options.lte || 0
 
     return browser.call(async () => {
         let actual
@@ -16,7 +23,7 @@ function toBeRequestedTimesFn(received: WebdriverIO.Mock, times: number | Expect
         const pass = await waitUntil(async () => {
             actual = received.calls.length
             return compareNumbers(actual, gte, lte, eq)
-        }, isNot, options)
+        }, isNot, { ...options, wait: isNot ? 0 : options.wait })
 
         const error = numberError(gte, lte, eq)
         const message = enhanceError('mock', error, actual, this, verb, expectation, '', options)

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -102,7 +102,7 @@ export const enhanceErrorBe = (
     return enhanceError(subject, not(context.isNot) + expectation, not(!pass) + expectation, context, verb, expectation, '', options)
 }
 
-export const numberError = (gte: number, lte: number, eq?: number): any => {
+export const numberError = (gte: number, lte?: number, eq?: number): any => {
     if (typeof eq === 'number') {
         return eq
     }

--- a/test/matchers/mock/toBeCalled.test.ts
+++ b/test/matchers/mock/toBeCalled.test.ts
@@ -1,5 +1,6 @@
 import { toBeRequested } from '../../../src/matchers/mock/toBeRequested'
 import { Matches } from 'webdriverio'
+import { getExpected, getExpectMessage, getReceived, removeColors } from '../../__fixtures__/utils'
 
 class TestMock {
     _calls: any[]
@@ -59,8 +60,10 @@ describe('toBeRequested', () => {
     test('message', async () => {
         const mock: WebdriverIO.Mock = new TestMock()
 
-        const result = await toBeRequested(mock)
-        expect(result.message()).toContain('Expect mock to be called')
+        const message = removeColors((await toBeRequested(mock)).message())
+        expect(getExpectMessage(message)).toBe('Expect mock to be called')
+        expect(getReceived(message)).toBe('Received: 0')
+        expect(getExpected(message)).toBe('Expected: ">= 1"')
 
         const result2 = await toBeRequested.call({ isNot: true }, mock)
         expect(result2.message()).toContain('Expect mock not to be called')


### PR DESCRIPTION
- fix to `toBeRequested` message #188
- don't wait for `mock.calls.length` to decrease #189

![image](https://user-images.githubusercontent.com/25589559/93002858-3d164780-f53a-11ea-8ac7-62213d3e234b.png)
