### PR TITLE
Body as buffer

### DIFF
--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -26,7 +26,6 @@ export function toBeRequestedWithFn(
                         headersMatcher(call.headers, requestedWith.requestHeaders) &&
                         headersMatcher(call.responseHeaders, requestedWith.responseHeaders) &&
                         bodyMatcher(call.postData, requestedWith.postData) &&
-                        !Buffer.isBuffer(call.body) &&
                         bodyMatcher(call.body, requestedWith.response)
                     ) {
                         return true

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -128,12 +128,12 @@ const headersMatcher = (
  * is postData/response matching an expected condition
  */
 const bodyMatcher = (
-    body: string | ExpectWebdriverIO.JsonCompatible | undefined,
+    body: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined,
     expected?:
         | string
         | ExpectWebdriverIO.JsonCompatible
         | ExpectWebdriverIO.PartialMatcher
-        | ((r: string | ExpectWebdriverIO.JsonCompatible | undefined) => boolean)
+        | ((r: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined) => boolean)
 ) => {
     if (typeof expected === 'undefined') {
         return true
@@ -146,6 +146,9 @@ const bodyMatcher = (
     }
 
     let parsedBody = body
+    if (body instanceof Buffer) {
+        parsedBody = body.toString()
+    }
 
     // convert postData/body from string to JSON if expected value is JSON-like
     if (typeof(body) === 'string' && isExpectedJsonLike(expected)) {

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -322,10 +322,10 @@ describe('toBeRequestedWith', () => {
         },
         {
             name: 'body as Buffer',
-            mocks: [{ ...mockGet, body: 'asd' }],
+            mocks: [{ ...mockGet, body: Buffer.from('asd') }],
             pass: true,
             params: {
-                response: Buffer.from('asd', 'binary'),
+                response: 'asd',
             },
         },
         {

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -321,6 +321,14 @@ describe('toBeRequestedWith', () => {
             },
         },
         {
+            name: 'body as Buffer',
+            mocks: [{ ...mockGet, body: 'asd' }],
+            pass: true,
+            params: {
+                response: Buffer.from('asd', 'binary'),
+            },
+        },
+        {
             name: 'body as JSON',
             mocks: [{ ...mockGet, body: 'asd' }],
             pass: false,


### PR DESCRIPTION
Body can be a `Buffer` in WebdriverIO

https://github.com/webdriverio/webdriverio/blob/d2fbe0923b95392793e2e0c7138aa712492ea94d/packages/webdriverio/webdriverio-core.d.ts#L563