### PR TITLE
body matcher object type support

### DIFF
--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -112,12 +112,12 @@ const headersMatcher = (
  * is request/response matching an expected condition
  */
 const bodyMatcher = (
-    body: string | undefined,
+    body: string | ExpectWebdriverIO.JsonCompatible | undefined,
     expected?:
         | string
         | ExpectWebdriverIO.JsonCompatible
         | ExpectWebdriverIO.PartialMatcher
-        | ((r: string | undefined) => boolean)
+        | ((r: string | ExpectWebdriverIO.JsonCompatible | undefined) => boolean)
 ) => {
     if (typeof expected === 'undefined') {
         return true
@@ -132,7 +132,7 @@ const bodyMatcher = (
     let parsedBody = body
 
     // convert request body from string to JSON if expected value is JSON-like
-    if (isExpectedJsonLike(expected)) {
+    if (typeof(body) === 'string' && isExpectedJsonLike(expected)) {
         parsedBody = tryParseBody(body)
 
         // failed to parse string as JSON
@@ -207,12 +207,14 @@ const minifyRequestMock = (
         url: requestMock.url,
         method: requestMock.method,
         headers: requestMock.headers,
-        request: isExpectedJsonLike(requestedWith.request)
-            ? tryParseBody(requestMock.postData, requestMock.postData)
-            : requestMock.postData,
-        response: isExpectedJsonLike(requestedWith.response)
-            ? tryParseBody(requestMock.body, requestMock.body)
-            : requestMock.body,
+        request:
+            typeof requestMock.body === 'string' && isExpectedJsonLike(requestedWith.request)
+                ? tryParseBody(requestMock.postData, requestMock.postData)
+                : requestMock.postData,
+        response:
+            typeof requestMock.body === 'string' && isExpectedJsonLike(requestedWith.response)
+                ? tryParseBody(requestMock.body, requestMock.body)
+                : requestMock.body,
     }
 
     deleteUndefinedValues(r, requestedWith)

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -21,16 +21,14 @@ const mockGet: Matches = {
         total: 100,
         page: 1,
         data: {
-            result: {
-                aLongValue1: {
-                    k1: { value1: 'bar1' },
-                    k2: { value2: 'bar2' },
-                },
-                foo: { id: 1 },
-                bar: { id: 2 },
-                longValue2: { value: 'foo2' },
-                longValue3: { value: 'foo3' },
+            aLongValue1: {
+                k1: { value1: 'bar1' },
+                k2: { value2: 'bar2' },
             },
+            foo: { id: 1 },
+            bar: { id: 2 },
+            longValue2: { value: 'foo2' },
+            longValue3: { value: 'foo3' },
         },
     }),
     initialPriority: 'Low',
@@ -58,7 +56,7 @@ describe('toBeRequestedWith', () => {
             mock.calls.push({ ...mockGet })
         }, 5)
         setTimeout(() => {
-            mock.calls.push({ ...mockGet }, { ...mockPost })
+            mock.calls.push({ ...mockGet }, { ...mockPost, body: JSON.parse(mockPost.body) })
         }, 15)
 
         const params = {


### PR DESCRIPTION
Didn't know that `body` can be an object.
The PR fixes it.