### PR TITLE
Add export to jest-global.d.ts

### DIFF
--- a/types/jest-global.d.ts
+++ b/types/jest-global.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="expect-webdriverio/types/standalone"/>
 
-declare const expect: ExpectWebdriverIO.Expect
+export declare const expect: ExpectWebdriverIO.Expect
 
 declare namespace NodeJS {
     interface Global {


### PR DESCRIPTION
Solves conflict between this package and the @wdio/jasmine-framework. Issue: Cannot redeclare block-scoped variable 'expect'