### PR TITLE
fix: incorrect handling of an array of elements

### DIFF
--- a/src/matchers/element/toBeClickable.ts
+++ b/src/matchers/element/toBeClickable.ts
@@ -1,11 +1,10 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeClickableFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'clickable'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {

--- a/src/matchers/element/toBeDisabled.ts
+++ b/src/matchers/element/toBeDisabled.ts
@@ -1,11 +1,11 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeDisabledFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'disabled'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    received = await received
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => !await el.isEnabled(), options)

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -1,11 +1,11 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeDisplayedFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'displayed'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    received = await received
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {

--- a/src/matchers/element/toBeDisplayedInViewport.ts
+++ b/src/matchers/element/toBeDisplayedInViewport.ts
@@ -1,11 +1,10 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeDisplayedInViewportFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'displayed in viewport'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {

--- a/src/matchers/element/toBeEnabled.ts
+++ b/src/matchers/element/toBeEnabled.ts
@@ -1,11 +1,10 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeEnabledFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'enabled'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isEnabled(), options)

--- a/src/matchers/element/toBeExisting.ts
+++ b/src/matchers/element/toBeExisting.ts
@@ -1,12 +1,12 @@
-import { getFirstElement, getBrowserObject, executeCommandBe, aliasFn } from '../../utils'
+import { getBrowserObject, executeCommandBe, aliasFn } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toExistFn(received: WdioElementMaybePromise, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'exist'
     this.verb = this.verb || ''
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    received = await received
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, async el => {

--- a/src/matchers/element/toBeFocused.ts
+++ b/src/matchers/element/toBeFocused.ts
@@ -1,11 +1,10 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function toBeFocusedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'focused'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isFocused(), options)

--- a/src/matchers/element/toBeSelected.ts
+++ b/src/matchers/element/toBeSelected.ts
@@ -1,11 +1,10 @@
-import { getFirstElement, getBrowserObject, executeCommandBe } from '../../utils'
+import { getBrowserObject, executeCommandBe } from '../../utils'
 import { runExpect, getContext } from '../../util/expectAdapter'
 
 async function toBeSelectedFn(received: WebdriverIO.Element | WebdriverIO.ElementArray, options: ExpectWebdriverIO.CommandOptions = {}) {
     this.expectation = this.expectation || 'selected'
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         const result = await executeCommandBe.call(this, received, el => el.isSelected(), options)

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, compareText, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, compareText, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function conditionAttr(el: WebdriverIO.Element, attribute: string): Promise<any> {
@@ -23,8 +23,7 @@ export async function toHaveAttributeAndValueFn(received: WebdriverIO.Element | 
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received
@@ -53,8 +52,7 @@ export async function toHaveAttributeFn(received: WebdriverIO.Element | Webdrive
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, compareNumbers, numberError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, compareNumbers, numberError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function condition(el: WebdriverIO.Element, options: ExpectWebdriverIO.NumberOptions): Promise<any> {
@@ -34,8 +34,7 @@ async function toHaveChildrenFn(received: WebdriverIO.Element | WebdriverIO.Elem
         numberOptions = expected
     }
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function condition(el: WebdriverIO.Element, attribute: string, value: string | RegExp, options: ExpectWebdriverIO.StringOptions): Promise<any> {
@@ -35,8 +35,7 @@ async function toHaveElementClassFn(received: WebdriverIO.Element | WebdriverIO.
     const { expectation = 'class', verb = 'have' } = this
 
     const attribute = 'class'
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,5 +1,4 @@
 import {
-    getFirstElement,
     getBrowserObject,
     waitUntil,
     enhanceError,
@@ -45,8 +44,7 @@ export async function toHaveElementPropertyFn(
     const isNot = this.isNot
     const { expectation = 'property', verb = 'have' } = this
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, compareStyle, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, compareStyle, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function condition(el: WebdriverIO.Element, style: { [key: string]: string; }, options: ExpectWebdriverIO.StringOptions): Promise<any> {
@@ -9,8 +9,7 @@ export async function toHaveStyleFn(received: WebdriverIO.Element | WebdriverIO.
     const isNot = this.isNot
     const { expectation = 'style', verb = 'have' } = this
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, compareText, compareTextWithArray, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, compareText, compareTextWithArray, executeCommand, wrapExpectedWithArray, updateElementsArray } from '../../utils'
 import { runExpect } from '../../util/expectAdapter'
 
 async function condition(el: WebdriverIO.Element, text: string | RegExp | Array<string | RegExp>, options: ExpectWebdriverIO.StringOptions): Promise<any> {
@@ -13,8 +13,7 @@ export async function toHaveTextFn(received: WebdriverIO.Element | WebdriverIO.E
     const isNot = this.isNot
     const { expectation = 'text', verb = 'have' } = this
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let el = await received

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -1,4 +1,4 @@
-import { getFirstElement, getBrowserObject, waitUntil, enhanceError, compareNumbers, numberError, updateElementsArray } from '../../utils'
+import { getBrowserObject, waitUntil, enhanceError, compareNumbers, numberError, updateElementsArray } from '../../utils'
 import { refetchElements } from '../../util/refetchElements'
 import { runExpect } from '../../util/expectAdapter'
 
@@ -16,8 +16,7 @@ async function toBeElementsArrayOfSizeFn(received: WebdriverIO.ElementArray, exp
         numberOptions = expected
     }
 
-    const el = await getFirstElement(received)
-    const browser = getBrowserObject(el)
+    const browser = getBrowserObject(received)
 
     return browser.call(async () => {
         let elements = await received

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -225,15 +225,9 @@ function aliasFn(
 /**
  * traverse up the scope chain until browser element was reached
  */
-function getBrowserObject (elem: WebdriverIO.Element | WebdriverIO.Browser): WebdriverIO.Browser {
+function getBrowserObject (elem: WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Browser): WebdriverIO.Browser {
     const elemObject = elem as WebdriverIO.Element
     return (elemObject as WebdriverIO.Element).parent ? getBrowserObject(elemObject.parent) : elem as WebdriverIO.Browser
-}
-
-async function getFirstElement (received: WdioElementMaybePromise): Promise<WebdriverIO.Element> {
-    received = await received
-
-    return Array.isArray(received) ? received[0] : received
 }
 
 export {
@@ -247,5 +241,4 @@ export {
     compareNumbers,
     aliasFn,
     getBrowserObject,
-    getFirstElement,
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { compareNumbers, compareText, compareTextWithArray, getBrowserObject, getFirstElement } from '../src/utils'
+import { compareNumbers, compareText, compareTextWithArray, getBrowserObject } from '../src/utils'
 
 describe('utils', () => {
     describe('compareText', () => {
@@ -101,22 +101,6 @@ describe('utils', () => {
                     }
                 }
             } as any)).toEqual({ foo: 'bar' })
-        })
-    })
-
-    describe('getFirstElement', () => {
-        it('should return passed element', async () => {
-            const el = await $('sel')
-            const firstEl = await getFirstElement(el)
-
-            expect(firstEl).toEqual(el)
-        })
-
-        it('should return first element from elements array', async () => {
-            const els = await $$('sel')
-            const el = await getFirstElement(els)
-
-            expect(el).toEqual(els[0])
         })
     })
 })


### PR DESCRIPTION
Fixes - https://github.com/webdriverio/expect-webdriverio/issues/931

It turns out that the command call `browser.$$('foo-bar')` returns not an array of elements but some object which pretends to be an array. And code like:
```
const elems = await browser.$$('foo-bar');
console.log('is array elems:', Array.isArray(elems)); // returns `true`
console.log('elems[0]:', elems[0]); // but I cant get elems[0], throws error
```

Fortunately `elems` contains a field `parent` with `browser`. So I use it.