### PR TITLE
Add unit tests

### DIFF
--- a/src/util/expectAdapter.ts
+++ b/src/util/expectAdapter.ts
@@ -12,7 +12,7 @@ const { mode: MODE } = config
  */
 export const getContext = (context?: any): any => global === context ? {} : context || {}
 
-function runJestExpect(fn: (...args: any) => any, args: IArguments): any {
+export function runJestExpect(fn: (...args: any) => any, args: IArguments): any {
     return fn.apply(this, args)
 }
 
@@ -30,7 +30,7 @@ export const jestResultToJasmine = (result: JestExpectationResult | Promise<Jest
     return buildJasmineFromJestResult(result, isNot)
 }
 
-function runJasmineExpect(fn: (...args: any) => any): any {
+export function runJasmineExpect(fn: (...args: any) => any): any {
     // 2nd and 3rd args are `util` and `customEqualityTesters` that are not used
     const context = getContext(this)
     return {

--- a/test/__fixtures__/wdio.js
+++ b/test/__fixtures__/wdio.js
@@ -47,7 +47,10 @@ function $$(selector, ...args) {
         }
     })
     // Required to refetch
-    els.parent = element;
+    let parent = element;
+    parent._length = length;
+    els.parent = parent;
+    
     els.foundWith = "$$";
     // Required to check length prop
     els.props = [];

--- a/test/__fixtures__/wdio.js
+++ b/test/__fixtures__/wdio.js
@@ -39,13 +39,20 @@ function $(selector, ...args) {
 
 function $$(selector, ...args) {
     const length = this._length || 2
-    return Array(length).map((_, index) => {
+    let els = Array(length).map((_, index) => {
         return {
             ...element,
             selector,
             index
         }
     })
+    // Required to refetch
+    els.parent = element;
+    els.foundWith = "$$";
+    // Required to check length prop
+    els.props = [];
+    els.props.length = length;
+    return els;
 }
 
 async function waitUntil(condition, { timeout, m, interval }) {

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -1,0 +1,204 @@
+import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute';
+
+describe('toHaveAttribute', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+    })    
+
+    test('wait for success', async () => {
+        el._attempts = 2
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(el._attempts > 0) {
+                el._attempts --;
+                return "Wrong Value"
+            }
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
+    test('wait but failure', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            throw new Error('some error');
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
+        expect(result.pass).toBe(false)
+    })
+
+    test('success on the first attempt', async () => {
+        el._attempts = 0
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el._attempts ++
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
+    test('failure with non-string attribute value as actual', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return 123
+        })
+        const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+        expect(result.pass).toBe(false)
+    })
+
+    test('success with non-string attribute value as expected', async () => {
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            return "Correct Value"
+        })
+        const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+        expect(result.pass).toBe(true)
+    })
+
+    // test('no wait - failure', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: "Wrong Value" }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(false)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('no wait - success', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0;
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('not - failure', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
+    //     const received = getReceived(result.message())
+
+    //     expect(received).not.toContain('not')
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('should return false if styles dont match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const wrongStyle: { [key: string]: string; } = {
+    //         "font-family": "Incorrect Font",
+    //         "font-size": "100px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('should return true if styles match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('message shows correctly', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: "Wrong Value" }
+    //     })
+    //     const result = await toHaveStyle(el, 'WebdriverIO')
+    //     expect(getExpectMessage(result.message())).toContain('to have style')
+    // })
+
+    // test('success if style matches with ignoreCase', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredCaseStyle: { [key: string]: string; } = {
+    //         "font-family": "FaKtum",
+    //         "font-size": "26px",
+    //         "color": "#FFF"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+    
+    // test('success if style matches with trim', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "   Faktum   ",
+    //         "font-size": "   26px   ",
+    //         "color": "    #fff     "
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredSpaceStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+})

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -1,0 +1,204 @@
+import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
+
+describe('toHaveElementClass', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+    })    
+
+    test('wait for success', async () => {
+        el._attempts = 2
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(el._attempts > 0) {
+                el._attempts --;
+                return "wrong-class"
+            }
+            return "correct-class"
+        })
+        const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
+    // test('wait but failure', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         throw new Error('some error');
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('success on the first attempt', async () => {
+    //     el._attempts = 0
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         el._attempts ++
+    //         return "Correct Value"
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('failure with non-string attribute value as actual', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         return 123
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('success with non-string attribute value as expected', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         return "Correct Value"
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('no wait - failure', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: "Wrong Value" }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(false)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('no wait - success', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0;
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('not - failure', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
+    //     const received = getReceived(result.message())
+
+    //     expect(received).not.toContain('not')
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('should return false if styles dont match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const wrongStyle: { [key: string]: string; } = {
+    //         "font-family": "Incorrect Font",
+    //         "font-size": "100px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('should return true if styles match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('message shows correctly', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: "Wrong Value" }
+    //     })
+    //     const result = await toHaveStyle(el, 'WebdriverIO')
+    //     expect(getExpectMessage(result.message())).toContain('to have style')
+    // })
+
+    // test('success if style matches with ignoreCase', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredCaseStyle: { [key: string]: string; } = {
+    //         "font-family": "FaKtum",
+    //         "font-size": "26px",
+    //         "color": "#FFF"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+    
+    // test('success if style matches with trim', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "   Faktum   ",
+    //         "font-size": "   26px   ",
+    //         "color": "    #fff     "
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredSpaceStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+})

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -19,6 +19,34 @@ describe('toHaveElementClass', () => {
         expect(result.pass).toBe(true)
     });
 
+    describe('options', () => {
+        it('should fail when class is not a string', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return null
+            })
+            const result = await toHaveElementClass(el, "some-class");
+            expect(result.pass).toBe(false)
+        })
+
+        it('should pass when trimming the attribute', async () => {
+            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                return "  some-class  "
+            })
+            const result = await toHaveElementClass(el, "some-class", {trim: true});
+            expect(result.pass).toBe(true)
+        })
+        
+        it('should pass when ignore the case', async () => {
+            const result = await toHaveElementClass(el, "sOme-ClAsS", {ignoreCase: true});
+            expect(result.pass).toBe(true) 
+        })
+
+        it('should pass if containing', async () => {
+            const result = await toHaveElementClass(el, "some", {containing: true});
+            expect(result.pass).toBe(true) 
+        }) 
+    })
+    
     describe('failure when class name is not present', () => {
         let result: any
 

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -1,204 +1,56 @@
-import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
-import { toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
+import { toHaveClass, toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
 
 describe('toHaveElementClass', () => {
     let el: WebdriverIO.Element
 
     beforeEach(async () => { 
         el = await $('sel')
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(attribute === 'class') {
+                return 'some-class another-class'
+            }
+            return null
+        })
     })    
 
-    test('wait for success', async () => {
-        el._attempts = 2
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            if(el._attempts > 0) {
-                el._attempts --;
-                return "wrong-class"
-            }
-            return "correct-class"
-        })
-        const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
+    test('success when class name is present', async () => {
+        const result = await toHaveElementClass(el, "some-class");
         expect(result.pass).toBe(true)
-        expect(el._attempts).toBe(0)
-    })
+    });
 
-    // test('wait but failure', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         throw new Error('some error');
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
-    //     expect(result.pass).toBe(false)
-    // })
+    describe('failure when class name is not present', () => {
+        let result: any
 
-    // test('success on the first attempt', async () => {
-    //     el._attempts = 0
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         el._attempts ++
-    //         return "Correct Value"
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
+        beforeEach(async () => {
+            result = await toHaveElementClass(el, "test");
+        })
 
-    // test('failure with non-string attribute value as actual', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         return 123
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-    //     expect(result.pass).toBe(false)
-    // })
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
 
-    // test('success with non-string attribute value as expected', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         return "Correct Value"
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
-    //     expect(result.pass).toBe(true)
-    // })
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have class')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('test')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('some-class another-class')
+            })
+        })
+    });
+});
 
-    // test('no wait - failure', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: "Wrong Value" }
-    //     })
+global.console.warn = jest.fn()
 
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(false)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('no wait - success', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0;
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('not - failure', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
-    //     const received = getReceived(result.message())
-
-    //     expect(received).not.toContain('not')
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('should return false if styles dont match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const wrongStyle: { [key: string]: string; } = {
-    //         "font-family": "Incorrect Font",
-    //         "font-size": "100px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
-    //     expect(result.pass).toBe(false)
-    // })
-
-    // test('should return true if styles match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('message shows correctly', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: "Wrong Value" }
-    //     })
-    //     const result = await toHaveStyle(el, 'WebdriverIO')
-    //     expect(getExpectMessage(result.message())).toContain('to have style')
-    // })
-
-    // test('success if style matches with ignoreCase', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredCaseStyle: { [key: string]: string; } = {
-    //         "font-family": "FaKtum",
-    //         "font-size": "26px",
-    //         "color": "#FFF"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
+describe('toHaveClass', () => {
+    let el: WebdriverIO.Element
     
-    // test('success if style matches with trim', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "   Faktum   ",
-    //         "font-size": "   26px   ",
-    //         "color": "    #fff     "
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredSpaceStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
+    test('warning message in console', async () => {
+        const result = await toHaveClass(el, "test");
+        expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClass is deprecated and will be removed in next release. Use toHaveElementClass instead.')
+    })
 })

--- a/test/matchers/element/toHaveElementClassContaining.test.ts
+++ b/test/matchers/element/toHaveElementClassContaining.test.ts
@@ -14,8 +14,13 @@ describe('toHaveElementClassContaining', () => {
         })
     })    
 
-    test('success when class name is present', async () => {
+    test('success when whole class name is present', async () => {
         const result = await toHaveElementClassContaining(el, "some-class");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success when part of class name is present', async () => {
+        const result = await toHaveElementClassContaining(el, "other");
         expect(result.pass).toBe(true)
     });
 

--- a/test/matchers/element/toHaveTextContaining.test.ts
+++ b/test/matchers/element/toHaveTextContaining.test.ts
@@ -1,0 +1,50 @@
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
+import { toHaveTextContaining } from '../../../src/matchers/element/toHaveTextContaining'
+
+describe('toHaveTextContaining', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el._text = jest.fn().mockImplementation(() => {
+            return "This is example text"
+        })
+    })    
+
+    describe('success', () => {
+        test('exact passes', async () => {
+            const result = await toHaveTextContaining(el, "This is example text");
+            expect(result.pass).toBe(true)
+        });
+
+        test('part passes', async () => {
+            const result = await toHaveTextContaining(el, "example text");
+            expect(result.pass).toBe(true)
+        })
+    })
+
+    describe('failure', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveTextContaining(el, "webdriver");
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have text containing')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('webdriver')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('This is example text')
+            })
+        })
+    });
+    
+});

--- a/test/matchers/element/toHaveValue.test.ts
+++ b/test/matchers/element/toHaveValue.test.ts
@@ -1,0 +1,45 @@
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
+import { toHaveValue } from '../../../src/matchers/element/toHaveValue'
+
+describe('toHaveValue', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el._value = jest.fn().mockImplementation(() => {
+            return "This is an example value"
+        })
+    })    
+
+    describe('success', () => {
+        test('exact passes', async () => {
+            const result = await toHaveValue(el, "This is an example value");
+            expect(result.pass).toBe(true)
+        });
+    })
+
+    describe('failure', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveValue(el, "webdriver");
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have property value')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('webdriver')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('This is an example value')
+            })
+        })
+    });
+    
+});

--- a/test/matchers/element/toHaveValueContaining.test.ts
+++ b/test/matchers/element/toHaveValueContaining.test.ts
@@ -1,0 +1,49 @@
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
+import { toHaveValueContaining } from '../../../src/matchers/element/toHaveValueContaining'
+
+describe('toHaveValueContaining', () => {
+    let el: WebdriverIO.Element
+
+    beforeEach(async () => { 
+        el = await $('sel')
+        el._value = jest.fn().mockImplementation(() => {
+            return "This is an example value"
+        })
+    })    
+
+    describe('success', () => {
+        test('exact passes', async () => {
+            const result = await toHaveValueContaining(el, "This is an example value");
+            expect(result.pass).toBe(true)
+        });
+        test('part passes', async () => {
+            const result = await toHaveValueContaining(el, "example value");
+            expect(result.pass).toBe(true)
+        });
+    })
+
+    describe('failure', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveValueContaining(el, "webdriver");
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have property value')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('webdriver')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('This is an example value')
+            })
+        })
+    });
+    
+});

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -6,13 +6,23 @@ describe('toBeElementsArrayOfSize', () => {
     let els: WebdriverIO.ElementArray
 
     beforeEach(async () => {
-        // Create an element array of length 2
-        els = await $$('parent');
     })    
 
-    test('success', async () => {
-        const result = await toBeElementsArrayOfSize(els, 2, {});
-        expect(result.pass).toBe(true)
+    describe('success', () => {
+        test('array of size 2', async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            const result = await toBeElementsArrayOfSize(els, 2, {});
+            expect(result.pass).toBe(true)
+        })  
+        test('array of size 5', async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            // @ts-ignore
+            els.parent._length = 5;
+            const result = await toBeElementsArrayOfSize(els, 5, {});
+            expect(result.pass).toBe(true)
+        })  
     })
     
     // test('wait but failure', async () => {

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -4,24 +4,24 @@ import { toHaveElementClass } from '../../../src/matchers/element/toHaveElementC
 describe('toBeElementsArrayOfSize', () => {
     let els: WebdriverIO.ElementArray
 
-    beforeEach(async () => { 
-        els = [await $('sel1'), await $('sel2'), await $('sel3')]
-    })    
+    // beforeEach(async () => { 
+    //     els = [await $('sel1'), await $('sel2'), await $('sel3')]
+    // })    
 
-    test('wait for success', async () => {
-        el._attempts = 2
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-            if(el._attempts > 0) {
-                el._attempts --;
-                return "wrong-class"
-            }
-            return "correct-class"
-        })
-        const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
-        expect(result.pass).toBe(true)
-        expect(el._attempts).toBe(0)
-    })
-
+    // test('wait for success', async () => {
+    //     el._attempts = 2
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         if(el._attempts > 0) {
+    //             el._attempts --;
+    //             return "wrong-class"
+    //         }
+    //         return "correct-class"
+    //     })
+    //     const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(0)
+    // })
+    
     // test('wait but failure', async () => {
     //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
     //         throw new Error('some error');

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -59,6 +59,13 @@ describe('toBeElementsArrayOfSize', () => {
             }
             expect(error).toEqual(new Error('Invalid params passed to toBeElementsArrayOfSize.'));
         })
+        it('works if size contains options', async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            let error;
+            let result = await toBeElementsArrayOfSize(els, {lte: 5});
+            expect(result.pass).toBe(true);
+        })
         
     })
     

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -1,26 +1,19 @@
 import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
-import { toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
+import { toBeElementsArrayOfSize } from '../../../src/matchers/elements/toBeElementsArrayOfSize';
+import { walkUpBindingElementsAndPatterns } from 'typescript';
 
 describe('toBeElementsArrayOfSize', () => {
     let els: WebdriverIO.ElementArray
 
-    // beforeEach(async () => { 
-    //     els = [await $('sel1'), await $('sel2'), await $('sel3')]
-    // })    
+    beforeEach(async () => {
+        // Create an element array of length 2
+        els = await $$('parent');
+    })    
 
-    // test('wait for success', async () => {
-    //     el._attempts = 2
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         if(el._attempts > 0) {
-    //             el._attempts --;
-    //             return "wrong-class"
-    //         }
-    //         return "correct-class"
-    //     })
-    //     const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(0)
-    // })
+    test('success', async () => {
+        const result = await toBeElementsArrayOfSize(els, 2, {});
+        expect(result.pass).toBe(true)
+    })
     
     // test('wait but failure', async () => {
     //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -1,12 +1,8 @@
-import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { getExpectMessage, getReceived, getExpected} from '../../__fixtures__/utils';
 import { toBeElementsArrayOfSize } from '../../../src/matchers/elements/toBeElementsArrayOfSize';
-import { walkUpBindingElementsAndPatterns } from 'typescript';
 
 describe('toBeElementsArrayOfSize', () => {
     let els: WebdriverIO.ElementArray
-
-    beforeEach(async () => {
-    })    
 
     describe('success', () => {
         test('array of size 2', async () => {
@@ -24,184 +20,46 @@ describe('toBeElementsArrayOfSize', () => {
             expect(result.pass).toBe(true)
         })  
     })
+
+    describe('failure', () => {
+        let result: any; 
+
+        beforeEach(async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            result = await toBeElementsArrayOfSize(els, 5, {});
+        })
+
+        test('fails', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to be elements array of size')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('5')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('2')
+            })
+        })
+    })
+
+    describe('error catching', () => {
+        test('throws error with incorrect size param', async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            let error;
+            try {
+                await toBeElementsArrayOfSize(els, "5")
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toEqual(new Error('Invalid params passed to toBeElementsArrayOfSize.'));
+        })
+        
+    })
     
-    // test('wait but failure', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         throw new Error('some error');
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
-    //     expect(result.pass).toBe(false)
-    // })
-
-    // test('success on the first attempt', async () => {
-    //     el._attempts = 0
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         el._attempts ++
-    //         return "Correct Value"
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('failure with non-string attribute value as actual', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         return 123
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
-    //     expect(result.pass).toBe(false)
-    // })
-
-    // test('success with non-string attribute value as expected', async () => {
-    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
-    //         return "Correct Value"
-    //     })
-    //     const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('no wait - failure', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: "Wrong Value" }
-    //     })
-
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(false)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('no wait - success', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0;
-    //     let counter = 0;
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
-
-    // test('not - failure', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
-    //     const received = getReceived(result.message())
-
-    //     expect(received).not.toContain('not')
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('should return false if styles dont match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const wrongStyle: { [key: string]: string; } = {
-    //         "font-family": "Incorrect Font",
-    //         "font-size": "100px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
-    //     expect(result.pass).toBe(false)
-    // })
-
-    // test('should return true if styles match', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: mockStyle[property] }
-    //     })
-
-    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
-    //     expect(result.pass).toBe(true)
-    // })
-
-    // test('message shows correctly', async () => {
-    //     const el = await $('sel')
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         return { value: "Wrong Value" }
-    //     })
-    //     const result = await toHaveStyle(el, 'WebdriverIO')
-    //     expect(getExpectMessage(result.message())).toContain('to have style')
-    // })
-
-    // test('success if style matches with ignoreCase', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredCaseStyle: { [key: string]: string; } = {
-    //         "font-family": "FaKtum",
-    //         "font-size": "26px",
-    //         "color": "#FFF"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
-    
-    // test('success if style matches with trim', async () => {
-    //     const el = await $('sel')
-    //     el._attempts = 0
-    //     let counter = 0;
-
-    //     const actualStyle: { [key: string]: string; } = {
-    //         "font-family": "   Faktum   ",
-    //         "font-size": "   26px   ",
-    //         "color": "    #fff     "
-    //     } 
-
-    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
-    //         counter ++;
-    //         if(counter == Object.keys(mockStyle).length) {
-    //             counter = 0;
-    //             el._attempts ++;
-    //         }
-    //         return { value: actualStyle[property] }
-    //     })
-
-    //     const alteredSpaceStyle: { [key: string]: string; } = {
-    //         "font-family": "Faktum",
-    //         "font-size": "26px",
-    //         "color": "#fff"
-    //     } 
-
-    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
-    //     expect(result.pass).toBe(true)
-    //     expect(el._attempts).toBe(1)
-    // })
 })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -1,0 +1,204 @@
+import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
+
+describe('toBeElementsArrayOfSize', () => {
+    let els: WebdriverIO.ElementArray
+
+    beforeEach(async () => { 
+        els = [await $('sel1'), await $('sel2'), await $('sel3')]
+    })    
+
+    test('wait for success', async () => {
+        el._attempts = 2
+        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            if(el._attempts > 0) {
+                el._attempts --;
+                return "wrong-class"
+            }
+            return "correct-class"
+        })
+        const result = await toHaveElementClass(el, "correct-class", { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
+    // test('wait but failure', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         throw new Error('some error');
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value");
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('success on the first attempt', async () => {
+    //     el._attempts = 0
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         el._attempts ++
+    //         return "Correct Value"
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('failure with non-string attribute value as actual', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         return 123
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('success with non-string attribute value as expected', async () => {
+    //     el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+    //         return "Correct Value"
+    //     })
+    //     const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('no wait - failure', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: "Wrong Value" }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(false)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('no wait - success', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0;
+    //     let counter = 0;
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle(el, mockStyle, { wait: 0 })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+
+    // test('not - failure', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+    //     const result = await toHaveStyle.call({ isNot: true }, el, mockStyle, { wait: 0 })
+    //     const received = getReceived(result.message())
+
+    //     expect(received).not.toContain('not')
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('should return false if styles dont match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const wrongStyle: { [key: string]: string; } = {
+    //         "font-family": "Incorrect Font",
+    //         "font-size": "100px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
+    //     expect(result.pass).toBe(false)
+    // })
+
+    // test('should return true if styles match', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: mockStyle[property] }
+    //     })
+
+    //     const result = await toHaveStyle.bind({ isNot: true })(el, mockStyle, { wait: 1 })
+    //     expect(result.pass).toBe(true)
+    // })
+
+    // test('message shows correctly', async () => {
+    //     const el = await $('sel')
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         return { value: "Wrong Value" }
+    //     })
+    //     const result = await toHaveStyle(el, 'WebdriverIO')
+    //     expect(getExpectMessage(result.message())).toContain('to have style')
+    // })
+
+    // test('success if style matches with ignoreCase', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredCaseStyle: { [key: string]: string; } = {
+    //         "font-family": "FaKtum",
+    //         "font-size": "26px",
+    //         "color": "#FFF"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+    
+    // test('success if style matches with trim', async () => {
+    //     const el = await $('sel')
+    //     el._attempts = 0
+    //     let counter = 0;
+
+    //     const actualStyle: { [key: string]: string; } = {
+    //         "font-family": "   Faktum   ",
+    //         "font-size": "   26px   ",
+    //         "color": "    #fff     "
+    //     } 
+
+    //     el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+    //         counter ++;
+    //         if(counter == Object.keys(mockStyle).length) {
+    //             counter = 0;
+    //             el._attempts ++;
+    //         }
+    //         return { value: actualStyle[property] }
+    //     })
+
+    //     const alteredSpaceStyle: { [key: string]: string; } = {
+    //         "font-family": "Faktum",
+    //         "font-size": "26px",
+    //         "color": "#fff"
+    //     } 
+
+    //     const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
+    //     expect(result.pass).toBe(true)
+    //     expect(el._attempts).toBe(1)
+    // })
+})

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -62,8 +62,7 @@ describe('toBeElementsArrayOfSize', () => {
         it('works if size contains options', async () => {
             // Create an element array of length 2
             els = await $$('parent');
-            let error;
-            let result = await toBeElementsArrayOfSize(els, {lte: 5});
+            const result = await toBeElementsArrayOfSize(els, {lte: 5});
             expect(result.pass).toBe(true);
         })
         

--- a/test/util/expectAdapter.test.ts
+++ b/test/util/expectAdapter.test.ts
@@ -1,0 +1,104 @@
+import { buildJasmineFromJestResult, jestResultToJasmine, runJestExpect, runJasmineExpect } from '../../src/util/expectAdapter';
+
+describe('expectAdapter', () => {
+    describe('buildJasmineFromJestResult', () => {
+        let input: JestExpectationResult;
+
+        beforeEach(() => {
+            input = {
+                pass: false,
+                message: () => "Test message"
+            }
+        })
+
+        test('pass (false) isNot (false)', () => {
+            const output = buildJasmineFromJestResult(input, false);
+            expect(output).toMatchObject({
+                pass: false,
+                message: "Test message"
+            })
+        })
+
+        it('pass (false) isNot (true)', () => {
+            const output = buildJasmineFromJestResult(input, true);
+            expect(output).toMatchObject({
+                pass: true,
+                message: "Test message"
+            })
+        })
+    });
+
+    describe('jestResultToJasmine', () => {
+        let input: any; 
+
+        beforeEach(() => {
+            input = {
+                pass: false,
+                message: () => "Test message"
+            }
+        })
+
+        it('object input', () => {
+            const output = jestResultToJasmine(input, false);
+            expect(output).toMatchObject({
+                pass: false,
+                message: "Test message"
+            })
+        })
+
+        it('promise input', async () => {
+            const promise: Promise<JestExpectationResult> = new Promise((resolve, reject) => {
+                resolve(input);
+            });
+            const output = await jestResultToJasmine(promise, false);
+            expect(output).toMatchObject({
+                pass: false,
+                message: "Test message"
+            })
+        })
+    });
+    
+    describe('runExpect', () => {
+        describe('runJestExpect', () => {
+            const testFn = jest.fn();
+            const args: any = {}
+            runJestExpect.call(this, testFn, args);
+            expect(testFn).toHaveBeenCalled();
+        })
+        describe('runJasmineExpect', () => {
+            let output: any;
+            let testFn: any;
+
+            beforeEach(() => {
+                testFn = jest.fn(() => {
+                    return {
+                        pass: false, 
+                        message: () => "Test message"
+                    }
+                });
+                output = runJasmineExpect.call(this, testFn);
+            })
+
+            test('returns object of functions', () => {
+                expect(output).toEqual(
+                    expect.objectContaining({
+                        compare: expect.any(Function),
+                        negativeCompare: expect.any(Function)
+                    })
+                )  
+            });
+
+            test('compare should call function', () => {
+                output.compare();
+                expect(testFn).toHaveBeenCalled()
+            })
+            
+            test('negaitve compare should call function', () => {
+                output.negativeCompare();
+                expect(testFn).toHaveBeenCalled()
+            })
+            
+        })
+    })
+    
+})


### PR DESCRIPTION
Unit tests:
- Add expectAdapter tests
- Adds a series of tests for matchers that weren't being hit very well
- Updates (statement) code coverage from ~84 -> ~93

Code change 
- To test expectAdapter exported 2 named functions, found this was the only way to test those two functions

Individual matchers are still missing some unit tests but I think src/util is probably the next place to look at adding some unit tests? I also managed to update my git config to push from my personal GitHub 🎇

#2 