### PR TITLE
Fix test typings issue with webdriverio

### DIFF
--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,14 +1,14 @@
 /// <reference types="expect-webdriverio/types/expect-webdriverio"/>
 
 declare namespace ExpectWebdriverIO {
-    interface Matchers<R, T> extends Readonly<import('expect').Matchers<R>> {
+    interface Matchers<R extends void|Promise<void>, T> extends Readonly<import('expect').Matchers<R>> {
         not: Matchers<R, T>
-        resolves: Matchers<Promise<R>, T>
-        rejects: Matchers<Promise<R>, T>
+        resolves: Matchers<R, T>
+        rejects: Matchers<R, T>
     }
 
     type Expect = {
-        <T = unknown>(actual: T): Matchers<T, T>
+        <T = unknown>(actual: T): Matchers<void, T>
         extend(map: Record<string, Function>): void
     } & AsymmetricMatchers
 


### PR DESCRIPTION
Fix the `test:typings` encountered in [webdriverio v7 tests](https://github.com/webdriverio/webdriverio/actions/runs/4611625593/jobs/8151537891?pr=10115) due to the upgrade to typescript 5


@christian-bromann Have changed the types similar to what is there in the [expect  of jest](https://github.com/facebook/jest/blob/285b40d5954fd81e07b02db92185fd317ba92578/packages/expect/src/types.ts#L137). Are these valid changes?, this solved the issue with typescript 5 though. I wasn't able to test the functionality, as I am new to this repo and not aware of what type of tests are effected by this. The build and tests passed fine though.

Do you feel testing is necessary for this? In that case, can you guide me on what type of expect assertions need to be tested as part of this PR