### PR TITLE
Support node16 module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,18 @@
     "wdio"
   ],
   "type": "module",
-  "exports": "./lib/index.js",
-  "types": "types/jest-global.d.ts",
+  "module": "./lib/index.js",
+  "exports": {
+    ".": [
+      {
+        "types": "./types/jest-global.d.ts",
+        "import": "./lib/index.js"
+      },
+      "./lib/index.js"
+    ],
+    "./types": "./types/jest-global.d.ts"
+  },
+  "types": "./types/jest-global.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
     "node": ">=16 || >=18 || >=20"

--- a/types/jest-global.d.ts
+++ b/types/jest-global.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./standalone"/>
+/// <reference types="./standalone.js"/>
 
 declare const expect: ExpectWebdriverIO.Expect
 

--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./expect-webdriverio"/>
+/// <reference types="./expect-webdriverio.js"/>
 
 declare namespace ExpectWebdriverIO {
     interface Matchers<R, T> extends Readonly<import('expect').Matchers<R>> {


### PR DESCRIPTION
This module has problems with node16 module resolution mode support in ts. With this PR I'm fixing it the same as I did for other wdio packages here - https://github.com/webdriverio/webdriverio/pull/9474