### PR TITLE
Fix for global.expect.bind is not a function when adding custom matcher

### DIFF
--- a/src/addMatchers.ts
+++ b/src/addMatchers.ts
@@ -22,6 +22,9 @@ export const addMatchers = (): any => {
         global.expect = expectLib
     } else {
         // WebdriverIO standalone mode + Jest
+        if (global.expect.expect !== undefined) {
+            global.expect = global.expect.expect
+        }
         expectLib = global.expect
     }
 

--- a/src/types/some-expect.d.ts
+++ b/src/types/some-expect.d.ts
@@ -21,6 +21,7 @@ declare namespace jest {
 type anyFunction = (...args: any) => any
 
 interface SomeExpectLib {
+    expect: undefined;
     // jasmine
     extend: Function;
 


### PR DESCRIPTION
I'm getting this error with the the following  versions:
expect@28.1.1
expect-webdriverio@3.4.0

```
Debugger attached.
Execution of 1 workers started at 2022-06-27T19:55:09.420Z
[0-0] Warning! Unsupported expect lib is used.
[0-0] Only Jasmine >= 3.3.0 and Jest's expect are supported.
[0-0] expect-webdriverio is assigned to global.expectWdio
[0-0] RUNNING in chrome - <REDACTED>
[0-0] TypeError in "<REDACTED>"before all" hook in "<REDACTED>""
TypeError: global.expect.bind is not a function
[0-0] FAILED in chrome - <REDACTED>
```

Relevant part of wdio.conf `before` function:
```
const matchers = require('wdio/matchers');
before(capabilities, specs) {
    require('expect-webdriverio').setOptions({ wait: 20000 });
    matchers.addCustomMatchers();
}
```

Relevant part of matchers.js:
```
module.exports = {
  addCustomMatchers: () => {
    expect.extend({
      async myMatcher(actual, expected) {
        // my matcher code
      },
    });
  },
}
```

The commit on this PR fixes the error for me, but I'm not sure if it's the correct fix.

This is related to the following PRs:
https://github.com/webdriverio/expect-webdriverio/pull/754
https://github.com/webdriverio/expect-webdriverio/pull/753
https://github.com/webdriverio/expect-webdriverio/pull/762

@christian-bromann Please let me know if you have a better solution for my code example above 🙏 
