### PR TITLE
Support for Multiremote and fixed many errors of current main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib
 coverage
 
 .vscode
+.history
 .idea
 
 *.log

--- a/jasmine.d.ts
+++ b/jasmine.d.ts
@@ -1,6 +1,8 @@
-/// <reference types="expect-webdriverio/types/expect-webdriverio"/>
+import { ExpectWebdriverIOStandalone } from './types/standalone'
 
-declare module jasmine {
-    interface Matchers<T> extends ExpectWebdriverIO.Matchers<any, T> {}
-    interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
+declare global {
+    namespace jasmine {
+        interface Matchers<T> extends ExpectWebdriverIOStandalone.Matchers<any, T> {}
+        interface AsyncMatchers<T, U> extends ExpectWebdriverIOStandalone.Matchers<Promise<void>, T> {}
+    }
 }

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -1,5 +1,7 @@
-/// <reference types="expect-webdriverio/types/expect-webdriverio"/>
+import { ExpectWebdriverIOStandalone } from './types/standalone'
 
-declare namespace jest {
-    interface Matchers<R, T> extends ExpectWebdriverIO.Matchers<R, T> { }
+declare global {
+    namespace jest {
+        interface Matchers<R, T> extends ExpectWebdriverIOStandalone.Matchers<R, T> {}
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
-      "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -667,21 +667,12 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -691,19 +682,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3322,12 +3300,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.1.0.tgz",
-      "integrity": "sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.0.3",
+        "@eslint/eslintrc": "^1.0.4",
         "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3361,7 +3339,7 @@
         "progress": "^2.0.0",
         "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
@@ -4053,9 +4031,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -9494,9 +9472,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
-      "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -9505,35 +9483,16 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
         }
       }
     },
@@ -11574,12 +11533,12 @@
       }
     },
     "eslint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.1.0.tgz",
-      "integrity": "sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.3",
+        "@eslint/eslintrc": "^1.0.4",
         "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -11613,7 +11572,7 @@
         "progress": "^2.0.0",
         "regexpp": "^3.2.0",
         "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
@@ -12127,9 +12086,9 @@
       }
     },
     "globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1518,14 +1518,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.1.0.tgz",
-      "integrity": "sha512-vx1P+mhCtYw3+bRHmbalq/VKP2Y3gnzNgxGxfEWc6OFpuEL7iQdAeq11Ke3Rhy8NjgB+AHsIWEwni3e+Y7djKA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.3.1.tgz",
+      "integrity": "sha512-TD+ONlx5c+Qhk21x9gsJAMRohWAUMavSOmJgv3JGy9dgPhuBd5Wok0lmMClZDyJNLLZK1JRKiATzCKZNUmoyfw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.1.0",
-        "@typescript-eslint/types": "5.1.0",
-        "@typescript-eslint/typescript-estree": "5.1.0",
+        "@typescript-eslint/scope-manager": "5.3.1",
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/typescript-estree": "5.3.1",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1542,6 +1542,80 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
+      "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/visitor-keys": "5.3.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
+      "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
+      "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/visitor-keys": "5.3.1",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
+      "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -10158,15 +10232,58 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.1.0.tgz",
-      "integrity": "sha512-vx1P+mhCtYw3+bRHmbalq/VKP2Y3gnzNgxGxfEWc6OFpuEL7iQdAeq11Ke3Rhy8NjgB+AHsIWEwni3e+Y7djKA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.3.1.tgz",
+      "integrity": "sha512-TD+ONlx5c+Qhk21x9gsJAMRohWAUMavSOmJgv3JGy9dgPhuBd5Wok0lmMClZDyJNLLZK1JRKiATzCKZNUmoyfw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.1.0",
-        "@typescript-eslint/types": "5.1.0",
-        "@typescript-eslint/typescript-estree": "5.1.0",
+        "@typescript-eslint/scope-manager": "5.3.1",
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/typescript-estree": "5.3.1",
         "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
+          "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "@typescript-eslint/visitor-keys": "5.3.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
+          "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
+          "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "@typescript-eslint/visitor-keys": "5.3.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
+          "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/src/addMatchers.ts
+++ b/src/addMatchers.ts
@@ -1,6 +1,7 @@
 let expectLib: SomeExpectLib
 
 export const isJasmine = (): boolean => {
+    // @ts-ignore
     return Boolean(global.jasmine && global.expect && global.expectAsync && global.jasmine.getEnv && global.jasmine.addMatchers && global.jasmine.addAsyncMatchers)
 }
 
@@ -13,22 +14,27 @@ export const loadExpect = (): any => {
 }
 
 export const addMatchers = (): any => {
+    // @ts-ignore
     if (global.expect === undefined) {
         // WebdriverIO Test Runner + Mocha/Cucumber (but not Jasmine)
         //
         // by default import expect lib and assign it to global object
         // This is a default behavior for Mocha and CucumberJS
         if (!loadExpect()) { return }
+        // @ts-ignore
         global.expect = expectLib
     } else {
         // WebdriverIO standalone mode + Jest
+        // @ts-ignore
         expectLib = global.expect
     }
 
     // check if expect is either Jest or Jasmine
+    // @ts-ignore
     if (!global.expect.extend && !isJasmine()) {
         // otherwise allow expect-webdriverio to be used together with some other expect lib
         if (!loadExpect()) { return }
+        // @ts-ignore
         global.expectWdio = expectLib
         console.warn('Warning! Unsupported expect lib is used.\n' +
             "Only Jasmine >= 3.3.0 and Jest's expect are supported.\n" +
@@ -45,6 +51,7 @@ export const addMatchers = (): any => {
     }
 
     // JASMINE
+    // @ts-ignore
     expectLib = global.jasmine
 
     return expectLib.getEnv().beforeAll(function addExpectWebdriverIOMatchers(): void {

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { waitUntil, enhanceError, compareText } from '../../utils'
 

--- a/src/matchers/browser/toHaveTitleContaining.ts
+++ b/src/matchers/browser/toHaveTitleContaining.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveTitleFn } from './toHaveTitle'
 

--- a/src/matchers/browser/toHaveUrl.ts
+++ b/src/matchers/browser/toHaveUrl.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { waitUntil, enhanceError, compareText } from '../../utils'
 

--- a/src/matchers/browser/toHaveUrlContaining.ts
+++ b/src/matchers/browser/toHaveUrlContaining.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveUrlFn } from './toHaveUrl'
 

--- a/src/matchers/element/toBeClickable.ts
+++ b/src/matchers/element/toBeClickable.ts
@@ -1,11 +1,12 @@
-
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeClickableFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeClickableFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'clickable'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {
             try {
                 return el.isClickable()

--- a/src/matchers/element/toBeDisabled.ts
+++ b/src/matchers/element/toBeDisabled.ts
@@ -1,10 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeDisabledFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeDisabledFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'disabled'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => !await el.isEnabled(), options)
         return result
     })

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -1,10 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeDisplayedFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeDisplayedFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'displayed'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {
             try {
                 return el.isDisplayed()

--- a/src/matchers/element/toBeDisplayedInViewport.ts
+++ b/src/matchers/element/toBeDisplayedInViewport.ts
@@ -1,10 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeDisplayedInViewportFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeDisplayedInViewportFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'displayed in viewport'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {
             try {
                 return el.isDisplayedInViewport()

--- a/src/matchers/element/toBeEnabled.ts
+++ b/src/matchers/element/toBeEnabled.ts
@@ -1,10 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeEnabledFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeEnabledFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'enabled'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isEnabled(), options)
         return result
     })
@@ -13,4 +15,3 @@ function toBeEnabledFn(received: WebdriverIO.Element | WebdriverIO.ElementArray,
 export function toBeEnabled(...args: any): any {
     return runExpect.call(this, toBeEnabledFn, args)
 }
-

--- a/src/matchers/element/toBeExisting.ts
+++ b/src/matchers/element/toBeExisting.ts
@@ -1,11 +1,13 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe, aliasFn } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toExistFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toExistFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'exist'
     this.verb = this.verb || ''
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {
             try {
                 return el.isExisting()
@@ -21,9 +23,9 @@ export function toExist(...args: any): any {
     return runExpect.call(this, toExistFn, args)
 }
 
-export function toBeExisting(el: WdioElementMaybePromise, options?: ExpectWebdriverIO.CommandOptions): any {
-    return aliasFn.call(this, toExist, { verb: 'be', expectation: 'existing' }, el, options)
+export function toBeExisting(el: WdioElementMaybePromise, options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser): any {
+    return aliasFn.call(this, toExist, { verb: 'be', expectation: 'existing' }, el, options, driver)
 }
-export function toBePresent(el: WdioElementMaybePromise, options?: ExpectWebdriverIO.CommandOptions): any {
-    return aliasFn.call(this, toExist, { verb: 'be', expectation: 'present' }, el, options)
+export function toBePresent(el: WdioElementMaybePromise, options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser): any {
+    return aliasFn.call(this, toExist, { verb: 'be', expectation: 'present' }, el, options, driver)
 }

--- a/src/matchers/element/toBeFocused.ts
+++ b/src/matchers/element/toBeFocused.ts
@@ -1,10 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeFocusedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeFocusedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'focused'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isFocused(), options)
         return result
     })

--- a/src/matchers/element/toBeSelected.ts
+++ b/src/matchers/element/toBeSelected.ts
@@ -1,11 +1,13 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { executeCommandBe } from '../../utils'
 import { runExpect, getContext } from '../../util/expectAdapter'
 
 
-function toBeSelectedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}): any {
+function toBeSelectedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
     this.expectation = this.expectation || 'selected'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isSelected(), options)
         return result
     })
@@ -15,8 +17,8 @@ export function toBeSelected(...args: any): any {
     return runExpect.call(this, toBeSelectedFn, args)
 }
 
-export function toBeChecked (el: WebdriverIO.Element, options: ExpectWebdriverIO.CommandOptions): any {
+export function toBeChecked (el: WebdriverIO.Element, options: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser): any {
     const context = getContext(this)
     context.expectation = 'checked'
-    return toBeSelected.call(context, el, options)
+    return toBeSelected.call(context, el, options, driver)
 }

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, compareText, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -19,11 +20,12 @@ async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string,
     return compareText(attr, value, options)
 }
 
-export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let attr
         const pass = await waitUntil(async () => {
@@ -38,7 +40,7 @@ export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | Webdri
 
         const expected = wrapExpectedWithArray(el, attr, value)
         const message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
-    
+
         return {
             pass,
             message: (): string => message
@@ -46,13 +48,14 @@ export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | Webdri
     })
 }
 
-export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string): any {
+export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
-        
+
         const pass = await waitUntil(async () => {
             const result = await executeCommand.call(this, el, conditionAttr, {}, [attribute])
             el = result.el
@@ -72,7 +75,7 @@ export function toHaveAttributeFn(received: WebdriverIO.Element | WebdriverIO.El
 }
 
 export function toHaveAttribute(...args: any): any {
-    if(args.length===3 || args.length===4 ) {
+    if((args.length===3 && typeof args[2] === "string") || args.length===4 || args.length===5) {
         // Name and value is passed in e.g. el.toHaveAttribute('attr', 'value', (opts))
         return runExpect.call(this, toHaveAttributeAndValueFn, args)
     } else {

--- a/src/matchers/element/toHaveAttributeContaining.ts
+++ b/src/matchers/element/toHaveAttributeContaining.ts
@@ -1,11 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-function toHaveAttributeContainingFn(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveAttributeContainingFn(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     return toHaveAttributeAndValueFn.call(this, el, attribute, value, {
         ...options,
         containing: true
-    })
+    }, driver)
 }
 
 export function toHaveAttributeContaining(...args: any): any {

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, compareNumbers, numberError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -18,7 +19,7 @@ async function condition(el: WebdriverIO.Element, options: ExpectWebdriverIO.Num
     }
 }
 
-function toHaveChildrenFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, expected?: number | ExpectWebdriverIO.NumberOptions, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveChildrenFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, expected?: number | ExpectWebdriverIO.NumberOptions, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'children', verb = 'have' } = this
 
@@ -30,7 +31,8 @@ function toHaveChildrenFn(received: WebdriverIO.Element | WebdriverIO.ElementArr
         numberOptions = expected
     }
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let children
         const pass = await waitUntil(async () => {

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -31,13 +32,14 @@ async function condition(el: WebdriverIO.Element, attribute: string, value: stri
     }
 }
 
-function toHaveElementClassFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, className: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveElementClassFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, className: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'class', verb = 'have' } = this
 
     const attribute = 'class'
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let attr
 

--- a/src/matchers/element/toHaveElementClassContaining.ts
+++ b/src/matchers/element/toHaveElementClassContaining.ts
@@ -1,11 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-function toHaveElementClassContainingFn(el: WebdriverIO.Element, className: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveElementClassContainingFn(el: WebdriverIO.Element, className: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     return toHaveAttributeAndValueFn.call(this, el, 'class', className, {
         ...options,
         containing: true
-    })
+    }, driver)
 }
 
 export function toHaveElementClassContaining(...args: any): any {

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import {
     waitUntil,
     enhanceError,
@@ -38,12 +39,14 @@ export function toHaveElementPropertyFn(
     received: WebdriverIO.Element | WebdriverIO.ElementArray,
     property: string,
     value?: any,
-    options: ExpectWebdriverIO.StringOptions = {}
+    options: ExpectWebdriverIO.StringOptions = {},
+    driver?: WebdriverIO.Browser
 ): any {
     const isNot = this.isNot
     const { expectation = 'property', verb = 'have' } = this
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let prop: any
         const pass = await waitUntil(

--- a/src/matchers/element/toHaveHref.ts
+++ b/src/matchers/element/toHaveHref.ts
@@ -1,8 +1,9 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-export function toHaveHrefFn(el: WebdriverIO.Element, href: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeAndValueFn.call(this, el, 'href', href, options)
+export function toHaveHrefFn(el: WebdriverIO.Element, href: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
+    return toHaveAttributeAndValueFn.call(this, el, 'href', href, options, driver)
 }
 
 export function toHaveHref(...args: any): any {

--- a/src/matchers/element/toHaveHrefContaining.ts
+++ b/src/matchers/element/toHaveHrefContaining.ts
@@ -1,11 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveHrefFn } from './toHaveHref'
 
-function toHaveHrefContainingFn(el: WebdriverIO.Element, href: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveHrefContainingFn(el: WebdriverIO.Element, href: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     return toHaveHrefFn.call(this, el, href, {
         ...options,
         containing: true
-    })
+    }, driver)
 }
 
 export function toHaveHrefContaining(...args: any): any {

--- a/src/matchers/element/toHaveId.ts
+++ b/src/matchers/element/toHaveId.ts
@@ -1,8 +1,9 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-export function toHaveIdFn(el: WebdriverIO.Element, id: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveAttributeAndValueFn.call(this, el, 'id', id, options)
+export function toHaveIdFn(el: WebdriverIO.Element, id: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
+    return toHaveAttributeAndValueFn.call(this, el, 'id', id, options, driver)
 }
 
 export function toHaveId(...args: any): any {

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, compareStyle, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -5,11 +6,12 @@ async function condition(el: WebdriverIO.Element, style: { [key: string]: string
     return compareStyle(el, style, options)
 }
 
-export function toHaveStyleFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, style: { [key: string]: string; }, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveStyleFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, style: { [key: string]: string; }, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'style', verb = 'have' } = this
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let actualStyle
 

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, compareText, compareTextWithArray, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -9,11 +10,12 @@ async function condition(el: WebdriverIO.Element, text: string | Array<string>, 
     return compareText(actualText, text, options)
 }
 
-export function toHaveTextFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveTextFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'text', verb = 'have' } = this
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let el = await received
         let actualText
 

--- a/src/matchers/element/toHaveTextContaining.ts
+++ b/src/matchers/element/toHaveTextContaining.ts
@@ -1,11 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveTextFn } from './toHaveText'
 
-function toHaveTextContainingFn(el: WebdriverIO.Element, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveTextContainingFn(el: WebdriverIO.Element, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     return toHaveTextFn.call(this, el, text, {
         ...options,
         containing: true
-    })
+    }, driver)
 }
 
 export function toHaveTextContaining(...args: any): any {

--- a/src/matchers/element/toHaveValue.ts
+++ b/src/matchers/element/toHaveValue.ts
@@ -1,8 +1,9 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveElementPropertyFn } from './toHaveElementProperty'
 
-export function toHaveValueFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
-    return toHaveElementPropertyFn.call(this, el, 'value', value, options)
+export function toHaveValueFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
+    return toHaveElementPropertyFn.call(this, el, 'value', value, options, driver)
 }
 
 export function toHaveValue(...args: any): any {

--- a/src/matchers/element/toHaveValueContaining.ts
+++ b/src/matchers/element/toHaveValueContaining.ts
@@ -1,11 +1,12 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveValueFn } from './toHaveValue'
 
-function toHaveValueContainingFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveValueContainingFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     return toHaveValueFn.call(this, el, value, {
         ...options,
         containing: true
-    })
+    }, driver)
 }
 
 export function toHaveValueContaining(...args: any): any {

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -1,8 +1,9 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import { waitUntil, enhanceError, compareNumbers, numberError, updateElementsArray } from '../../utils'
 import { refetchElements } from '../../util/refetchElements'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeElementsArrayOfSizeFn(received: WebdriverIO.ElementArray, expected: number | ExpectWebdriverIO.NumberOptions, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toBeElementsArrayOfSizeFn(received: WebdriverIO.ElementArray, expected: number | ExpectWebdriverIO.NumberOptions, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot
     const { expectation = 'elements array of size', verb = 'be' } = this
 
@@ -16,7 +17,8 @@ function toBeElementsArrayOfSizeFn(received: WebdriverIO.ElementArray, expected:
         numberOptions = expected
     }
 
-    return browser.call(async () => {
+    const browserToUse: WebdriverIO.Browser = driver ?? browser;
+    return browserToUse.call(async () => {
         let elements = await received
         const arrLength = elements.length
 

--- a/src/matchers/mock/toBeRequested.ts
+++ b/src/matchers/mock/toBeRequested.ts
@@ -4,8 +4,8 @@ import type { Mock } from 'webdriverio'
 import { toBeRequestedTimes } from './toBeRequestedTimes'
 import { runExpect } from '../../util/expectAdapter'
 
-function toBeRequestedFn(received: Mock, options: ExpectWebdriverIO.CommandOptions = {}): any {
-    return toBeRequestedTimes.call({ ...(this || {}), expectation: 'called' }, received, { ...options, gte: 1 })
+function toBeRequestedFn(received: Mock, options: ExpectWebdriverIO.CommandOptions = {}, driver?: WebdriverIO.Browser): any {
+    return toBeRequestedTimes.call({ ...(this || {}), expectation: 'called' }, received, { ...options, gte: 1 }, driver)
 }
 
 export function toBeRequested(...args: any): any {

--- a/src/matchers/mock/toBeRequested.ts
+++ b/src/matchers/mock/toBeRequested.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import type { Mock } from 'webdriverio'
 
 import { toBeRequestedTimes } from './toBeRequestedTimes'

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -5,7 +5,7 @@ import { waitUntil, enhanceError, compareNumbers } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 import { numberError } from '../../util/formatMessage'
 
-export function toBeRequestedTimesFn(received: Mock, expected: number| ExpectWebdriverIO.NumberOptions = {}, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toBeRequestedTimesFn(received: Mock, expected: number| ExpectWebdriverIO.NumberOptions = {}, options: ExpectWebdriverIO.StringOptions = {}, driver?: WebdriverIO.Browser): any {
     const isNot = this.isNot || false
     const { expectation = `called${typeof expected === 'number' ? ' ' + expected : '' } time${expected !== 1 ? 's' : ''}`, verb = 'be' } = this
 
@@ -17,7 +17,8 @@ export function toBeRequestedTimesFn(received: Mock, expected: number| ExpectWeb
         numberOptions = expected
     }
 
-    return browser.call(async () => {
+    const browserToUse = driver ?? browser;
+    return browserToUse.call(async () => {
         let actual
 
         const pass = await waitUntil(async () => {

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import type { Mock } from 'webdriverio'
 
 import { waitUntil, enhanceError, compareNumbers } from '../../utils'
@@ -7,7 +8,7 @@ import { numberError } from '../../util/formatMessage'
 export function toBeRequestedTimesFn(received: Mock, expected: number| ExpectWebdriverIO.NumberOptions = {}, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot || false
     const { expectation = `called${typeof expected === 'number' ? ' ' + expected : '' } time${expected !== 1 ? 's' : ''}`, verb = 'be' } = this
-    
+
     // type check
     let numberOptions: ExpectWebdriverIO.NumberOptions;
     if (typeof expected === 'number') {

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import type { Mock } from 'webdriverio'
 import type { Matches } from 'webdriverio'
 

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -12,12 +12,14 @@ const KEY_LIMIT = 12
 export function toBeRequestedWithFn(
     received: Mock,
     requestedWith: ExpectWebdriverIO.RequestedWith = {},
-    options: ExpectWebdriverIO.CommandOptions = {}
+    options: ExpectWebdriverIO.CommandOptions = {},
+    driver?: WebdriverIO.Browser
 ): any {
     const isNot = this.isNot || false
     const { expectation = 'called with', verb = 'be' } = this
 
-    return browser.call(async () => {
+    const browserToUse = driver ?? browser;
+    return browserToUse.call(async () => {
         let actual: Matches | undefined
         const pass = await waitUntil(
             async () => {

--- a/src/matchers/mock/toBeRequestedWithResponse.ts
+++ b/src/matchers/mock/toBeRequestedWithResponse.ts
@@ -7,9 +7,10 @@ import { runExpect } from '../../util/expectAdapter'
 function toBeRequestedWithResponseFn(
     received: Mock,
     response: any,
-    options: ExpectWebdriverIO.CommandOptions = {}
+    options: ExpectWebdriverIO.CommandOptions = {},
+    driver?: WebdriverIO.Browser
 ): any {
-    return toBeRequestedWithFn.call(this, received, { response }, options)
+    return toBeRequestedWithFn.call(this, received, { response }, options, driver)
 }
 
 export function toBeRequestedWithResponse(...args: any): any {

--- a/src/matchers/mock/toBeRequestedWithResponse.ts
+++ b/src/matchers/mock/toBeRequestedWithResponse.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../../types/expect-webdriverio'
 import type { Mock } from 'webdriverio'
 
 import { toBeRequestedWithFn } from './toBeRequestedWith'

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,12 +6,17 @@ const DEFAULT_OPTIONS = {
 let mode: 'jasmine' | 'jest' = 'jest'
 
 let expectLib: SomeExpectLib
+// @ts-ignore
 if (global.expectWdio) {
+    // @ts-ignore
     expectLib = global.expectWdio
+    // @ts-ignore
 } else if (global.jasmine && !global.expect?.extend) {
+    // @ts-ignore
     expectLib = global.jasmine
     mode = 'jasmine'
 } else {
+    // @ts-ignore
     expectLib = global.expect as SomeExpectLib
 }
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from '../types/expect-webdriverio'
 import { refetchElements } from './refetchElements'
 
 /**

--- a/src/util/expectAdapter.ts
+++ b/src/util/expectAdapter.ts
@@ -13,7 +13,7 @@ const { mode: MODE } = config
 export const getContext = (context?: any): any => global === context ? {} : context || {}
 
 export function runJestExpect(fn: (...args: any) => any, args: IArguments): any {
-    return fn.apply(this, args)
+    return fn.apply(this ?? {}, args)
 }
 
 export const buildJasmineFromJestResult = (result: JestExpectationResult, isNot: boolean): any => {

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -1,5 +1,6 @@
 import { printExpected, printReceived, printDiffOrStringify } from 'jest-matcher-utils';
 import { equals } from '../jasmineUtils'
+import { ExpectWebdriverIO } from '../types/expect-webdriverio';
 
 const EXPECTED_LABEL = 'Expected';
 const RECEIVED_LABEL = 'Received';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { ExpectWebdriverIO } from './types/expect-webdriverio'
 import { getConfig } from './options'
 
 import { executeCommand } from './util/executeCommand'

--- a/test-types/default/tsconfig.json
+++ b/test-types/default/tsconfig.json
@@ -3,6 +3,9 @@
     "outDir": "dist",
     "noImplicitAny": true,
     "types": [
+      "node",
+      "webdriverio/async",
+      "expect/build/types",
       "expect-webdriverio"
     ]
   }

--- a/test-types/jasmine/tsconfig.json
+++ b/test-types/jasmine/tsconfig.json
@@ -5,6 +5,8 @@
     "outDir": "dist",
     "noImplicitAny": true,
     "types": [
+      "node",
+      "webdriverio/async",
       "@types/jasmine",
       "expect-webdriverio/jasmine"
     ]

--- a/test-types/jest/tsconfig.json
+++ b/test-types/jest/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ES2018"],
+    "lib": ["ES2018", "DOM"],
     "noImplicitAny": true,
     "types": [
+      "node",
+      "webdriverio/async",
       "@types/jest",
       "expect-webdriverio/jest"
     ]

--- a/test/matchers/beMatchers.test.ts
+++ b/test/matchers/beMatchers.test.ts
@@ -122,6 +122,12 @@ describe('be* matchers', () => {
                 expect(getExpectMessage(result.message()))
                     .toContain(matcherNameToString(name))
             })
+
+            test('message with custom driver', async () => {
+                const result = await fn.call({}, $('sel'), {}, browser)
+                expect(getExpectMessage(result.message()))
+                    .toContain(matcherNameToString(name))
+            })
         })
     })
 })

--- a/test/matchers/element/toBeDisabled.test.ts
+++ b/test/matchers/element/toBeDisabled.test.ts
@@ -127,4 +127,13 @@ describe('toBeDisabled', () => {
         const result = await toBeDisabled(el)
         expect(getExpectMessage(result.message())).toContain('to be disabled')
     })
+
+    test('message with custom driver', async () => {
+        const el = await $('sel')
+        el._value = function (): boolean {
+            return false
+        }
+        const result = await toBeDisabled(el, {}, browser)
+        expect(getExpectMessage(result.message())).toContain('to be disabled')
+    })
 })

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -4,9 +4,9 @@ import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute';
 describe('toHaveAttribute', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
-    })    
+    })
 
     describe('attribute exists', () => {
         test('success when present', async () => {
@@ -14,6 +14,14 @@ describe('toHaveAttribute', () => {
                 return "Correct Value"
             })
             const result = await toHaveAttribute(el, "attribute_name");
+            expect(result.pass).toBe(true)
+        })
+
+        test('success when present with custom driver', async () => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", browser);
             expect(result.pass).toBe(true)
         })
 
@@ -45,13 +53,20 @@ describe('toHaveAttribute', () => {
             })
         })
     })
-    
+
     describe('attribute has value', () => {
         test('success with correct value', async () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
             const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            expect(result.pass).toBe(true)
+        })
+        test('success with correct value and custom driver', async () => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true }, browser);
             expect(result.pass).toBe(true)
         })
         test('failure with wrong value', async () => {

--- a/test/matchers/element/toHaveAttributeContaining.test.ts
+++ b/test/matchers/element/toHaveAttributeContaining.test.ts
@@ -4,15 +4,23 @@ import { toHaveAttrContaining } from '../../../src/matchers/element/toHaveAttrib
 describe('toHaveAttributeContaining', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
-    })    
+    })
 
     test('success when contains', async () => {
         el.getAttribute = jest.fn().mockImplementation(() => {
             return "An example phrase"
         })
         const result = await toHaveAttrContaining(el, "attribute_name", "example");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success when contains with custom driver', async () => {
+        el.getAttribute = jest.fn().mockImplementation(() => {
+            return "An example phrase"
+        })
+        const result = await toHaveAttrContaining(el, "attribute_name", "example", {}, browser);
         expect(result.pass).toBe(true)
     });
 
@@ -42,5 +50,5 @@ describe('toHaveAttributeContaining', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -8,6 +8,13 @@ describe('toHaveChildren', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('no value with custom driver', async () => {
+        const el = await $('sel')
+
+        const result = await toHaveChildren(el, { wait: 0 }, {}, browser)
+        expect(result.pass).toBe(true)
+    })
+
     test('exact number value', async () => {
         const el = await $('sel')
 

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -4,7 +4,7 @@ import { toHaveClass, toHaveElementClass } from '../../../src/matchers/element/t
 describe('toHaveElementClass', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
             if(attribute === 'class') {
@@ -12,10 +12,15 @@ describe('toHaveElementClass', () => {
             }
             return null
         })
-    })    
+    })
 
     test('success when class name is present', async () => {
         const result = await toHaveElementClass(el, "some-class");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success when class name is present with custom driver', async () => {
+        const result = await toHaveElementClass(el, "some-class", {}, browser);
         expect(result.pass).toBe(true)
     });
 
@@ -35,18 +40,18 @@ describe('toHaveElementClass', () => {
             const result = await toHaveElementClass(el, "some-class", {trim: true});
             expect(result.pass).toBe(true)
         })
-        
+
         it('should pass when ignore the case', async () => {
             const result = await toHaveElementClass(el, "sOme-ClAsS", {ignoreCase: true});
-            expect(result.pass).toBe(true) 
+            expect(result.pass).toBe(true)
         })
 
         it('should pass if containing', async () => {
             const result = await toHaveElementClass(el, "some", {containing: true});
-            expect(result.pass).toBe(true) 
-        }) 
+            expect(result.pass).toBe(true)
+        })
     })
-    
+
     describe('failure when class name is not present', () => {
         let result: any
 
@@ -76,7 +81,7 @@ global.console.warn = jest.fn()
 
 describe('toHaveClass', () => {
     let el: WebdriverIO.Element
-    
+
     test('warning message in console', async () => {
         await toHaveClass(el, "test");
         expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClass is deprecated and will be removed in next release. Use toHaveElementClass instead.')

--- a/test/matchers/element/toHaveElementClassContaining.test.ts
+++ b/test/matchers/element/toHaveElementClassContaining.test.ts
@@ -4,7 +4,7 @@ import { toHaveClassContaining, toHaveElementClassContaining } from '../../../sr
 describe('toHaveElementClassContaining', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
             if(attribute === 'class') {
@@ -12,10 +12,15 @@ describe('toHaveElementClassContaining', () => {
             }
             return null
         })
-    })    
+    })
 
     test('success when whole class name is present', async () => {
         const result = await toHaveElementClassContaining(el, "some-class");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success when whole class name is present with custom driver', async () => {
+        const result = await toHaveElementClassContaining(el, "some-class", {}, browser);
         expect(result.pass).toBe(true)
     });
 
@@ -53,7 +58,7 @@ global.console.warn = jest.fn()
 
 describe('toHaveClassContaining', () => {
     let el: WebdriverIO.Element
-    
+
     test('warning message in console', async () => {
         await toHaveClassContaining(el, "test");
         expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClassContaining is deprecated and will be removed in next release. Use toHaveElementClassContaining instead.')

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -14,6 +14,19 @@ describe('toHaveElementProperty', () => {
         expect(el._attempts).toBe(1)
     })
 
+    test('ignore case of stringified value with custom driver', async () => {
+        const el = await $('sel')
+        el._attempts = 0
+        el._value = function (): string {
+            this._attempts++
+            return 'iphone'
+        }
+
+        const result = await toHaveElementProperty(el, 'property', 'iPhone', { wait: 0, ignoreCase: true }, browser)
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
     test('should return false if values dont match', async () => {
         const el = await $('sel')
         el._value = function (): string {

--- a/test/matchers/element/toHaveHref.test.ts
+++ b/test/matchers/element/toHaveHref.test.ts
@@ -4,7 +4,7 @@ import { toHaveHref } from '../../../src/matchers/element/toHaveHref';
 describe('toHaveHref', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
             if(attribute === 'href') {
@@ -12,10 +12,15 @@ describe('toHaveHref', () => {
             }
             return null
         })
-    })    
+    })
 
     test('success when contains', async () => {
         const result = await toHaveHref(el, "https://www.example.com");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success when contains with custom driver', async () => {
+        const result = await toHaveHref(el, "https://www.example.com", {}, browser);
         expect(result.pass).toBe(true)
     });
 
@@ -42,5 +47,5 @@ describe('toHaveHref', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveHrefContaining.test.ts
+++ b/test/matchers/element/toHaveHrefContaining.test.ts
@@ -4,7 +4,7 @@ import { toHaveHrefContaining } from '../../../src/matchers/element/toHaveHrefCo
 describe('toHaveHrefContaining', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
             if(attribute === 'href') {
@@ -12,11 +12,16 @@ describe('toHaveHrefContaining', () => {
             }
             return null
         })
-    })    
+    })
 
     describe('success', () => {
         test('exact passes', async () => {
             const result = await toHaveHrefContaining(el, "https://www.example.com");
+            expect(result.pass).toBe(true)
+        });
+
+        test('exact passes with custom driver', async () => {
+            const result = await toHaveHrefContaining(el, "https://www.example.com", {}, browser);
             expect(result.pass).toBe(true)
         });
 
@@ -49,5 +54,5 @@ describe('toHaveHrefContaining', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveId.test.ts
+++ b/test/matchers/element/toHaveId.test.ts
@@ -4,7 +4,7 @@ import { toHaveId } from '../../../src/matchers/element/toHaveId';
 describe('toHaveHref', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el.getAttribute = jest.fn().mockImplementation((attribute: string) => {
             if(attribute === 'id') {
@@ -12,10 +12,15 @@ describe('toHaveHref', () => {
             }
             return null
         })
-    })    
+    })
 
     test('success', async () => {
         const result = await toHaveId(el, "test id");
+        expect(result.pass).toBe(true)
+    });
+
+    test('success with custom driver', async () => {
+        const result = await toHaveId(el, "test id", {}, browser);
         expect(result.pass).toBe(true)
     });
 
@@ -42,5 +47,5 @@ describe('toHaveHref', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -7,7 +7,7 @@ describe('toHaveStyle', () => {
         "font-family": "Faktum",
         "font-size": "26px",
         "color": "#000"
-    } 
+    }
 
     test('wait for success', async () => {
         el = await $('sel')
@@ -25,6 +25,26 @@ describe('toHaveStyle', () => {
             return { value: mockStyle[property] }
         })
         const result = await toHaveStyle(el, mockStyle, { ignoreCase: true });
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
+    test('wait for success with custom driver', async () => {
+        el = await $('sel')
+        el._attempts = 2
+        let counter = 0;
+        el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
+            if(el._attempts > 0) {
+                counter ++;
+                if(counter == Object.keys(mockStyle).length) {
+                    counter = 0;
+                    el._attempts --;
+                }
+                return {value: "Wrong Value"};
+            }
+            return { value: mockStyle[property] }
+        })
+        const result = await toHaveStyle(el, mockStyle, { ignoreCase: true }, browser);
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(0)
     })
@@ -120,7 +140,7 @@ describe('toHaveStyle', () => {
             "font-family": "Incorrect Font",
             "font-size": "100px",
             "color": "#fff"
-        } 
+        }
 
         const result = await toHaveStyle.bind({ isNot: true })(el, wrongStyle, { wait: 1 })
         expect(result.pass).toBe(false)
@@ -154,7 +174,7 @@ describe('toHaveStyle', () => {
             "font-family": "Faktum",
             "font-size": "26px",
             "color": "#fff"
-        } 
+        }
 
         el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
             counter ++;
@@ -169,13 +189,13 @@ describe('toHaveStyle', () => {
             "font-family": "FaKtum",
             "font-size": "26px",
             "color": "#FFF"
-        } 
+        }
 
         const result = await toHaveStyle(el, alteredCaseStyle, { ignoreCase: true })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
-    
+
     test('success if style matches with trim', async () => {
         const el = await $('sel')
         el._attempts = 0
@@ -185,7 +205,7 @@ describe('toHaveStyle', () => {
             "font-family": "   Faktum   ",
             "font-size": "   26px   ",
             "color": "    #fff     "
-        } 
+        }
 
         el.getCSSProperty = jest.fn().mockImplementation((property: string) => {
             counter ++;
@@ -200,7 +220,7 @@ describe('toHaveStyle', () => {
             "font-family": "Faktum",
             "font-size": "26px",
             "color": "#fff"
-        } 
+        }
 
         const result = await toHaveStyle(el, alteredSpaceStyle, {   trim: true })
         expect(result.pass).toBe(true)

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -18,6 +18,22 @@ describe('toHaveText', () => {
         expect(el._attempts).toBe(0)
     })
 
+    test('wait for success with custom driver', async () => {
+        const el = await $('sel')
+        el._attempts = 2
+        el._text= function (): string {
+            if (this._attempts > 0) {
+                this._attempts--
+                return ''
+            }
+            return 'webdriverio'
+        }
+
+        const result = await toHaveText(el, 'WebdriverIO', { ignoreCase: true }, browser)
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(0)
+    })
+
     test('wait but failure', async () => {
         const el = await $('sel')
         el._text = function (): string {

--- a/test/matchers/element/toHaveTextContaining.test.ts
+++ b/test/matchers/element/toHaveTextContaining.test.ts
@@ -4,16 +4,21 @@ import { toHaveTextContaining } from '../../../src/matchers/element/toHaveTextCo
 describe('toHaveTextContaining', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el._text = jest.fn().mockImplementation(() => {
             return "This is example text"
         })
-    })    
+    })
 
     describe('success', () => {
         test('exact passes', async () => {
             const result = await toHaveTextContaining(el, "This is example text");
+            expect(result.pass).toBe(true)
+        });
+
+        test('exact passes with custom driver', async () => {
+            const result = await toHaveTextContaining(el, "This is example text", {}, browser);
             expect(result.pass).toBe(true)
         });
 
@@ -46,5 +51,5 @@ describe('toHaveTextContaining', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveValue.test.ts
+++ b/test/matchers/element/toHaveValue.test.ts
@@ -4,16 +4,20 @@ import { toHaveValue } from '../../../src/matchers/element/toHaveValue'
 describe('toHaveValue', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el._value = jest.fn().mockImplementation(() => {
             return "This is an example value"
         })
-    })    
+    })
 
     describe('success', () => {
         test('exact passes', async () => {
             const result = await toHaveValue(el, "This is an example value");
+            expect(result.pass).toBe(true)
+        });
+        test('exact passes with custom driver', async () => {
+            const result = await toHaveValue(el, "This is an example value", {}, browser);
             expect(result.pass).toBe(true)
         });
     })
@@ -41,5 +45,5 @@ describe('toHaveValue', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/element/toHaveValueContaining.test.ts
+++ b/test/matchers/element/toHaveValueContaining.test.ts
@@ -4,16 +4,20 @@ import { toHaveValueContaining } from '../../../src/matchers/element/toHaveValue
 describe('toHaveValueContaining', () => {
     let el: WebdriverIO.Element
 
-    beforeEach(async () => { 
+    beforeEach(async () => {
         el = await $('sel')
         el._value = jest.fn().mockImplementation(() => {
             return "This is an example value"
         })
-    })    
+    })
 
     describe('success', () => {
         test('exact passes', async () => {
             const result = await toHaveValueContaining(el, "This is an example value");
+            expect(result.pass).toBe(true)
+        });
+        test('exact passes with custom driver', async () => {
+            const result = await toHaveValueContaining(el, "This is an example value", {}, browser);
             expect(result.pass).toBe(true)
         });
         test('part passes', async () => {
@@ -45,5 +49,5 @@ describe('toHaveValueContaining', () => {
             })
         })
     });
-    
+
 });

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -10,7 +10,13 @@ describe('toBeElementsArrayOfSize', () => {
             els = await $$('parent');
             const result = await toBeElementsArrayOfSize(els, 2, {});
             expect(result.pass).toBe(true)
-        })  
+        })
+        test('array of size 2 with custom driver', async () => {
+            // Create an element array of length 2
+            els = await $$('parent');
+            const result = await toBeElementsArrayOfSize(els, 2, {}, browser);
+            expect(result.pass).toBe(true)
+        })
         test('array of size 5', async () => {
             // Create an element array of length 2
             els = await $$('parent');
@@ -18,11 +24,11 @@ describe('toBeElementsArrayOfSize', () => {
             els.parent._length = 5;
             const result = await toBeElementsArrayOfSize(els, 5, {});
             expect(result.pass).toBe(true)
-        })  
+        })
     })
 
     describe('failure', () => {
-        let result: any; 
+        let result: any;
 
         beforeEach(async () => {
             // Create an element array of length 2
@@ -65,9 +71,9 @@ describe('toBeElementsArrayOfSize', () => {
             const result = await toBeElementsArrayOfSize(els, {lte: 5});
             expect(result.pass).toBe(true);
         })
-        
+
     })
-    
+
     describe('number options', () => {
         describe('lte', () => {
             test('should pass if lte', async () => {
@@ -84,7 +90,7 @@ describe('toBeElementsArrayOfSize', () => {
                 expect(result.pass).toBe(false);
             })
         })
-        
+
         describe('gte', () => {
             test('should pass if gte', async () => {
                 // Create an element array of length 2
@@ -115,7 +121,7 @@ describe('toBeElementsArrayOfSize', () => {
                 const result = await toBeElementsArrayOfSize(els, {gte: 10, lte: 10});
                 expect(result.pass).toBe(false);
             })
-            
+
             test('should fail if not lte but is gte', async () => {
                 // Create an element array of length 2
                 els = await $$('parent');
@@ -124,5 +130,5 @@ describe('toBeElementsArrayOfSize', () => {
             })
         })
     })
-    
+
 })

--- a/test/matchers/mock/toBeRequested.test.ts
+++ b/test/matchers/mock/toBeRequested.test.ts
@@ -46,6 +46,20 @@ describe('toBeRequested', () => {
         expect(result2.pass).toBe(true)
     })
 
+    test('wait for success with custom driver', async () => {
+        const mock: Mock = new TestMock()
+        const result = await toBeRequested(mock, {}, browser)
+        expect(result.pass).toBe(false)
+
+        setTimeout(() => {
+            mock.calls.push(mockMatch)
+            mock.calls.push(mockMatch)
+        }, 10)
+
+        const result2 = await toBeRequested(mock, {}, browser)
+        expect(result2.pass).toBe(true)
+    })
+
     test('not to be called', async () => {
         const mock: Mock = new TestMock()
 

--- a/test/matchers/mock/toBeRequestedTimes.test.ts
+++ b/test/matchers/mock/toBeRequestedTimes.test.ts
@@ -43,6 +43,17 @@ describe('toBeRequestedTimes', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('wait for success with custom driver', async () => {
+        const mock: Mock = new TestMock()
+
+        setTimeout(() => {
+            mock.calls.push(mockMatch)
+        }, 10)
+
+        const result = await toBeRequestedTimes(mock, 1, {}, browser)
+        expect(result.pass).toBe(true)
+    })
+
     test('wait for success using number options', async () => {
         const mock: Mock = new TestMock()
 

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -119,6 +119,17 @@ describe('toBeRequestedWith', () => {
         expect(result.pass).toBe(false)
     })
 
+    test('wait for NOT success with custom driver', async () => {
+        const mock = new TestMock()
+
+        setTimeout(() => {
+            mock.calls.push({ ...mockGet }, { ...mockPost })
+        }, 10)
+
+        const result = await toBeRequestedWith.call({ isNot: true }, mock, { method: 'DELETE' }, browser)
+        expect(result.pass).toBe(false)
+    })
+
     const scenarios = [
         // success
         {

--- a/test/matchers/mock/toBeRequestedWithResponse.test.ts
+++ b/test/matchers/mock/toBeRequestedWithResponse.test.ts
@@ -121,4 +121,11 @@ describe('toBeRequestedWithResponse', () => {
         const result = await toBeRequestedWithResponse(mock, { foo: 'foo' })
         expect(result.message()).toContain('Expect mock to be called')
     })
+
+    test('message with custom driver', async () => {
+        const mock: Mock = new TestMock()
+
+        const result = await toBeRequestedWithResponse(mock, { foo: 'foo' }, {}, browser)
+        expect(result.message()).toContain('Expect mock to be called')
+    })
 })

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -15,6 +15,7 @@ describe('options', () => {
 
                 expect(getConfig()).toEqual({ options, mode: 'jest' })
 
+                //@ts-ignore
                 delete global.expectWdio
             })
         })
@@ -30,12 +31,12 @@ describe('options', () => {
                 expect(getConfig()).toEqual({ options, mode: 'jasmine' })
 
                 // @ts-ignore
-                delete global.jasmine 
+                delete global.jasmine
                 // @ts-ignore
                 delete global.expect.extend
             })
         })
-        
+
         test('global', () => {
             jest.isolateModules(() => {
                 const { getConfig } = require(optionsModule)
@@ -53,7 +54,7 @@ describe('options', () => {
                 expect(getConfig()).toEqual({ options: { ...options, wait: 1234} , mode: 'jest' })
             })
         })
-        
+
         test('no change if invalid type', () => {
             jest.isolateModules(() => {
                 const { getConfig, setDefaultOptions } = require(optionsModule)

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -277,20 +277,21 @@ declare namespace ExpectWebdriverIO {
         /**
          * Check that `WebdriverIO.Mock` was called
          */
-        toBeRequested(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeRequested(options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * Check that `WebdriverIO.Mock` was called N times
          */
         toBeRequestedTimes(
             times: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions
+            options?: ExpectWebdriverIO.NumberOptions,
+            driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>
         ): R
 
         /**
          * Check that `WebdriverIO.Mock` was called with the specific parameters
          */
-        toBeRequestedWith(requestedWith: RequestedWith, options?: ExpectWebdriverIO.CommandOptions): R
+        toBeRequestedWith(requestedWith: RequestedWith, options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
     }
 
     type RequestedWith = {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1,3 +1,5 @@
+import type * as WebdriverIO from "webdriverio"
+
 declare namespace ExpectWebdriverIO {
     function setOptions(options: DefaultOptions): void
 
@@ -65,29 +67,29 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `isDisplayed`
          */
-        toBeDisplayed(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeDisplayed(options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toExist(options?: ExpectWebdriverIO.CommandOptions): R
+        toExist(options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toBePresent(options?: ExpectWebdriverIO.CommandOptions): R
+        toBePresent(options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toBeExisting(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeExisting(options?: ExpectWebdriverIO.CommandOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttribute(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttribute(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttr(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttr(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute`
@@ -96,7 +98,8 @@ declare namespace ExpectWebdriverIO {
         toHaveAttributeContaining(
             attribute: string,
             contains: string,
-            options?: ExpectWebdriverIO.StringOptions
+            options?: ExpectWebdriverIO.StringOptions,
+            driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>
         ): R
         /**
          * `WebdriverIO.Element` -> `getAttribute`
@@ -105,82 +108,83 @@ declare namespace ExpectWebdriverIO {
         toHaveAttrContaining(
             attribute: string,
             contains: string,
-            options?: ExpectWebdriverIO.StringOptions
+            options?: ExpectWebdriverIO.StringOptions,
+            driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>
         ): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClass` instead.
          */
-        toHaveClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClass(className: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          */
-        toHaveElementClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClass(className: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClassContaining` instead.
          * Element's class includes the className.
          */
-        toHaveClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * Element's class includes the className.
          */
-        toHaveElementClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty`
          */
-        toHaveElementProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveValue(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValue(value: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          * Element's value includes the value.
          */
-        toHaveValueContaining(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValueContaining(value: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isClickable`
          */
-        toBeClickable(options?: ExpectWebdriverIO.StringOptions): R
+        toBeClickable(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `!isEnabled`
          */
-        toBeDisabled(options?: ExpectWebdriverIO.StringOptions): R
+        toBeDisabled(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isDisplayedInViewport`
          */
-        toBeDisplayedInViewport(options?: ExpectWebdriverIO.StringOptions): R
+        toBeDisplayedInViewport(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isEnabled`
          */
-        toBeEnabled(options?: ExpectWebdriverIO.StringOptions): R
+        toBeEnabled(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isFocused`
          */
-        toBeFocused(options?: ExpectWebdriverIO.StringOptions): R
+        toBeFocused(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isSelected`
          */
-        toBeSelected(options?: ExpectWebdriverIO.StringOptions): R
+        toBeSelected(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `isSelected`
          */
-        toBeChecked(options?: ExpectWebdriverIO.StringOptions): R
+        toBeChecked(options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `$$('./*').length`
@@ -188,48 +192,49 @@ declare namespace ExpectWebdriverIO {
          */
         toHaveChildren(
             size?: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions
+            options?: ExpectWebdriverIO.NumberOptions,
+            driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>
         ): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveHref(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHref(href: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveLink(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLink(href: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveHrefContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHrefContaining(href: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveLinkContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLinkContaining(href: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveId(id: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveId(id: string, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
          * `WebdriverIO.Element` -> `getText`
          */
-        toHaveText(text: string | string[], options?: ExpectWebdriverIO.StringOptions): R
+        toHaveText(text: string | string[], options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
         /**
          * `WebdriverIO.Element` -> `getText`
          * Element's text includes the text provided
          */
-        toHaveTextContaining(text: string | string[], options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTextContaining(text: string | string[], options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         /**
         * `WebdriverIO.Element` -> `getAttribute("style")`
         */
-        toHaveStyle(style: { [key: string]: string; }, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveStyle(style: { [key: string]: string; }, options?: ExpectWebdriverIO.StringOptions, driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>): R
 
         // ===== browser only =====
         /**
@@ -263,7 +268,8 @@ declare namespace ExpectWebdriverIO {
          */
         toBeElementsArrayOfSize(
             size: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions
+            options?: ExpectWebdriverIO.NumberOptions,
+            driver?: WebdriverIO.Browser<'sync'> | WebdriverIO.Browser<'async'>
         ): R
 
         // ==== network mock ====

--- a/types/jest-global.d.ts
+++ b/types/jest-global.d.ts
@@ -1,9 +1,9 @@
-/// <reference types="expect-webdriverio/types/standalone"/>
+import { ExpectWebdriverIOStandalone } from './standalone'
 
-declare const expect: ExpectWebdriverIO.Expect
+declare const expect: ExpectWebdriverIOStandalone.Expect
 
 declare namespace NodeJS {
     interface Global {
-        expect: ExpectWebdriverIO.Expect;
+        expect: ExpectWebdriverIOStandalone.Expect
     }
 }

--- a/types/standalone-global.d.ts
+++ b/types/standalone-global.d.ts
@@ -1,12 +1,12 @@
-/// <reference types="expect-webdriverio/types/standalone"/>
+import { ExpectWebdriverIOStandalone } from "./standalone";
 
 /**
  * to use as an additional expectation lib (not recommended)
  */
-declare const expectWdio: ExpectWebdriverIO.Expect
+declare const expectWdio: ExpectWebdriverIOStandalone.Expect
 
 declare namespace NodeJS {
     interface Global {
-        expectWdio: ExpectWebdriverIO.Expect;
+        expectWdio: ExpectWebdriverIOStandalone.Expect;
     }
 }

--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="expect-webdriverio/types/expect-webdriverio"/>
+import { Matchers as ExpectMatchers } from "expect/build/types";
+import { ExpectWebdriverIO as ExpectWebdriverIONamespace } from "./expect-webdriverio";
 
-declare namespace ExpectWebdriverIO {
-    interface Matchers<R, T> extends Readonly<import('expect/build/types').Matchers<R>> {
-        not: Matchers<R, T>
-        resolves: Matchers<Promise<R>, T>
-        rejects: Matchers<Promise<R>, T>
+declare namespace ExpectWebdriverIOStandalone {
+    interface Matchers<R, T> extends Readonly<ExpectMatchers<R>>, ExpectWebdriverIONamespace.Matchers<R, T> {
+        not: ExpectWebdriverIONamespace.Matchers<R, T> & ExpectMatchers<R>
+        resolves: ExpectWebdriverIONamespace.Matchers<Promise<R>, T> & ExpectMatchers<Promise<R>>
+        rejects: ExpectWebdriverIONamespace.Matchers<Promise<R>, T> & ExpectMatchers<Promise<R>>
     }
 
     type Expect = {
@@ -13,12 +14,12 @@ declare namespace ExpectWebdriverIO {
     } & AsymmetricMatchers
 
     type AsymmetricMatchers = {
-        any(expectedObject: any): PartialMatcher
-        anything(): PartialMatcher
-        arrayContaining(sample: Array<unknown>): PartialMatcher
-        objectContaining(sample: Record<string, unknown>): PartialMatcher
-        stringContaining(expected: string): PartialMatcher
-        stringMatching(expected: string | RegExp): PartialMatcher
+        any(expectedObject: any): ExpectWebdriverIONamespace.PartialMatcher
+        anything(): ExpectWebdriverIONamespace.PartialMatcher
+        arrayContaining(sample: Array<unknown>): ExpectWebdriverIONamespace.PartialMatcher
+        objectContaining(sample: Record<string, unknown>): ExpectWebdriverIONamespace.PartialMatcher
+        stringContaining(expected: string): ExpectWebdriverIONamespace.PartialMatcher
+        stringMatching(expected: string | RegExp): ExpectWebdriverIONamespace.PartialMatcher
         not: AsymmetricMatchers
     }
 }


### PR DESCRIPTION
I have added support for multiremote and custom driver when we use the elements or mock matchers. Also I have added some fixes for the current main branch, however the `npm run test:types` is causing issues yet due to external library types. I will fix them in another PR.

It should fix or use as workaround for [issue 106](https://github.com/webdriverio/expect-webdriverio/issues/106).

**UPDATED:** Types fixed as well.