### PR TITLE
fix TS error in a test

### DIFF
--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -26,6 +26,7 @@ export function toBeRequestedWithFn(
                         headersMatcher(call.headers, requestedWith.requestHeaders) &&
                         headersMatcher(call.responseHeaders, requestedWith.responseHeaders) &&
                         bodyMatcher(call.postData, requestedWith.postData) &&
+                        !Buffer.isBuffer(call.body) &&
                         bodyMatcher(call.body, requestedWith.response)
                     ) {
                         return true


### PR DESCRIPTION
fix this:
```console
 FAIL  test/matchers/mock/toBeRequestedWith.test.ts
  ● Test suite failed to run
    src/matchers/mock/toBeRequestedWith.ts:29:37 - error TS2345: Argument of type 'string | Buffer | JsonObject | JsonArray' is not assignable to parameter of type 'string | jsonObject | jsonArray | undefined'.
      Type 'Buffer' is not assignable to type 'string | jsonObject | jsonArray | undefined'.
        Type 'Buffer' is not assignable to type 'jsonObject'.
          Index signature is missing in type 'Buffer'.
    29                         bodyMatcher(call.body, requestedWith.response)
                                           ~~~~~~~~~
```