### PR TITLE
To have attribute improvement + improved test coverage

### DIFF
--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,20 +1,25 @@
 import { waitUntil, enhanceError, compareText, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-async function condition(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions): Promise<any> {
+async function conditionAttr(el: WebdriverIO.Element, attribute: string): Promise<any> {
+    const attr = await el.getAttribute(attribute)
+    if (typeof attr !== 'string') {
+        return { result: false, value: attr }
+    } else {
+        return { result: true, value: attr }
+    }
+}
+
+async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions): Promise<any> {
     const attr = await el.getAttribute(attribute)
     if (typeof attr !== 'string') {
         return { result: false, value: attr }
     }
 
-    if (typeof value !== 'string') {
-        return { result: true, value: attr }
-    }
-
     return compareText(attr, value, options)
 }
 
-export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value?: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
@@ -22,7 +27,7 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
         let el = await received
         let attr
         const pass = await waitUntil(async () => {
-            const result = await executeCommand.call(this, el, condition, options, [attribute, value, options])
+            const result = await executeCommand.call(this, el, conditionAttrAndValue, options, [attribute, value, options])
             el = result.el
             attr = result.values
 
@@ -46,8 +51,43 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
     })
 }
 
+export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string): any {
+    const isNot = this.isNot
+    const { expectation = 'attribute', verb = 'have' } = this
+
+    return browser.call(async () => {
+        let el = await received
+        let attr
+        const pass = await waitUntil(async () => {
+            const result = await executeCommand.call(this, el, conditionAttr, {}, [attribute])
+            el = result.el
+            attr = result.values
+
+            return result.success
+        }, isNot, {})
+
+        updateElementsArray(pass, received, el)
+
+        let message: string
+        message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, {})
+
+        return {
+            pass,
+            message: (): string => message
+        }
+    })
+}
+
 export function toHaveAttribute(...args: any): any {
-    return runExpect.call(this, toHaveAttributeFn, args)
+    if(typeof args[1] === 'string') {
+        if(typeof args[2] === 'string') {
+            // Name and value is passed in e.g. toHaveAttribute('attr', 'value')
+            return runExpect.call(this, toHaveAttributeAndValueFn, args)
+        } else {
+            // Only name is passed in e.g. toHaveAttribute('attr')
+            return runExpect.call(this, toHaveAttributeFn, args)
+        }
+    }
 }
 
 export const toHaveAttr = toHaveAttribute

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -36,10 +36,8 @@ export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | Webdri
 
         updateElementsArray(pass, received, el)
 
-        let message: string
-        
         const expected = wrapExpectedWithArray(el, attr, value)
-        message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
+        const message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
     
         return {
             pass,
@@ -65,8 +63,7 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
 
         updateElementsArray(pass, received, el)
 
-        let message: string
-        message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, {})
+        const message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, {})
 
         return {
             pass,

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -37,13 +37,10 @@ export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | Webdri
         updateElementsArray(pass, received, el)
 
         let message: string
-        if (typeof value === 'string') {
-            const expected = wrapExpectedWithArray(el, attr, value)
-            message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
-        } else {
-            message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, options)
-        }
-
+        
+        const expected = wrapExpectedWithArray(el, attr, value)
+        message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
+    
         return {
             pass,
             message: (): string => message
@@ -79,14 +76,12 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
 }
 
 export function toHaveAttribute(...args: any): any {
-    if(typeof args[1] === 'string') {
-        if(typeof args[2] === 'string') {
-            // Name and value is passed in e.g. toHaveAttribute('attr', 'value')
-            return runExpect.call(this, toHaveAttributeAndValueFn, args)
-        } else {
-            // Only name is passed in e.g. toHaveAttribute('attr')
-            return runExpect.call(this, toHaveAttributeFn, args)
-        }
+    if(args.length===3 || args.length===4 ) {
+        // Name and value is passed in e.g. el.toHaveAttribute('attr', 'value', (opts))
+        return runExpect.call(this, toHaveAttributeAndValueFn, args)
+    } else {
+        // Only name is passed in e.g. el.toHaveAttribute('attr')
+        return runExpect.call(this, toHaveAttributeFn, args)
     }
 }
 

--- a/src/matchers/element/toHaveAttributeContaining.ts
+++ b/src/matchers/element/toHaveAttributeContaining.ts
@@ -1,8 +1,8 @@
 import { runExpect } from '../../util/expectAdapter'
-import { toHaveAttributeFn } from './toHaveAttribute'
+import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
 function toHaveAttributeContainingFn(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeFn.call(this, el, attribute, value, {
+    return toHaveAttributeAndValueFn.call(this, el, attribute, value, {
         ...options,
         containing: true
     })

--- a/src/matchers/element/toHaveElementClassContaining.ts
+++ b/src/matchers/element/toHaveElementClassContaining.ts
@@ -1,8 +1,8 @@
 import { runExpect } from '../../util/expectAdapter'
-import { toHaveAttributeFn } from './toHaveAttribute'
+import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
 function toHaveElementClassContainingFn(el: WebdriverIO.Element, className: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeFn.call(this, el, 'class', className, {
+    return toHaveAttributeAndValueFn.call(this, el, 'class', className, {
         ...options,
         containing: true
     })

--- a/src/matchers/element/toHaveElementClassContaining.ts
+++ b/src/matchers/element/toHaveElementClassContaining.ts
@@ -12,7 +12,6 @@ export function toHaveElementClassContaining(...args: any): any {
     return runExpect.call(this, toHaveElementClassContainingFn, args)
 }
 
-
 /**
  * toHaveClass conflicts with Jasmine's https://jasmine.github.io/api/edge/matchers#toHaveClass matcher
  * and will be removed from expect-webdriverio in favor of `toHaveElementClass`

--- a/src/matchers/element/toHaveHref.ts
+++ b/src/matchers/element/toHaveHref.ts
@@ -1,8 +1,8 @@
 import { runExpect } from '../../util/expectAdapter'
-import { toHaveAttributeFn } from './toHaveAttribute'
+import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
 export function toHaveHrefFn(el: WebdriverIO.Element, href: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeFn.call(this, el, 'href', href, options)
+    return toHaveAttributeAndValueFn.call(this, el, 'href', href, options)
 }
 
 export function toHaveHref(...args: any): any {

--- a/src/matchers/element/toHaveId.ts
+++ b/src/matchers/element/toHaveId.ts
@@ -1,8 +1,8 @@
 import { runExpect } from '../../util/expectAdapter'
-import { toHaveAttributeFn } from './toHaveAttribute'
+import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
 export function toHaveIdFn(el: WebdriverIO.Element, id: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeFn.call(this, el, 'id', id, options)
+    return toHaveAttributeAndValueFn.call(this, el, 'id', id, options)
 }
 
 export function toHaveId(...args: any): any {

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -25,7 +25,7 @@ describe('toHaveAttribute', () => {
             expect(result.pass).toBe(false)
         })
 
-        describe('message shows correctly', async () => {
+        describe('message shows correctly', () => {
             let result: any
 
             beforeEach(async () => {
@@ -75,7 +75,7 @@ describe('toHaveAttribute', () => {
             const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
             expect(result.pass).toBe(false)
         })
-        describe('message shows correctly', async () => {
+        describe('message shows correctly', () => {
             let result: any
 
             beforeEach(async () => {

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -1,0 +1,212 @@
+import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute';
+
+describe('toHaveAttribute', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+    })    
+
+    test('wait for success', async () => {
+        el._attempts = 2
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(el._attempts > 0) {
+                el._attempts --;
+                return "Wrong Value"
+        }
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
+    test('wait but failure', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            throw new Error('some error');
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
+        expect(result.pass).toBe(false)
+    })
+
+    test('success on the first attempt', async () => {
+        el._attempts = 0
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el._attempts ++
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
+    test('failure with non-string attribute value as actual', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return 123
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(false)
+    })
+
+    test('failure with non-string attribute value as expected', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+        expect(result.pass).toBe(true)
+    })
+
+    test('success with check for attribute presence', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name");
+        expect(result.pass).toBe(true)
+    })
+
+    // test('no wait - failure', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: "Wrong Value" }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(false)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('no wait - success', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0;
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('not - failure', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
+    //     const received = getReceived(result.message())
+
+    //     expect(received).not.toContain('not')
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('should return false if styles dont match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const wrongStyle: { [key: string]: string; } = {
+    //         "font-family": "Incorrect Font",
+    //         "font-size": "100px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('should return true if styles match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('message shows correctly', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: "Wrong Value" }
+    //     })
+    //     const result = await toHaveStyle(el, 'WebdriverIO')
+    //     expect(getExpectMessage(result.message())).toContain('to have style')
+    // })
+
+    // test('success if style matches with ignoreCase', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredCaseStyle: { [key: string]: string; } = {
+    //         "font-family": "FaKtum",
+    //         "font-size": "26px",
+    //         "color": "#FFF"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+    
+    // test('success if style matches with trim', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "   Faktum   ",
+    //         "font-size": "   26px   ",
+    //         "color": "    #fff     "
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredSpaceStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+})

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -1,4 +1,4 @@
-import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
 import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute';
 
 describe('toHaveAttribute', () => {
@@ -8,205 +8,91 @@ describe('toHaveAttribute', () => {
         el = await $('sel')
     })    
 
-    test('wait for success', async () => {
-        el._attempts = 2
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            if(el._attempts > 0) {
-                el._attempts --;
-                return "Wrong Value"
-        }
-            return "Correct Value"
+    describe('attribute exists', () => {
+        test('success when present', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name");
+            expect(result.pass).toBe(true)
         })
-        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-        expect(result.pass).toBe(true)
-        expect(el._attempts).toBe(0)
-    })
 
-    test('wait but failure', async () => {
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            throw new Error('some error');
+        test('failure when not present', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return null
+            })
+            const result = await toHaveAttribute(el, "attribute_name");
+            expect(result.pass).toBe(false)
         })
-        const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
-        expect(result.pass).toBe(false)
-    })
 
-    test('success on the first attempt', async () => {
-        el._attempts = 0
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            el._attempts ++
-            return "Correct Value"
+        describe('message shows correctly', async () => {
+            let result: any
+
+            beforeEach(async () => {
+                el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                    return null
+                })
+                result = await toHaveAttribute(el, "attribute_name");
+            })
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('true')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('false')
+            })
         })
-        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-        expect(result.pass).toBe(true)
-        expect(el._attempts).toBe(1)
     })
-
-    test('failure with non-string attribute value as actual', async () => {
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            return 123
-        })
-        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-        expect(result.pass).toBe(false)
-    })
-
-    test('failure with non-string attribute value as expected', async () => {
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            return "Correct Value"
-        })
-        const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
-        expect(result.pass).toBe(true)
-    })
-
-    test('success with check for attribute presence', async () => {
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            return "Correct Value"
-        })
-        const result = await toHaveAttribute(el, "attribute_name");
-        expect(result.pass).toBe(true)
-    })
-
-    // test('no wait - failure', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: "Wrong Value" }
-    //     })
-
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(false)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('no wait - success', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0;
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('not - failure', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
-    //     const received = getReceived(result.message())
-
-    //     expect(received).not.toContain('not')
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('should return false if styles dont match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const wrongStyle: { [key: string]: string; } = {
-    //         "font-family": "Incorrect Font",
-    //         "font-size": "100px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
-    //     expect(result.pass).toBe(false)
-    // })
-
-    // test('should return true if styles match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('message shows correctly', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: "Wrong Value" }
-    //     })
-    //     const result = await toHaveStyle(el, 'WebdriverIO')
-    //     expect(getExpectMessage(result.message())).toContain('to have style')
-    // })
-
-    // test('success if style matches with ignoreCase', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredCaseStyle: { [key: string]: string; } = {
-    //         "font-family": "FaKtum",
-    //         "font-size": "26px",
-    //         "color": "#FFF"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
     
-    // test('success if style matches with trim', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
+    describe('attribute has value', () => {
+        test('success with correct value', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            expect(result.pass).toBe(true)
+        })
+        test('failure with wrong value', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "Wrong Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            expect(result.pass).toBe(false)
+        })
+        test('failure with non-string attribute value as actual', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return 123
+            })
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            expect(result.pass).toBe(false)
+        })
+        test('failure with non-string attribute value as expected', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+            expect(result.pass).toBe(false)
+        })
+        describe('message shows correctly', async () => {
+            let result: any
 
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "   Faktum   ",
-    //         "font-size": "   26px   ",
-    //         "color": "    #fff     "
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredSpaceStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
+            beforeEach(async () => {
+                el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                    return "Wrong"
+                })
+                result = await toHaveAttribute(el, "attribute_name", "Correct");
+            })
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('Correct')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('Wrong')
+            })
+        })
+    })
 })

--- a/test/matchers/element/toHaveAttributeContaining.test.ts
+++ b/test/matchers/element/toHaveAttributeContaining.test.ts
@@ -1,7 +1,7 @@
 import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
 import { toHaveAttrContaining } from '../../../src/matchers/element/toHaveAttributeContaining';
 
-describe('toHaveAttribute', () => {
+describe('toHaveAttributeContaining', () => {
     let el: WebdriverIO.Element
 
     beforeEach(async () => { 
@@ -16,7 +16,7 @@ describe('toHaveAttribute', () => {
         expect(result.pass).toBe(true)
     });
 
-    describe('failure when deosnt contain', () => {
+    describe('failure when doesnt contain', () => {
         let result: any
 
         beforeEach(async () => {

--- a/test/matchers/element/toHaveAttributeContaining.test.ts
+++ b/test/matchers/element/toHaveAttributeContaining.test.ts
@@ -30,7 +30,7 @@ describe('toHaveAttribute', () => {
             expect(result.pass).toBe(false)
         })
 
-        describe('message shows correctly', async () => {
+        describe('message shows correctly', () => {
             test('expect message', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute')
             })

--- a/test/matchers/element/toHaveAttributeContaining.test.ts
+++ b/test/matchers/element/toHaveAttributeContaining.test.ts
@@ -1,0 +1,46 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveAttrContaining } from '../../../src/matchers/element/toHaveAttributeContaining';
+
+describe('toHaveAttribute', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+    })    
+
+    test('success when contains', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return "An example phrase"
+        })
+        const result = await toHaveAttrContaining(el, "attribute_name", "example");
+        expect(result.pass).toBe(true)
+    });
+
+    describe('failure when deosnt contain', () => {
+        let result: any
+
+        beforeEach(async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "An example phrase"
+            })
+            result = await toHaveAttrContaining(el, "attribute_name", "donkey");
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', async () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('donkey')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('An example phrase')
+            })
+        })
+    });
+    
+});

--- a/test/matchers/element/toHaveElementClassContaining.test.ts
+++ b/test/matchers/element/toHaveElementClassContaining.test.ts
@@ -1,0 +1,56 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveClassContaining, toHaveElementClassContaining } from '../../../src/matchers/element/toHaveElementClassContaining';
+
+describe('toHaveElementClassContaining', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(attribute === 'class') {
+                return 'some-class another-class'
+            }
+            return null
+        })
+    })    
+
+    test('success when class name is present', async () => {
+        const result = await toHaveElementClassContaining(el, "some-class");
+        expect(result.pass).toBe(true)
+    });
+
+    describe('failure when class name is not present', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveElementClassContaining(el, "test");
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute class')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('test')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('some-class another-class')
+            })
+        })
+    });
+});
+
+global.console.warn = jest.fn()
+
+describe('toHaveClassContaining', () => {
+    let el: WebdriverIO.Element
+    
+    test('warning message in console', async () => {
+        const result = await toHaveClassContaining(el, "test");
+        expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClassContaining is deprecated and will be removed in next release. Use toHaveElementClassContaining instead.')
+    })
+})

--- a/test/matchers/element/toHaveHref.test.ts
+++ b/test/matchers/element/toHaveHref.test.ts
@@ -23,7 +23,7 @@ describe('toHaveHref', () => {
         let result: any
 
         beforeEach(async () => {
-            result = await toHaveHref(el, "https://webdriver.io");
+            result = await toHaveHref(el, "an href");
         })
 
         test('failure', () => {
@@ -35,12 +35,10 @@ describe('toHaveHref', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute href')
             })
             test('expected message', () => {
-                const re = /https:////webdriver.io/i
-                expect(getExpected(result.message())).toMatch(re)
+                expect(getExpected(result.message())).toContain('an href')
             })
             test('received message', () => {
-                const re = /https:////www.example.com/i
-                expect(getReceived(result.message())).toMatch(re)
+                expect(getReceived(result.message())).toContain('https://www.example.com')
             })
         })
     });

--- a/test/matchers/element/toHaveHref.test.ts
+++ b/test/matchers/element/toHaveHref.test.ts
@@ -1,0 +1,48 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveHref } from '../../../src/matchers/element/toHaveHref';
+
+describe('toHaveHref', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(attribute === 'href') {
+                return "https://www.example.com"
+            }
+            return null
+        })
+    })    
+
+    test('success when contains', async () => {
+        const result = await toHaveHref(el, "https://www.example.com");
+        expect(result.pass).toBe(true)
+    });
+
+    describe('failure when doesnt contain', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveHref(el, "https://webdriver.io");
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute')
+            })
+            test('expected message', () => {
+                let re = /https:////webdriver.io/i
+                expect(getExpected(result.message())).toMatch(re)
+            })
+            test('received message', () => {
+                let re = /https:////www.example.com/i
+                expect(getReceived(result.message())).toMatch(re)
+            })
+        })
+    });
+    
+});

--- a/test/matchers/element/toHaveHref.test.ts
+++ b/test/matchers/element/toHaveHref.test.ts
@@ -32,7 +32,7 @@ describe('toHaveHref', () => {
 
         describe('message shows correctly', () => {
             test('expect message', () => {
-                expect(getExpectMessage(result.message())).toContain('to have attribute')
+                expect(getExpectMessage(result.message())).toContain('to have attribute href')
             })
             test('expected message', () => {
                 const re = /https:////webdriver.io/i

--- a/test/matchers/element/toHaveHref.test.ts
+++ b/test/matchers/element/toHaveHref.test.ts
@@ -35,11 +35,11 @@ describe('toHaveHref', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute')
             })
             test('expected message', () => {
-                let re = /https:////webdriver.io/i
+                const re = /https:////webdriver.io/i
                 expect(getExpected(result.message())).toMatch(re)
             })
             test('received message', () => {
-                let re = /https:////www.example.com/i
+                const re = /https:////www.example.com/i
                 expect(getReceived(result.message())).toMatch(re)
             })
         })

--- a/test/matchers/element/toHaveHrefContaining.test.ts
+++ b/test/matchers/element/toHaveHrefContaining.test.ts
@@ -1,0 +1,55 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveHrefContaining } from '../../../src/matchers/element/toHaveHrefContaining';
+
+describe('toHaveHrefContaining', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(attribute === 'href') {
+                return "https://www.example.com"
+            }
+            return null
+        })
+    })    
+
+    describe('success', () => {
+        test('exact passes', async () => {
+            const result = await toHaveHrefContaining(el, "https://www.example.com");
+            expect(result.pass).toBe(true)
+        });
+
+        test('part passes', async () => {
+            const result = await toHaveHrefContaining(el, "example");
+            expect(result.pass).toBe(true)
+        })
+    })
+
+    describe('failure', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveHrefContaining(el, "webdriver");
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute href containing')
+            })
+            test('expected message', () => {
+                const re = /webdriver/i
+                expect(getExpected(result.message())).toMatch(re)
+            })
+            test('received message', () => {
+                const re = /https:////www.example.com/i
+                expect(getReceived(result.message())).toMatch(re)
+            })
+        })
+    });
+    
+});

--- a/test/matchers/element/toHaveHrefContaining.test.ts
+++ b/test/matchers/element/toHaveHrefContaining.test.ts
@@ -42,12 +42,10 @@ describe('toHaveHrefContaining', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute href containing')
             })
             test('expected message', () => {
-                const re = /webdriver/i
-                expect(getExpected(result.message())).toMatch(re)
+                expect(getExpected(result.message())).toContain('webdriver')
             })
             test('received message', () => {
-                const re = /https:////www.example.com/i
-                expect(getReceived(result.message())).toMatch(re)
+                expect(getReceived(result.message())).toContain('https://www.example.com')
             })
         })
     });

--- a/test/matchers/element/toHaveId.test.ts
+++ b/test/matchers/element/toHaveId.test.ts
@@ -1,0 +1,46 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveId } from '../../../src/matchers/element/toHaveId';
+
+describe('toHaveHref', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(attribute === 'id') {
+                return "test id"
+            }
+            return null
+        })
+    })    
+
+    test('success', async () => {
+        const result = await toHaveId(el, "test id");
+        expect(result.pass).toBe(true)
+    });
+
+    describe('failure', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveId(el, "an attribute");
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute id')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('an attribute')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('test id')
+            })
+        })
+    });
+    
+});


### PR DESCRIPTION
* Adds a parameter check to distinguish between toHaveAttribute('attrib')  toHaveAttribute('attrib', 'value')
* Adds test cases for toHaveAttribute
* Updates all matchers that make use of toHaveAttribute
* Adds test cases for all matchers that make use of toHaveAttribute

In support of #2 improving unit test coverage
closes #438 