### PR TITLE
Increase code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
         }
     },
     testEnvironment: 'node',
-    coveragePathIgnorePatterns: ['/__fixtures__/'],
+    coveragePathIgnorePatterns: ['/__fixtures__/', 'src/jasmineUtils.ts'],
     testPathIgnorePatterns: ['/__fixtures__/'],
     setupFilesAfterEnv: ['./test/__fixtures__/index.js']
 }

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -52,11 +52,10 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
 
     return browser.call(async () => {
         let el = await received
-        let attr
+        
         const pass = await waitUntil(async () => {
             const result = await executeCommand.call(this, el, conditionAttr, {}, [attribute])
             el = result.el
-            attr = result.values
 
             return result.success
         }, isNot, {})

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -40,7 +40,9 @@ export const updateElementsArray = (
 
         // add every refetched item to original element array
         if (received.length === 0) {
-            refetched.forEach(el => received.push(el))
+            for(var i=0; i<refetched.length; i++) {
+                received.push(refetched[i])
+            }
         }
     }
 }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -40,7 +40,7 @@ export const updateElementsArray = (
 
         // add every refetched item to original element array
         if (received.length === 0) {
-            for(var i=0; i<refetched.length; i++) {
+            for(let i = 0; i < refetched.length; i++) {
                 received.push(refetched[i])
             }
         }

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -10,7 +10,7 @@ describe('toHaveAttribute', () => {
 
     describe('attribute exists', () => {
         test('success when present', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
             const result = await toHaveAttribute(el, "attribute_name");
@@ -18,7 +18,7 @@ describe('toHaveAttribute', () => {
         })
 
         test('failure when not present', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return null
             })
             const result = await toHaveAttribute(el, "attribute_name");
@@ -29,7 +29,7 @@ describe('toHaveAttribute', () => {
             let result: any
 
             beforeEach(async () => {
-                el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                el.getAttribute = jest.fn().mockImplementation(() => {
                     return null
                 })
                 result = await toHaveAttribute(el, "attribute_name");
@@ -48,28 +48,28 @@ describe('toHaveAttribute', () => {
     
     describe('attribute has value', () => {
         test('success with correct value', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
             const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
             expect(result.pass).toBe(true)
         })
         test('failure with wrong value', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Wrong Value"
             })
             const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
             expect(result.pass).toBe(false)
         })
         test('failure with non-string attribute value as actual', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return 123
             })
             const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
             expect(result.pass).toBe(false)
         })
         test('failure with non-string attribute value as expected', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
             const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
@@ -79,7 +79,7 @@ describe('toHaveAttribute', () => {
             let result: any
 
             beforeEach(async () => {
-                el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+                el.getAttribute = jest.fn().mockImplementation(() => {
                     return "Wrong"
                 })
                 result = await toHaveAttribute(el, "attribute_name", "Correct");

--- a/test/matchers/element/toHaveAttributeContaining.test.ts
+++ b/test/matchers/element/toHaveAttributeContaining.test.ts
@@ -9,7 +9,7 @@ describe('toHaveAttributeContaining', () => {
     })    
 
     test('success when contains', async () => {
-        el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+        el.getAttribute = jest.fn().mockImplementation(() => {
             return "An example phrase"
         })
         const result = await toHaveAttrContaining(el, "attribute_name", "example");
@@ -20,7 +20,7 @@ describe('toHaveAttributeContaining', () => {
         let result: any
 
         beforeEach(async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "An example phrase"
             })
             result = await toHaveAttrContaining(el, "attribute_name", "donkey");

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -21,7 +21,7 @@ describe('toHaveElementClass', () => {
 
     describe('options', () => {
         it('should fail when class is not a string', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return null
             })
             const result = await toHaveElementClass(el, "some-class");
@@ -29,7 +29,7 @@ describe('toHaveElementClass', () => {
         })
 
         it('should pass when trimming the attribute', async () => {
-            el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
                 return "  some-class  "
             })
             const result = await toHaveElementClass(el, "some-class", {trim: true});
@@ -78,7 +78,7 @@ describe('toHaveClass', () => {
     let el: WebdriverIO.Element
     
     test('warning message in console', async () => {
-        const result = await toHaveClass(el, "test");
+        await toHaveClass(el, "test");
         expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClass is deprecated and will be removed in next release. Use toHaveElementClass instead.')
     })
 })

--- a/test/matchers/element/toHaveElementClassContaining.test.ts
+++ b/test/matchers/element/toHaveElementClassContaining.test.ts
@@ -55,7 +55,7 @@ describe('toHaveClassContaining', () => {
     let el: WebdriverIO.Element
     
     test('warning message in console', async () => {
-        const result = await toHaveClassContaining(el, "test");
+        await toHaveClassContaining(el, "test");
         expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClassContaining is deprecated and will be removed in next release. Use toHaveElementClassContaining instead.')
     })
 })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -9,7 +9,7 @@ describe('toHaveElementProperty', () => {
             return 'iphone'
         }
 
-        const result = await toHaveElementProperty(el, 'value', 'iPhone', { wait: 0, ignoreCase: true })
+        const result = await toHaveElementProperty(el, 'property', 'iPhone', { wait: 0, ignoreCase: true })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -20,7 +20,7 @@ describe('toHaveElementProperty', () => {
             return 'iphone'
         }
 
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'value', 'foobar', { wait: 1 })
+        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'foobar', { wait: 1 })
         expect(result.pass).toBe(false)
     })
 
@@ -30,7 +30,37 @@ describe('toHaveElementProperty', () => {
             return 'iphone'
         }
 
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'value', 'iphone', { wait: 1 })
+        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'iphone', { wait: 1 })
         expect(result.pass).toBe(true)
+    })
+
+    test('should return false for null input', async () => {
+        const el = await $('sel')
+        el._value = function (): any {
+            return undefined
+        }
+
+        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'iphone', { wait: 1 })
+        expect(result.pass).toBe(false)
+    })
+
+    test('should return true if value is null', async () => {
+        const el = await $('sel')
+        el._value = function (): any {
+            return "Test Value"
+        }
+
+        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', null)
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return false if value is non-string', async () => {
+        const el = await $('sel')
+        el._value = function (): any {
+            return 5
+        }
+
+        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'Test Value')
+        expect(result.pass).toBe(false)
     })
 })

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -1,6 +1,5 @@
 import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
 import { toHaveStyle } from '../../../src/matchers/element/toHaveStyle'
-import { stringify } from 'jest-matcher-utils';
 
 describe('toHaveStyle', () => {
     let el: WebdriverIO.Element
@@ -34,7 +33,7 @@ describe('toHaveStyle', () => {
         el = await $('sel')
         el._attempts = 0
         let counter = 0
-        el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+        el.getCSSProperty = jest.fn().mockImplementation(() => {
             counter ++;
             if(counter == Object.keys(mockStyle).length) {
                 counter = 0;
@@ -67,7 +66,7 @@ describe('toHaveStyle', () => {
         const el = await $('sel')
         el._attempts = 0
         let counter = 0;
-        el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+        el.getCSSProperty = jest.fn().mockImplementation(() => {
             counter ++;
             if(counter == Object.keys(mockStyle).length) {
                 counter = 0;
@@ -139,7 +138,7 @@ describe('toHaveStyle', () => {
 
     test('message shows correctly', async () => {
         const el = await $('sel')
-        el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+        el.getCSSProperty = jest.fn().mockImplementation(() => {
             return { value: "Wrong Value" }
         })
         const result = await toHaveStyle(el, 'WebdriverIO')

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -8,21 +8,59 @@ const optionsModule = '../src/options'
 describe('options', () => {
     describe('getConfig', () => {
         test('expectWdio', () => {
-            // @ts-ignore
-            global.expectWdio = {}
-            const { getConfig } = require(optionsModule)
+            jest.isolateModules(() => {
+                // @ts-ignore
+                global.expectWdio = {}
+                const { getConfig } = require(optionsModule)
 
-            expect(getConfig()).toEqual({ options, mode: 'jest' })
+                expect(getConfig()).toEqual({ options, mode: 'jest' })
 
-            delete global.expectWdio
+                delete global.expectWdio
+            })
+        })
+
+        test('jasmine', () => {
+            jest.isolateModules(() => {
+                // @ts-ignore
+                global.jasmine = {}
+                // @ts-ignore
+                global.expect.extend = false
+                const { getConfig } = require(optionsModule)
+
+                expect(getConfig()).toEqual({ options, mode: 'jasmine' })
+
+                // @ts-ignore
+                delete global.jasmine 
+                // @ts-ignore
+                delete global.expect.extend
+            })
+        })
+        
+        test('global', () => {
+            jest.isolateModules(() => {
+                const { getConfig } = require(optionsModule)
+                expect(getConfig()).toEqual({ options, mode: 'jest' })
+            })
         })
     })
 
     describe('setDefaultOptions', () => {
-        test('bar', () => {
-            const { getConfig, setDefaultOptions } = require(optionsModule)
-            expect(typeof getConfig).toBe('function')
-            expect(typeof setDefaultOptions).toBe('function')
+        test('change if valid type', () => {
+            jest.isolateModules(() => {
+                const { getConfig, setDefaultOptions } = require(optionsModule)
+                expect(getConfig()).toEqual({ options, mode: 'jest' })
+                setDefaultOptions({wait: 1234})
+                expect(getConfig()).toEqual({ options: { ...options, wait: 1234} , mode: 'jest' })
+            })
+        })
+        
+        test('no change if invalid type', () => {
+            jest.isolateModules(() => {
+                const { getConfig, setDefaultOptions } = require(optionsModule)
+                expect(getConfig()).toEqual({ options, mode: 'jest' })
+                setDefaultOptions({fake_key: "test"})
+                expect(getConfig()).toEqual({ options, mode: 'jest' })
+            })
         })
     })
 

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -18,8 +18,7 @@ describe('elementsUtil', () => {
 
     describe('updateElementsArray', () => {
         let received: WebdriverIO.ElementArray,
-            refetched: WebdriverIO.ElementArray,
-            preCondition: WebdriverIO.ElementArray
+            refetched: WebdriverIO.ElementArray
 
         beforeEach(async () => {
             // Fetches element array of size 2
@@ -28,7 +27,6 @@ describe('elementsUtil', () => {
             received.parent._length = 5;
             // Only size 5 when refetched (useful for testing)
             refetched = await refetchElements(received, 5, true)
-            preCondition = received
         })
 
         test('is not success', () => {

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -1,4 +1,3 @@
-import { resolveProjectReferencePath } from 'typescript'
 import { updateElementsArray, wrapExpectedWithArray } from '../../src/util/elementsUtil'
 import { refetchElements } from '../../src/util/refetchElements'
 

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -1,0 +1,45 @@
+import { resolveProjectReferencePath } from 'typescript'
+import { updateElementsArray, wrapExpectedWithArray } from '../../src/util/elementsUtil'
+import { refetchElements } from '../../src/util/refetchElements'
+
+describe('elementsUtil', () => {
+    describe('wrapExpectedWithArray', () => {
+        test('is not array ', async () => {
+            const el = await $('sel')
+            const actual = wrapExpectedWithArray(el, "Test Actual", "Test Expected")
+            expect(actual).toEqual("Test Expected")
+        })
+
+        test('is array ', async () => {
+            const els = await $$('sel')
+            const actual = wrapExpectedWithArray(els, ["Test Actual", "Test Actual"], "Test Expected")
+            expect(actual).toEqual(["Test Expected"])
+        })
+    })
+
+    describe('updateElementsArray', () => {
+        let received: WebdriverIO.ElementArray,
+            refetched: WebdriverIO.ElementArray,
+            preCondition: WebdriverIO.ElementArray
+
+        beforeEach(async () => {
+            // Fetches element array of size 2
+            received = await $$('parent');
+            // @ts-ignore
+            received.parent._length = 5;
+            // Only size 5 when refetched (useful for testing)
+            refetched = await refetchElements(received, 5, true)
+            preCondition = received
+        })
+
+        test('is not success', () => {
+            updateElementsArray(false, received, refetched)
+            expect(received.length).toBe(2)
+        })
+
+        test('full', () => {
+            updateElementsArray(true, received, refetched, true)
+            expect(received.length).toBe(5)
+        })
+    })
+})

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -1,5 +1,4 @@
 import { executeCommand } from '../../src/util/executeCommand'
-import { waitUntil } from '../../src/utils'
 
 describe('refetchElements', () => {
     test('is array', async () => {
@@ -8,7 +7,7 @@ describe('refetchElements', () => {
         els.parent._length = 5;
         // Passing in array should cause elements
         // to be refetched hence length should be 5
-        let condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
+        const condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
 
         // @ts-ignore
         const result = await executeCommand.call(this, els, condition, {}, ["Test Property", "Test Value"], true)
@@ -20,7 +19,7 @@ describe('refetchElements', () => {
         while (els.length > 0) { els.pop() }
         // Passing in array should cause elements
         // to be refetched hence length should be 5
-        let condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
+        const condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
 
         // @ts-ignore
         const result = await executeCommand.call(this, els, condition, {wait: 0}, ["Test Property", "Test Value"])

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -10,7 +10,7 @@ describe('refetchElements', () => {
         const condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
 
         // @ts-ignore
-        const result = await executeCommand.call(this, els, condition, {}, ["Test Property", "Test Value"], true)
+        await executeCommand.call(this, els, condition, {}, ["Test Property", "Test Value"], true)
         expect(condition).toHaveBeenCalledTimes(5)
     })
 

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -1,0 +1,33 @@
+import { executeCommand } from '../../src/util/executeCommand'
+import { waitUntil } from '../../src/utils'
+
+describe('refetchElements', () => {
+    test('is array', async () => {
+        const els = await $$('sel') 
+        // @ts-ignore
+        els.parent._length = 5;
+        // Passing in array should cause elements
+        // to be refetched hence length should be 5
+        let condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
+
+        // @ts-ignore
+        const result = await executeCommand.call(this, els, condition, {}, ["Test Property", "Test Value"], true)
+        expect(condition).toHaveBeenCalledTimes(5)
+    })
+
+    test('empty array', async () => {
+        const els = await $$('sel') 
+        while (els.length > 0) { els.pop() }
+        // Passing in array should cause elements
+        // to be refetched hence length should be 5
+        let condition = jest.fn(() => { return { result: true, value: "Test Value "} } )
+
+        // @ts-ignore
+        const result = await executeCommand.call(this, els, condition, {wait: 0}, ["Test Property", "Test Value"])
+        expect(condition).toHaveBeenCalledTimes(0)
+        expect(result).toEqual({
+            el: els,
+            success: false
+        })
+    })
+})

--- a/test/util/expectAdapter.test.ts
+++ b/test/util/expectAdapter.test.ts
@@ -47,7 +47,7 @@ describe('expectAdapter', () => {
         })
 
         it('promise input', async () => {
-            const promise: Promise<JestExpectationResult> = new Promise((resolve, reject) => {
+            const promise: Promise<JestExpectationResult> = new Promise((resolve) => {
                 resolve(input);
             });
             const output = await jestResultToJasmine(promise, false);

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -25,7 +25,7 @@ describe('formatMessage', () => {
             })
 
             test('diff string', () => {
-                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                const diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
                 expect(actual).toMatch(diffString)
             })
         })
@@ -52,7 +52,7 @@ describe('formatMessage', () => {
                 })
 
                 test('diff string', () => {
-                    let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected [not]', 'Received      ', true)
+                    const diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected [not]', 'Received      ', true)
                     expect(actual).toMatch(diffString)
                 })
             })
@@ -76,7 +76,7 @@ describe('formatMessage', () => {
                 })
 
                 test('diff string', () => {
-                    let diffString = `Expected [not]: ${printExpected("Test Same")}\n` +
+                    const diffString = `Expected [not]: ${printExpected("Test Same")}\n` +
                         `Received      : ${printReceived("Test Same")}`
                     expect(actual).toMatch(diffString)
                 })
@@ -105,7 +105,7 @@ describe('formatMessage', () => {
             })
 
             test('diff string', () => {
-                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                const diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
                 expect(actual).toMatch(diffString)
             })
         })
@@ -131,7 +131,7 @@ describe('formatMessage', () => {
             })
 
             test('diff string', () => {
-                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                const diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
                 expect(actual).toMatch(diffString)
             })
         })
@@ -157,7 +157,7 @@ describe('formatMessage', () => {
             })
 
             test('diff string', () => {
-                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                const diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
                 expect(actual).toMatch(diffString)
             })
         })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -1,4 +1,4 @@
-import { printDiffOrStringify } from 'jest-matcher-utils';
+import { printDiffOrStringify, printExpected, printReceived } from 'jest-matcher-utils';
 
 import { enhanceError } from '../../src/util/formatMessage'
 
@@ -21,13 +21,67 @@ describe('formatMessage', () => {
             })
 
             test('starting message', () => {
-                expect(actual.includes('Expect Test Subject to Test Verb Test Expectation')).toBe(true)
+                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation')
             })
 
             test('diff string', () => {
                 let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
-                expect(actual.includes(diffString)).toBe(true)
+                expect(actual).toMatch(diffString)
             })
+        })
+
+        describe('isNot', () => {
+            let actual: string
+
+            describe('different', () => {
+                beforeEach(() => {
+                    actual = enhanceError(
+                        'Test Subject',
+                        'Test Expected',
+                        'Test Actual',
+                        { isNot: true },
+                        'Test Verb',
+                        'Test Expectation',
+                        '',
+                        { message: '', containing: false }
+                    )
+                })
+
+                test('starting message', () => {
+                    expect(actual).toMatch("Expect Test Subject not to Test Verb Test Expectation")
+                })
+
+                test('diff string', () => {
+                    let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected [not]', 'Received      ', true)
+                    expect(actual).toMatch(diffString)
+                })
+            })
+
+            describe('same', () => {
+                beforeEach(() => {
+                    actual = enhanceError(
+                        'Test Subject',
+                        'Test Same',
+                        'Test Same',
+                        { isNot: true },
+                        'Test Verb',
+                        'Test Expectation',
+                        '',
+                        { message: '', containing: false }
+                    )
+                })
+
+                test('starting message', () => {
+                    expect(actual).toMatch("Expect Test Subject not to Test Verb Test Expectation")
+                })
+
+                test('diff string', () => {
+                    let diffString = `Expected [not]: ${printExpected("Test Same")}\n` +
+                        `Received      : ${printReceived("Test Same")}`
+                    expect(actual).toMatch(diffString)
+                })
+            })
+
         })
 
         describe('containing', () => {
@@ -47,12 +101,64 @@ describe('formatMessage', () => {
             })
 
             test('starting message', () => {
-                expect(actual.includes('Expect Test Subject to Test Verb Test Expectation containing')).toBe(true)
+                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation containing')
             })
 
             test('diff string', () => {
                 let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
-                expect(actual.includes(diffString)).toBe(true)
+                expect(actual).toMatch(diffString)
+            })
+        })
+
+        describe('message', () => {
+            let actual: string
+
+            beforeEach(() => {
+                actual = enhanceError(
+                    'Test Subject',
+                    'Test Expected',
+                    'Test Actual',
+                    { isNot: false },
+                    'Test Verb',
+                    'Test Expectation',
+                    '',
+                    { message: 'Test Message', containing: false }
+                )
+            })
+
+            test('starting message', () => {
+                expect(actual).toMatch('Test Message\nExpect Test Subject to Test Verb Test Expectation')
+            })
+
+            test('diff string', () => {
+                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                expect(actual).toMatch(diffString)
+            })
+        })
+
+        describe('arg2', () => {
+            let actual: string
+
+            beforeEach(() => {
+                actual = enhanceError(
+                    'Test Subject',
+                    'Test Expected',
+                    'Test Actual',
+                    { isNot: false },
+                    'Test Verb',
+                    'Test Expectation',
+                    'Test Arg2',
+                    { message: 'Test Message', containing: false }
+                )
+            })
+
+            test('starting message', () => {
+                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation Test Arg2')
+            })
+
+            test('diff string', () => {
+                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                expect(actual).toMatch(diffString)
             })
         })
     })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -1,0 +1,59 @@
+import { printDiffOrStringify } from 'jest-matcher-utils';
+
+import { enhanceError } from '../../src/util/formatMessage'
+
+describe('formatMessage', () => {
+    describe('enhanceError', () => {
+        describe('default', () => {
+            let actual: string
+
+            beforeEach(() => {
+                actual = enhanceError(
+                    'Test Subject',
+                    'Test Expected',
+                    'Test Actual',
+                    { isNot: false },
+                    'Test Verb',
+                    'Test Expectation',
+                    '',
+                    { message: '', containing: false }
+                )
+            })
+
+            test('starting message', () => {
+                expect(actual.includes('Expect Test Subject to Test Verb Test Expectation')).toBe(true)
+            })
+
+            test('diff string', () => {
+                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                expect(actual.includes(diffString)).toBe(true)
+            })
+        })
+
+        describe('containing', () => {
+            let actual: string
+
+            beforeEach(() => {
+                actual = enhanceError(
+                    'Test Subject',
+                    'Test Expected',
+                    'Test Actual',
+                    { isNot: false },
+                    'Test Verb',
+                    'Test Expectation',
+                    '',
+                    { message: '', containing: true }
+                )
+            })
+
+            test('starting message', () => {
+                expect(actual.includes('Expect Test Subject to Test Verb Test Expectation containing')).toBe(true)
+            })
+
+            test('diff string', () => {
+                let diffString = printDiffOrStringify('Test Expected', 'Test Actual', 'Expected', 'Received', true)
+                expect(actual.includes(diffString)).toBe(true)
+            })
+        })
+    })
+})

--- a/test/util/refetchElements.test.ts
+++ b/test/util/refetchElements.test.ts
@@ -1,0 +1,22 @@
+import { doesNotMatch } from 'assert/strict';
+import { refetchElements } from '../../src/util/refetchElements'
+
+describe('refetchElements', () => {
+    let els: WebdriverIO.ElementArray
+
+    beforeEach(async () => {
+        els = await $$('parent');
+        // @ts-ignore
+        els.parent._length = 5;
+    })
+
+    test('default', async () => {
+        const actual = await refetchElements(els, 5, true)
+        expect(actual.length).toBe(5)
+    })
+
+    test('wait is 0', async () => {
+        const actual = await refetchElements(els, 0, true)
+        expect(actual).toEqual(els)
+    })
+})

--- a/test/util/refetchElements.test.ts
+++ b/test/util/refetchElements.test.ts
@@ -1,4 +1,3 @@
-import { doesNotMatch } from 'assert/strict';
 import { refetchElements } from '../../src/util/refetchElements'
 
 describe('refetchElements', () => {


### PR DESCRIPTION
- adds util/ test files (Hitting untested parts and still needs future work)
- improve toHaveElementProperty tests
- Change elementsUtil forEach to for loop as seemed to not be functioning correctly
- update options test to increase coverage
- remove jasmineUtil from test coverage since it was a file extracted out of jasmine 2.5.2 and seems to thererfore be outside of scope of increasing the coverage for the repo, this was my thinking but what do you think?

All these things considered statement coverage is now just over 99% but branch coverage needs improvement and there are still missing test cases I think