### PR TITLE
RegExp support - remaining work

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ Checks if browser is on a specific page.
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
+await browser.url('https://webdriver.io/')
 await expect(browser).toHaveUrl('https://webdriver.io')
 ```
 
@@ -75,7 +75,7 @@ Checks if browser is on a page URL that contains a value.
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
+await browser.url('https://webdriver.io/')
 await expect(browser).toHaveUrlContaining('webdriver')
 ```
 
@@ -86,7 +86,7 @@ Checks if website has a specific title.
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
+await browser.url('https://webdriver.io/')
 await expect(browser).toHaveTitle('WebdriverIO · Next-gen browser and mobile automation test framework for Node.js')
 ```
 
@@ -97,7 +97,7 @@ Checks if website has a specific title that contains a value.
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
+await browser.url('https://webdriver.io/')
 await expect(browser).toHaveTitleContaining('WebdriverIO')
 ```
 
@@ -110,7 +110,7 @@ Calls [`isDisplayed`](https://webdriver.io/docs/api/element/isDisplayed/) on giv
 ##### Usage
 
 ```js
-const elem = $('#someElem')
+const elem = await $('#someElem')
 await expect(elem).toBeDisplayed()
 ```
 
@@ -121,7 +121,7 @@ Calls [`isExisting`](https://webdriver.io/docs/api/element/isExisting) on given 
 ##### Usage
 
 ```js
-const elem = $('#someElem')
+const elem = await $('#someElem')
 await expect(elem).toExist()
 ```
 
@@ -132,7 +132,7 @@ Same as `toExist`.
 ##### Usage
 
 ```js
-const elem = $('#someElem')
+const elem = await $('#someElem')
 await expect(elem).toBePresent()
 ```
 
@@ -143,7 +143,7 @@ Same as `toExist`.
 ##### Usage
 
 ```js
-const elem = $('#someElem')
+const elem = await $('#someElem')
 await expect(elem).toBeExisting()
 ```
 
@@ -154,7 +154,7 @@ Checks if element has focus. This assertion only works in a web context.
 ##### Usage
 
 ```js
-const elem = $('#someElem')
+const elem = await $('#someElem')
 await expect(elem).toBeFocused()
 ```
 
@@ -165,7 +165,7 @@ Checks if an element has a certain attribute with a specific value.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveAttribute('class', 'form-control')
 ```
 
@@ -176,7 +176,7 @@ Same as `toHaveAttribute`.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveAttr('class', 'form-control')
 ```
 
@@ -187,7 +187,7 @@ Checks if an element has a certain attribute that contains a value.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveAttributeContaining('class', 'form')
 ```
 
@@ -198,7 +198,7 @@ Same as `toHaveAttributeContaining`.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveAttrContaining('class', 'form')
 ```
 
@@ -209,7 +209,7 @@ Checks if an element has a certain class name.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveElementClass('form-control', { message: 'Not a form control!', })
 ```
 
@@ -220,7 +220,7 @@ Checks if an element has a certain class name that contains provided value.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveElementClassContaining('form')
 ```
 
@@ -231,7 +231,7 @@ Checks if an element has a certain property.
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toHaveElementProperty('height', 23)
 await expect(elem).not.toHaveElementProperty('height', 0)
 ```
@@ -243,7 +243,7 @@ Checks if an input element has a certain value.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveValue('user', { ignoreCase: true })
 ```
 
@@ -254,7 +254,7 @@ Checks if an input element contains a certain value.
 ##### Usage
 
 ```js
-const myInput = $('input')
+const myInput = await $('input')
 await expect(myInput).toHaveValueContaining('us')
 ```
 
@@ -265,7 +265,7 @@ Checks if an element can be clicked by calling [`isClickable`](https://webdriver
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeClickable()
 ```
 
@@ -276,7 +276,7 @@ Checks if an element is disabled by calling [`isEnabled`](https://webdriver.io/d
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeDisabled()
 // same as
 await expect(elem).not.toBeEnabled()
@@ -289,7 +289,7 @@ Checks if an element is enabled by calling [`isEnabled`](https://webdriver.io/do
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeEnabled()
 // same as
 await expect(elem).not.toBeDisabled()
@@ -302,7 +302,7 @@ Checks if an element is enabled by calling [`isSelected`](https://webdriver.io/d
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeSelected()
 ```
 
@@ -313,7 +313,7 @@ Same as `toBeSelected`.
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeChecked()
 ```
 
@@ -324,7 +324,7 @@ Checks if link element has a specific link target.
 ##### Usage
 
 ```js
-const link = $('a')
+const link = await $('a')
 await expect(link).toHaveHref('https://webdriver.io')
 ```
 
@@ -335,7 +335,7 @@ Same as `toHaveHref`.
 ##### Usage
 
 ```js
-const link = $('a')
+const link = await $('a')
 await expect(link).toHaveLink('https://webdriver.io')
 ```
 
@@ -346,7 +346,7 @@ Checks if link element contains a specific link target.
 ##### Usage
 
 ```js
-const link = $('a')
+const link = await $('a')
 await expect(link).toHaveHrefContaining('webdriver.io')
 ```
 
@@ -357,7 +357,7 @@ Same as `toHaveHrefContaining`.
 ##### Usage
 
 ```js
-const link = $('a')
+const link = await $('a')
 await expect(link).toHaveLinkContaining('webdriver.io')
 ```
 
@@ -368,7 +368,7 @@ Checks if element has a specific `id` attribute.
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toHaveId('elem')
 ```
 
@@ -379,10 +379,10 @@ Checks if element has a specific text. Can also be called with an array as param
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
-const elem = $('.tagline')
+await browser.url('https://webdriver.io/')
+const elem = await $('.container')
 await expect(elem).toHaveText('Next-gen browser and mobile automation test framework for Node.js')
-await expect(elem).toHaveText(['Next-gen browser and mobile automation test framework for Node.js', 'Adding helper functions'])
+await expect(elem).toHaveText(['Next-gen browser and mobile automation test framework for Node.js', 'Get Started'])
 ```
 
 ### toHaveTextContaining
@@ -392,10 +392,10 @@ Checks if element contains a specific text. Can also be called with an array as 
 ##### Usage
 
 ```js
-browser.url('https://webdriver.io/')
-const elem = $('.tagline')
+await browser.url('https://webdriver.io/')
+const elem = await $('.container')
 await expect(elem).toHaveTextContaining('browser and mobile automation test framework')
-await expect(elem).toHaveTextContaining(['browser and mobile automation test framework', 'helper functions'])
+await expect(elem).toHaveTextContaining(['browser and mobile automation test framework', 'Started'])
 ```
 
 ### toBeDisplayedInViewport
@@ -405,7 +405,7 @@ Checks if an element is within the viewport by calling [`isDisplayedInViewport`]
 ##### Usage
 
 ```js
-const elem = $('#elem')
+const elem = await $('#elem')
 await expect(elem).toBeDisplayedInViewport()
 ```
 
@@ -416,7 +416,7 @@ Checks amount of the fetched element's children by calling `element.$('./*')` co
 ##### Usage
 
 ```js
-const list = $('ul')
+const list = await $('ul')
 await expect(list).toHaveChildren() // the list has at least one item
 // same as
 await expect(list).toHaveChildren({ gte: 1 })
@@ -433,7 +433,7 @@ Checks amount of fetched elements using [`$$`](https://webdriver.io/docs/api/ele
 ##### Usage
 
 ```js
-const listItems = $$('ul>li')
+const listItems = await $$('ul>li')
 await expect(listItems).toBeElementsArrayOfSize(5) // 5 items in the list
 
 await expect(listItems).toBeElementsArrayOfSize({ lte: 10 })
@@ -496,6 +496,23 @@ await expect(mock).toBeRequestedWith({
     postData: expect.objectContaining({ released: true, title: expect.stringContaining('foobar') }),
     response: r => Array.isArray(r) && r.data.items.length === 20
 })
+```
+
+## Using regular expressions
+
+You can also directly use regular expressions for all matchers that do text comparison.
+
+##### Usage
+
+```js
+await browser.url('https://webdriver.io/')
+const elem = await $('.container')
+await expect(elem).toHaveText(/node\.js/i)
+await expect(elem).toHaveText([/node\.js/i, 'Get Started'])
+await expect(elem).toHaveTextContaining([/node\.js/i, 'Started'])
+await expect(browser).toHaveTitle(/webdriverio/i)
+await expect(browser).toHaveUrl(/webdriver\.io/)
+await expect(elem).toHaveElementClass(/Container/i)
 ```
 
 ## Default Matchers

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -19,7 +19,7 @@ async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string,
     return compareText(attr, value, options)
 }
 
-export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveAttributeAndValueFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, attribute: string, value: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -1,7 +1,7 @@
 import { waitUntil, enhanceError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
-async function condition(el: WebdriverIO.Element, attribute: string, value: string, options: ExpectWebdriverIO.StringOptions): Promise<any> {
+async function condition(el: WebdriverIO.Element, attribute: string, value: string | RegExp, options: ExpectWebdriverIO.StringOptions): Promise<any> {
     const { ignoreCase = false, trim = false, containing = false } = options
 
     let attr = await el.getAttribute(attribute)
@@ -14,24 +14,23 @@ async function condition(el: WebdriverIO.Element, attribute: string, value: stri
     }
     if (ignoreCase) {
         attr = attr.toLowerCase()
-        value = value.toLowerCase()
-    }
-    if (containing) {
-        return {
-            result: attr.includes(value),
-            value: attr
+        if (! (value instanceof RegExp)) {
+            value = value.toLowerCase()
         }
     }
 
     const classes = attr.split(' ')
 
+    const valueInClasses = classes.some((t) => {
+        return value instanceof RegExp ? !!t.match(value) : containing ? t.includes(value) : t === value
+    })
     return {
-        result: classes.includes(value),
-        value: attr
+        value: attr,
+        result: valueInClasses
     }
 }
 
-function toHaveElementClassFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, className: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveElementClassFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, className: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     const isNot = this.isNot
     const { expectation = 'class', verb = 'have' } = this
 

--- a/src/matchers/element/toHaveElementClassContaining.ts
+++ b/src/matchers/element/toHaveElementClassContaining.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-function toHaveElementClassContainingFn(el: WebdriverIO.Element, className: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveElementClassContainingFn(el: WebdriverIO.Element, className: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     return toHaveAttributeAndValueFn.call(this, el, 'class', className, {
         ...options,
         containing: true

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -25,7 +25,7 @@ async function condition(
         return { result: true, value: prop }
     }
 
-    if (typeof value !== 'string' || (typeof prop !== 'string' && !asString)) {
+    if (!(value instanceof RegExp) && (typeof value !== 'string' || (typeof prop !== 'string' && !asString))) {
         return { result: prop === value, value: prop }
     }
 
@@ -37,7 +37,7 @@ async function condition(
 export function toHaveElementPropertyFn(
     received: WebdriverIO.Element | WebdriverIO.ElementArray,
     property: string,
-    value?: any,
+    value?: string | RegExp,
     options: ExpectWebdriverIO.StringOptions = {}
 ): any {
     const isNot = this.isNot

--- a/src/matchers/element/toHaveId.ts
+++ b/src/matchers/element/toHaveId.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveAttributeAndValueFn } from './toHaveAttribute'
 
-export function toHaveIdFn(el: WebdriverIO.Element, id: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveIdFn(el: WebdriverIO.Element, id: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     return toHaveAttributeAndValueFn.call(this, el, 'id', id, options)
 }
 

--- a/src/matchers/element/toHaveValue.ts
+++ b/src/matchers/element/toHaveValue.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveElementPropertyFn } from './toHaveElementProperty'
 
-export function toHaveValueFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+export function toHaveValueFn(el: WebdriverIO.Element, value: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     return toHaveElementPropertyFn.call(this, el, 'value', value, options)
 }
 

--- a/src/matchers/element/toHaveValueContaining.ts
+++ b/src/matchers/element/toHaveValueContaining.ts
@@ -1,7 +1,7 @@
 import { runExpect } from '../../util/expectAdapter'
 import { toHaveValueFn } from './toHaveValue'
 
-function toHaveValueContainingFn(el: WebdriverIO.Element, value: string, options: ExpectWebdriverIO.StringOptions = {}): any {
+function toHaveValueContainingFn(el: WebdriverIO.Element, value: string | RegExp, options: ExpectWebdriverIO.StringOptions = {}): any {
     return toHaveValueFn.call(this, el, value, {
         ...options,
         containing: true

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -1,5 +1,5 @@
-import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
-import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute';
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils'
+import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute'
 
 describe('toHaveAttribute', () => {
     let el: WebdriverIO.Element
@@ -13,7 +13,7 @@ describe('toHaveAttribute', () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
-            const result = await toHaveAttribute(el, "attribute_name");
+            const result = await toHaveAttribute(el, "attribute_name")
             expect(result.pass).toBe(true)
         })
 
@@ -21,7 +21,7 @@ describe('toHaveAttribute', () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return null
             })
-            const result = await toHaveAttribute(el, "attribute_name");
+            const result = await toHaveAttribute(el, "attribute_name")
             expect(result.pass).toBe(false)
         })
 
@@ -32,7 +32,7 @@ describe('toHaveAttribute', () => {
                 el.getAttribute = jest.fn().mockImplementation(() => {
                     return null
                 })
-                result = await toHaveAttribute(el, "attribute_name");
+                result = await toHaveAttribute(el, "attribute_name")
             })
             test('expect message', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute')
@@ -51,28 +51,35 @@ describe('toHaveAttribute', () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
-            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true })
+            expect(result.pass).toBe(true)
+        })
+        test('success with RegExp and correct value', async () => {
+            el.getAttribute = jest.fn().mockImplementation(() => {
+                return "Correct Value"
+            })
+            const result = await toHaveAttribute(el, "attribute_name", /cOrReCt VaLuE/i)
             expect(result.pass).toBe(true)
         })
         test('failure with wrong value', async () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Wrong Value"
             })
-            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true })
             expect(result.pass).toBe(false)
         })
         test('failure with non-string attribute value as actual', async () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return 123
             })
-            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true });
+            const result = await toHaveAttribute(el, "attribute_name", "Correct Value", { ignoreCase: true })
             expect(result.pass).toBe(false)
         })
         test('failure with non-string attribute value as expected', async () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "Correct Value"
             })
-            const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true });
+            const result = await toHaveAttribute(el, "attribute_name", 123, { ignoreCase: true })
             expect(result.pass).toBe(false)
         })
         describe('message shows correctly', () => {
@@ -82,13 +89,32 @@ describe('toHaveAttribute', () => {
                 el.getAttribute = jest.fn().mockImplementation(() => {
                     return "Wrong"
                 })
-                result = await toHaveAttribute(el, "attribute_name", "Correct");
+                result = await toHaveAttribute(el, "attribute_name", "Correct")
             })
             test('expect message', () => {
                 expect(getExpectMessage(result.message())).toContain('to have attribute')
             })
             test('expected message', () => {
                 expect(getExpected(result.message())).toContain('Correct')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('Wrong')
+            })
+        })
+        describe('failure with RegExp, message shows correctly', () => {
+            let result: any
+
+            beforeEach(async () => {
+                el.getAttribute = jest.fn().mockImplementation(() => {
+                    return "Wrong"
+                })
+                result = await toHaveAttribute(el, "attribute_name", /WDIO/)
+            })
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have attribute')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('/WDIO/')
             })
             test('received message', () => {
                 expect(getReceived(result.message())).toContain('Wrong')

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -1,5 +1,5 @@
-import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils';
-import { toHaveClass, toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass';
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils'
+import { toHaveClass, toHaveElementClass } from '../../../src/matchers/element/toHaveElementClass'
 
 describe('toHaveElementClass', () => {
     let el: WebdriverIO.Element
@@ -15,16 +15,21 @@ describe('toHaveElementClass', () => {
     })    
 
     test('success when class name is present', async () => {
-        const result = await toHaveElementClass(el, "some-class");
+        const result = await toHaveElementClass(el, "some-class")
         expect(result.pass).toBe(true)
-    });
+    })
+
+    test('success with RegExp when class name is present', async () => {
+        const result = await toHaveElementClass(el, /sOmE-cLaSs/i)
+        expect(result.pass).toBe(true)
+    })
 
     describe('options', () => {
         it('should fail when class is not a string', async () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return null
             })
-            const result = await toHaveElementClass(el, "some-class");
+            const result = await toHaveElementClass(el, "some-class")
             expect(result.pass).toBe(false)
         })
 
@@ -32,17 +37,17 @@ describe('toHaveElementClass', () => {
             el.getAttribute = jest.fn().mockImplementation(() => {
                 return "  some-class  "
             })
-            const result = await toHaveElementClass(el, "some-class", {trim: true});
+            const result = await toHaveElementClass(el, "some-class", {trim: true})
             expect(result.pass).toBe(true)
         })
         
         it('should pass when ignore the case', async () => {
-            const result = await toHaveElementClass(el, "sOme-ClAsS", {ignoreCase: true});
+            const result = await toHaveElementClass(el, "sOme-ClAsS", {ignoreCase: true})
             expect(result.pass).toBe(true) 
         })
 
         it('should pass if containing', async () => {
-            const result = await toHaveElementClass(el, "some", {containing: true});
+            const result = await toHaveElementClass(el, "some", {containing: true})
             expect(result.pass).toBe(true) 
         }) 
     })
@@ -51,7 +56,7 @@ describe('toHaveElementClass', () => {
         let result: any
 
         beforeEach(async () => {
-            result = await toHaveElementClass(el, "test");
+            result = await toHaveElementClass(el, "test")
         })
 
         test('failure', () => {
@@ -69,8 +74,32 @@ describe('toHaveElementClass', () => {
                 expect(getReceived(result.message())).toContain('some-class another-class')
             })
         })
-    });
-});
+    })
+
+    describe('failure with RegExp when class name is not present', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveElementClass(el, /WDIO/)
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have class')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('/WDIO/')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('some-class another-class')
+            })
+        })
+    })
+})
 
 global.console.warn = jest.fn()
 
@@ -78,7 +107,7 @@ describe('toHaveClass', () => {
     let el: WebdriverIO.Element
     
     test('warning message in console', async () => {
-        await toHaveClass(el, "test");
+        await toHaveClass(el, "test")
         expect(console.warn).toHaveBeenCalledWith('expect(...).toHaveClass is deprecated and will be removed in next release. Use toHaveElementClass instead.')
     })
 })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -1,3 +1,4 @@
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils'
 import { toHaveElementProperty } from '../../../src/matchers/element/toHaveElementProperty'
 
 describe('toHaveElementProperty', () => {
@@ -34,6 +35,16 @@ describe('toHaveElementProperty', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('with RegExp should return true if values match', async () => {
+        const el = await $('sel')
+        el._value = function (): string {
+            return 'iphone'
+        }
+
+        const result = await toHaveElementProperty(el, 'property', /iPhOnE/i)
+        expect(result.pass).toBe(true)
+    })
+
     test('should return false for null input', async () => {
         const el = await $('sel')
         el._value = function (): any {
@@ -62,5 +73,33 @@ describe('toHaveElementProperty', () => {
 
         const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'Test Value')
         expect(result.pass).toBe(false)
+    })
+
+    describe('failure with RegExp when value does not match', () => {
+        let result: any
+
+        beforeEach(async () => {
+            const el = await $('sel')
+            el._value = function (): string {
+                return 'iphone'
+            }
+            result = await toHaveElementProperty(el, 'property', /WDIO/)
+        })
+
+        test('failure', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have property')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('/WDIO/')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('iphone')
+            })
+        })
     })
 })

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -1,4 +1,4 @@
-import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils'
 import { toHaveText } from '../../../src/matchers/element/toHaveText'
 
 describe('toHaveText', () => {
@@ -158,35 +158,35 @@ describe('toHaveText', () => {
         })
 
         test('success if match', async () => {
-            const result = await toHaveText(el, /ExAmplE/i);
+            const result = await toHaveText(el, /ExAmplE/i)
             expect(result.pass).toBe(true)
         })
 
         test('success if array matches with RegExp', async () => {
-            const result = await toHaveText(el, ['WDIO', /ExAmPlE/i]);
+            const result = await toHaveText(el, ['WDIO', /ExAmPlE/i])
             expect(result.pass).toBe(true)
         })
 
-        test('succes if array matches with text', async () => {
-            const result = await toHaveText(el, ['This is example text', /Webdriver/i]);
+        test('success if array matches with text', async () => {
+            const result = await toHaveText(el, ['This is example text', /Webdriver/i])
             expect(result.pass).toBe(true)
         })
 
-        test('succes if array matches with text and ignoreCase', async () => {
-            const result = await toHaveText(el, ['ThIs Is ExAmPlE tExT', /Webdriver/i], { ignoreCase: true });
+        test('success if array matches with text and ignoreCase', async () => {
+            const result = await toHaveText(el, ['ThIs Is ExAmPlE tExT', /Webdriver/i], { ignoreCase: true })
             expect(result.pass).toBe(true)
         })
 
         test('failure if no match', async () => {
-            const result = await toHaveText(el, /Webdriver/i);
+            const result = await toHaveText(el, /Webdriver/i)
             expect(result.pass).toBe(false)
             expect(getExpectMessage(result.message())).toContain('to have text')
             expect(getExpected(result.message())).toContain('/Webdriver/i')
             expect(getReceived(result.message())).toContain('This is example text')
         })
 
-        test('RegExp failure if array does not match with text', async () => {
-            const result = await toHaveText(el, ['WDIO', /Webdriver/i]);
+        test('failure if array does not match with text', async () => {
+            const result = await toHaveText(el, ['WDIO', /Webdriver/i])
             expect(result.pass).toBe(false)
             expect(getExpectMessage(result.message())).toContain('to have text')
             expect(getExpected(result.message())).toContain('/Webdriver/i')

--- a/test/matchers/element/toHaveValue.test.ts
+++ b/test/matchers/element/toHaveValue.test.ts
@@ -1,4 +1,4 @@
-import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils';
+import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils'
 import { toHaveValue } from '../../../src/matchers/element/toHaveValue'
 
 describe('toHaveValue', () => {
@@ -13,16 +13,21 @@ describe('toHaveValue', () => {
 
     describe('success', () => {
         test('exact passes', async () => {
-            const result = await toHaveValue(el, "This is an example value");
+            const result = await toHaveValue(el, "This is an example value")
             expect(result.pass).toBe(true)
-        });
+        })
+
+        test('RegExp passes', async () => {
+            const result = await toHaveValue(el, /ExAmPlE/i)
+            expect(result.pass).toBe(true)
+        })
     })
 
     describe('failure', () => {
         let result: any
 
         beforeEach(async () => {
-            result = await toHaveValue(el, "webdriver");
+            result = await toHaveValue(el, "webdriver")
         })
 
         test('does not pass', () => {
@@ -40,6 +45,29 @@ describe('toHaveValue', () => {
                 expect(getReceived(result.message())).toContain('This is an example value')
             })
         })
-    });
-    
-});
+    })
+
+    describe('failure with RegExp', () => {
+        let result: any
+
+        beforeEach(async () => {
+            result = await toHaveValue(el, /WDIO/)
+        })
+
+        test('does not pass', () => {
+            expect(result.pass).toBe(false)
+        })
+
+        describe('message shows correctly', () => {
+            test('expect message', () => {
+                expect(getExpectMessage(result.message())).toContain('to have property value')
+            })
+            test('expected message', () => {
+                expect(getExpected(result.message())).toContain('/WDIO/')
+            })
+            test('received message', () => {
+                expect(getReceived(result.message())).toContain('This is an example value')
+            })
+        })
+    })
+})

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -83,11 +83,11 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttribute(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttribute(attribute: string, value?: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttr(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttr(attribute: string, value?: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute`
@@ -95,7 +95,7 @@ declare namespace ExpectWebdriverIO {
          */
         toHaveAttributeContaining(
             attribute: string,
-            contains: string,
+            contains: string | RegExp,
             options?: ExpectWebdriverIO.StringOptions
         ): R
         /**
@@ -104,7 +104,7 @@ declare namespace ExpectWebdriverIO {
          */
         toHaveAttrContaining(
             attribute: string,
-            contains: string,
+            contains: string | RegExp,
             options?: ExpectWebdriverIO.StringOptions
         ): R
 
@@ -112,40 +112,40 @@ declare namespace ExpectWebdriverIO {
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClass` instead.
          */
-        toHaveClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClass(className: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          */
-        toHaveElementClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClass(className: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClassContaining` instead.
          * Element's class includes the className.
          */
-        toHaveClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClassContaining(className: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * Element's class includes the className.
          */
-        toHaveElementClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClassContaining(className: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty`
          */
-        toHaveElementProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementProperty(property: string | RegExp, value?: any, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveValue(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValue(value: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          * Element's value includes the value.
          */
-        toHaveValueContaining(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValueContaining(value: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `isClickable`
@@ -194,37 +194,37 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveHref(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHref(href: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveLink(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLink(href: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveHrefContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHrefContaining(href: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveLinkContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLinkContaining(href: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveId(id: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveId(id: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Element` -> `getText`
          */
-        toHaveText(text: string | string[], options?: ExpectWebdriverIO.StringOptions): R
+        toHaveText(text: string | RegExp | Array<string | RegExp>, options?: ExpectWebdriverIO.StringOptions): R
         /**
          * `WebdriverIO.Element` -> `getText`
          * Element's text includes the text provided
          */
-        toHaveTextContaining(text: string | string[], options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTextContaining(text: string | RegExp | Array<string | RegExp>, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
         * `WebdriverIO.Element` -> `getAttribute("style")`
@@ -235,26 +235,26 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Browser` -> `getUrl`
          */
-        toHaveUrl(url: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveUrl(url: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         // ===== browser only =====
         /**
          * `WebdriverIO.Browser` -> `getUrl`
          * Browser's url includes the provided text
          */
-        toHaveUrlContaining(url: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveUrlContaining(url: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         /**
          * `WebdriverIO.Browser` -> `getTitle`
          */
-        toHaveTitle(title: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTitle(title: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         // ===== browser only =====
         /**
          * `WebdriverIO.Browser` -> `getTitle`
          * Browser's title includes the provided text
          */
-        toHaveTitleContaining(title: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTitleContaining(title: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
 
         // ===== $$ only =====
         /**


### PR DESCRIPTION
Remaining work for RegExp support which was added in https://github.com/webdriverio/expect-webdriverio/pull/735:
a) Added RegExp support to following additional assertions:
1. `toHaveElementClass`
2. `toHaveElementProperty`
3. `toHaveValue`
4. `toHaveId`
5. `toHaveHref`
6. `toHaveLink`

b) Added new unit tests for RegExp.
c) Updated types to reflect support for RegExp for corresponding assertions.