### PR TITLE
RegExp support for text comparison assertions

### DIFF
--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { waitUntil, enhanceError, compareText } from '../../utils'
 
-export function toHaveTitleFn(browser: WebdriverIO.Browser, title: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveTitleFn(browser: WebdriverIO.Browser, title: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'title', verb = 'have' } = this
 

--- a/src/matchers/browser/toHaveUrl.ts
+++ b/src/matchers/browser/toHaveUrl.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { waitUntil, enhanceError, compareText } from '../../utils'
 
-export function toHaveUrlFn(browser: WebdriverIO.Browser, url: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveUrlFn(browser: WebdriverIO.Browser, url: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'url', verb = 'have' } = this
 

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -10,7 +10,7 @@ async function conditionAttr(el: WebdriverIO.Element, attribute: string): Promis
     }
 }
 
-async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions): Promise<any> {
+async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string, value: string | RegExp, options: ExpectWebdriverIO.StringOptions): Promise<any> {
     const attr = await el.getAttribute(attribute)
     if (typeof attr !== 'string') {
         return { result: false, value: attr }

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -1,7 +1,7 @@
 import { waitUntil, enhanceError, compareText, compareTextWithArray, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-async function condition(el: WebdriverIO.Element, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions): Promise<any> {
+async function condition(el: WebdriverIO.Element, text: string | RegExp | Array<string | RegExp>, options: ExpectWebdriverIO.StringOptions): Promise<any> {
     const actualText = await el.getText()
     if (Array.isArray(text)) {
         return compareTextWithArray(actualText, text, options)
@@ -9,7 +9,7 @@ async function condition(el: WebdriverIO.Element, text: string | Array<string>, 
     return compareText(actualText, text, options)
 }
 
-export function toHaveTextFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveTextFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, text: string | RegExp | Array<string | RegExp>, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'text', verb = 'have' } = this
 

--- a/src/matchers/element/toHaveTextContaining.ts
+++ b/src/matchers/element/toHaveTextContaining.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveTextFn } from './toHaveText'
 
-function toHaveTextContainingFn(el: WebdriverIO.Element, text: string | Array<string>, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveTextContainingFn(el: WebdriverIO.Element, text: string | RegExp | Array<string | RegExp>, options: ExpectWebdriverIO.StringOptions = {}): any {
     return toHaveTextFn.call(this, el, text, {
         ...options,
         containing: true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,7 +104,7 @@ const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions
     return false
 }
 
-export const compareText = (actual: string, expected: string, { ignoreCase = false, trim = true, containing = false }) => {
+export const compareText = (actual: string, expected: string | RegExp, { ignoreCase = false, trim = true, containing = false }) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -117,7 +117,16 @@ export const compareText = (actual: string, expected: string, { ignoreCase = fal
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
-        expected = expected.toLowerCase()
+        if (! (expected instanceof RegExp)) {
+            expected = expected.toLowerCase()
+        }
+    }
+
+    if (expected instanceof RegExp) {
+        return {
+            value: actual,
+            result: !!actual.match(expected)
+        }
     }
     if (containing) {
         return {
@@ -125,13 +134,14 @@ export const compareText = (actual: string, expected: string, { ignoreCase = fal
             result: actual.includes(expected)
         }
     }
+
     return {
         value: actual,
         result: actual === expected
     }
 }
 
-export const compareTextWithArray = (actual: string, expectedArray: Array<string>, { ignoreCase = false, trim = false, containing = false }) => {
+export const compareTextWithArray = (actual: string, expectedArray: Array<string | RegExp>, { ignoreCase = false, trim = false, containing = false }) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -144,18 +154,15 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
-        expectedArray = expectedArray.map(item => item.toLowerCase())
+        expectedArray = expectedArray.map(item => (item instanceof RegExp) ? item : item.toLowerCase())
     }
-    if (containing) {
-        const textInArray = expectedArray.some((t) => actual.includes(t))
-        return {
-            value: actual,
-            result: textInArray
-        }
-    }
+
+    const textInArray = expectedArray.some((expected) => {
+        return expected instanceof RegExp ? !!actual.match(expected) : containing ? actual.includes(expected) : actual === expected
+    })
     return {
         value: actual,
-        result: expectedArray.includes(actual)
+        result: textInArray
     }
 }
 

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -1,4 +1,4 @@
-import { getExpectMessage, getReceived } from '../../__fixtures__/utils';
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
 import { toHaveText } from '../../../src/matchers/element/toHaveText'
 
 describe('toHaveText', () => {
@@ -146,4 +146,51 @@ describe('toHaveText', () => {
         expect(result.pass).toBe(false)
         expect(el._attempts).toBe(1)
     })
+
+    describe('with RegExp', () => {
+        let el: WebdriverIO.Element
+    
+        beforeEach(async () => { 
+            el = await $('sel')
+            el._text = jest.fn().mockImplementation(() => {
+                return "This is example text"
+            })
+        })
+
+        test('success if match', async () => {
+            const result = await toHaveText(el, /ExAmplE/i);
+            expect(result.pass).toBe(true)
+        })
+
+        test('success if array matches with RegExp', async () => {
+            const result = await toHaveText(el, ['WDIO', /ExAmPlE/i]);
+            expect(result.pass).toBe(true)
+        })
+
+        test('succes if array matches with text', async () => {
+            const result = await toHaveText(el, ['This is example text', /Webdriver/i]);
+            expect(result.pass).toBe(true)
+        })
+
+        test('succes if array matches with text and ignoreCase', async () => {
+            const result = await toHaveText(el, ['ThIs Is ExAmPlE tExT', /Webdriver/i], { ignoreCase: true });
+            expect(result.pass).toBe(true)
+        })
+
+        test('failure if no match', async () => {
+            const result = await toHaveText(el, /Webdriver/i);
+            expect(result.pass).toBe(false)
+            expect(getExpectMessage(result.message())).toContain('to have text')
+            expect(getExpected(result.message())).toContain('/Webdriver/i')
+            expect(getReceived(result.message())).toContain('This is example text')
+        })
+
+        test('RegExp failure if array does not match with text', async () => {
+            const result = await toHaveText(el, ['WDIO', /Webdriver/i]);
+            expect(result.pass).toBe(false)
+            expect(getExpectMessage(result.message())).toContain('to have text')
+            expect(getExpected(result.message())).toContain('/Webdriver/i')
+            expect(getExpected(result.message())).toContain('WDIO')
+        })
+    })  
 })

--- a/test/matchers/element/toHaveTextContaining.test.ts
+++ b/test/matchers/element/toHaveTextContaining.test.ts
@@ -21,6 +21,11 @@ describe('toHaveTextContaining', () => {
             const result = await toHaveTextContaining(el, "example text");
             expect(result.pass).toBe(true)
         })
+
+        test('RegExp passes', async () => {
+            const result = await toHaveTextContaining(el, /ExAmplE/i);
+            expect(result.pass).toBe(true)
+        })
     })
 
     describe('failure', () => {
@@ -47,4 +52,27 @@ describe('toHaveTextContaining', () => {
         })
     });
     
+    describe('failure with RegExp', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveTextContaining(el, /Webdriver/i);
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have text containing')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('/Webdriver/i')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('This is example text')
+            })
+        })
+    });
 });


### PR DESCRIPTION
Resolves https://github.com/webdriverio/expect-webdriverio/issues/585.
Added support for RegExp to those assertions that do text comparison:

1. `toHaveText`
2. `toHaveTextContaining`
3. `toHaveTitle`
4. `toHaveAttribute`
5. `toHaveUrl`

In case of the first two assertions, when `expected` is an array it can be a mix of strings and RegExps, i.e. `Array<string | RegExp>`, see the unit tests.