### PR TITLE
Overwrite sync expect fn with expectAsync

### DIFF
--- a/src/addMatchers.ts
+++ b/src/addMatchers.ts
@@ -48,8 +48,13 @@ export const addMatchers = (): any => {
     expectLib = global.jasmine
 
     return expectLib.getEnv().beforeAll(function addExpectWebdriverIOMatchers(): void {
-        expectLib.addMatchers({ ...matchers })
         expectLib.addAsyncMatchers({ ...matchers })
+
+        /**
+         * we can't use WebdriverIO async matchers with Jasmines synchronous expect
+         * library as we get something like `Error: Expected [object Promise] to be existing.`
+         */
+        global.expect = global.expectAsync as any
     })
 }
 


### PR DESCRIPTION
In Jasmine our async matchers aren't working because the expected promise is never resolved and results in errors like these:

```
Error: Expected [object Promise] to be existing.
    at <Jasmine>
    at ...
```

Therefor let's just overwrite the async expect function with this one. The only downside is that the following matchers aren't available anymore: `toBeNegativeInfinity`, `toBePositiveInfinity`, `toHaveBeenCalledBefore`, `toThrowMatching`, `withContext`, `toHaveSize`, `toHaveClass`. Given they aren't really useful in the e2e context I believe this is the best way to resolve the overall confusion.