### PR TITLE
improve types for Jasmine's expectAsync

### DIFF
--- a/jasmine.d.ts
+++ b/jasmine.d.ts
@@ -2,5 +2,5 @@
 
 declare module jasmine {
     interface Matchers<T> extends ExpectWebdriverIO.Matchers<any, T> {}
-    interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<any, T> {}
+    interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
 }

--- a/test-types/jasmine/expectAsync.ts
+++ b/test-types/jasmine/expectAsync.ts
@@ -2,8 +2,10 @@ declare const promise: Promise<object>
 
 it('should do something', () => {
     // Promises shouldn't have the `foo` method.
-    // @ts-expect-error
-    expectAsync(promise).toBeDisplayed().foo()
+    expectAsync(promise)
+        .toBeDisplayed()
+        // @ts-expect-error
+        .foo()
 
     expectAsync(promise).toBeDisplayed().then()
 })

--- a/test-types/jasmine/expectAsync.ts
+++ b/test-types/jasmine/expectAsync.ts
@@ -1,0 +1,7 @@
+declare const promise: Promise<object>
+
+it('should do something', () => {
+    // Promises shouldn't have the `foo` method.
+    // @ts-expect-error
+    expectAsync(promise).toBeDisplayed().foo()
+})

--- a/test-types/jasmine/expectAsync.ts
+++ b/test-types/jasmine/expectAsync.ts
@@ -4,4 +4,6 @@ it('should do something', () => {
     // Promises shouldn't have the `foo` method.
     // @ts-expect-error
     expectAsync(promise).toBeDisplayed().foo()
+
+    expectAsync(promise).toBeDisplayed().then()
 })


### PR DESCRIPTION
Expressions like `expectAsync($("#foo")).toBeDisplayed()` are now typed as `any`, not `Promise<void>`. Because of this it's impossible to use [the `@typescript-eslint/no-floating-promises` rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md) to make sure that `expectAsync` expectations are correctly `await`ed.