### PR TITLE
(expect-webdriverio): add string options to verify text at the start, end and index and to replace the actual value

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,7 @@ This option can be applied in addition to the command options when strings are b
 | ---- | ---- | ------- |
 | <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values |
 | <code><var>trim</var></code> | boolean | apply `trim` to actual value |
-| <code><var>replace</var></code> | Replacer or Record<string, Replacer*> | replace parts of the actual value that match the string/RegExp with the next string |
+| <code><var>replace</var></code> | Replacer or Record<string, Replacer> | replace parts of the actual value that match the string/RegExp with the next string |
 | <code><var>containing</var></code> | boolean | expect actual value to contain expected value, otherwise strict equal. |
 | <code><var>asString</var></code> | boolean | might be helpful to force converting property value to string |
 | <code><var>atStart</var></code> | boolean | expect actual value to start with the expected value |

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,8 +50,12 @@ This option can be applied in addition to the command options when strings are b
 | ---- | ---- | ------- |
 | <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values |
 | <code><var>trim</var></code> | boolean | apply `trim` to actual value |
+| <code><var>replace</var></code> | Array<string | RegExp, string> | replace parts of the actual value that match the string/RegExp with the next string |
 | <code><var>containing</var></code> | boolean | expect actual value to contain expected value, otherwise strict equal. |
 | <code><var>asString</var></code> | boolean | might be helpful to force converting property value to string |
+| <code><var>atStart</var></code> | boolean | expect actual value to start with the expected value |
+| <code><var>atEnd</var></code> | boolean | expect actual value to end with the expected value |
+| <code><var>atIndex</var></code> | number | expect actual value to have the expected value at the given index |
 
 ##### Number Options
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,7 @@ This option can be applied in addition to the command options when strings are b
 | ---- | ---- | ------- |
 | <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values |
 | <code><var>trim</var></code> | boolean | apply `trim` to actual value |
-| <code><var>replace</var></code> | Array<string | RegExp, string> | replace parts of the actual value that match the string/RegExp with the next string |
+| <code><var>replace</var></code> | Array<Array<string | RegExp, (substring: string, ...args: any[]) => string>> | replace parts of the actual value that match the string/RegExp with the next string |
 | <code><var>containing</var></code> | boolean | expect actual value to contain expected value, otherwise strict equal. |
 | <code><var>asString</var></code> | boolean | might be helpful to force converting property value to string |
 | <code><var>atStart</var></code> | boolean | expect actual value to start with the expected value |

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,7 @@ This option can be applied in addition to the command options when strings are b
 | ---- | ---- | ------- |
 | <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values |
 | <code><var>trim</var></code> | boolean | apply `trim` to actual value |
-| <code><var>replace</var></code> | Array<Array<string | RegExp, (substring: string, ...args: any[]) => string>> | replace parts of the actual value that match the string/RegExp with the next string |
+| <code><var>replace</var></code> | Replacer or Record<string, Replacer*> | replace parts of the actual value that match the string/RegExp with the next string |
 | <code><var>containing</var></code> | boolean | expect actual value to contain expected value, otherwise strict equal. |
 | <code><var>asString</var></code> | boolean | might be helpful to force converting property value to string |
 | <code><var>atStart</var></code> | boolean | expect actual value to start with the expected value |

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,19 +125,8 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
     if (trim) {
         actual = actual.trim()
     }
-    if (typeof replace === 'object') {
-        const replacers = Array.isArray(replace)
-            ? [replace]
-            : Object.values(replace)
-
-        if (replacers.some(r => r.length !== 2)) {
-            throw new Error('Replacers need to have a searchValue and a replaceValue');
-        }
-
-        for (const replacer of replacers) {
-            const [searchValue, replaceValue] = replacer
-            actual = actual.replace(searchValue, replaceValue as string)
-        }
+    if (Array.isArray(replace)) {
+        actual = replaceActual(replace, actual)
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
@@ -197,19 +186,8 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
     if (trim) {
         actual = actual.trim()
     }
-    if (typeof replace === 'object') {
-        const replacers = Array.isArray(replace)
-            ? [replace]
-            : Object.values(replace)
-
-        if (replacers.some(r => r.length !== 2)) {
-            throw new Error('Replacers need to have a searchValue and a replaceValue');
-        }
-
-        for (const replacer of replacers) {
-            const [searchValue, replaceValue] = replacer
-            actual = actual.replace(searchValue, replaceValue as string)
-        }
+    if (Array.isArray(replace)) {
+        actual = replaceActual(replace, actual)
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
@@ -292,4 +270,22 @@ export {
     waitUntil,
     compareNumbers,
     aliasFn
+}
+
+function replaceActual(replace: Replacer | Replacer[], actual: string) {
+    const hasMultipleReplacers = (replace as Replacer[]).every(r => Array.isArray(r));
+    const replacers = hasMultipleReplacers
+        ? replace as Replacer[]
+        : [replace as Replacer]
+
+    if (replacers.some(r => Array.isArray(r) && r.length !== 2)) {
+        throw new Error('Replacers need to have a searchValue and a replaceValue');
+    }
+
+    for (const replacer of replacers) {
+        const [searchValue, replaceValue] = replacer
+        actual = actual.replace(searchValue, replaceValue as string)
+    }
+
+    return actual
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,8 +125,15 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
     if (trim) {
         actual = actual.trim()
     }
-    if (Array.isArray(replace) && replace.length === 2) {
-        actual = actual.replace(replace[0], replace[1])
+    if (Array.isArray(replace) && replace.length) {
+        if (replace.some(r => r.length !== 2)) {
+            throw new Error('The replace option needs to be an array containing one or more replacers [[searchValue, replaceValue]]');
+        }
+
+        for (const replacer of replace) {
+            const [searchValue, replaceValue] = replacer
+            actual = actual.replace(searchValue, replaceValue as string)
+        }
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
@@ -186,8 +193,15 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
     if (trim) {
         actual = actual.trim()
     }
-    if (Array.isArray(replace) && replace.length === 2) {
-        actual = actual.replace(replace[0], replace[1])
+    if (Array.isArray(replace) && replace.length) {
+        if (replace.some(r => r.length !== 2)) {
+            throw new Error('The replace option needs to be an array containing one or more replacers [[searchValue, replaceValue]]');
+        }
+
+        for (const replacer of replace) {
+            const [searchValue, replaceValue] = replacer
+            actual = actual.replace(searchValue, replaceValue as string)
+        }
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions
     return false
 }
 
-export const compareText = (actual: string, expected: string | RegExp, { ignoreCase = false, trim = true, containing = false, atStart = false, atEnd = false, atIndex = undefined }: ExpectWebdriverIO.StringOptions) => {
+export const compareText = (actual: string, expected: string | RegExp, { ignoreCase = false, trim = true, containing = false, atStart = false, atEnd = false, atIndex, replace }: ExpectWebdriverIO.StringOptions) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -124,6 +124,9 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
 
     if (trim) {
         actual = actual.trim()
+    }
+    if (Array.isArray(replace) && replace.length === 2) {
+        actual = actual.replace(replace[0], replace[1])
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
@@ -172,7 +175,7 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
     }
 }
 
-export const compareTextWithArray = (actual: string, expectedArray: Array<string | RegExp>, { ignoreCase = false, trim = false, containing = false, atStart = false, atEnd = false, atIndex = undefined }: ExpectWebdriverIO.StringOptions) => {
+export const compareTextWithArray = (actual: string, expectedArray: Array<string | RegExp>, { ignoreCase = false, trim = false, containing = false, atStart = false, atEnd = false, atIndex, replace }: ExpectWebdriverIO.StringOptions) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -182,6 +185,9 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
 
     if (trim) {
         actual = actual.trim()
+    }
+    if (Array.isArray(replace) && replace.length === 2) {
+        actual = actual.replace(replace[0], replace[1])
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,12 +125,16 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
     if (trim) {
         actual = actual.trim()
     }
-    if (Array.isArray(replace) && replace.length) {
-        if (replace.some(r => r.length !== 2)) {
-            throw new Error('The replace option needs to be an array containing one or more replacers [[searchValue, replaceValue]]');
+    if (typeof replace === 'object') {
+        const replacers = Array.isArray(replace)
+            ? [replace]
+            : Object.values(replace)
+
+        if (replacers.some(r => r.length !== 2)) {
+            throw new Error('Replacers need to have a searchValue and a replaceValue');
         }
 
-        for (const replacer of replace) {
+        for (const replacer of replacers) {
             const [searchValue, replaceValue] = replacer
             actual = actual.replace(searchValue, replaceValue as string)
         }
@@ -193,12 +197,16 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
     if (trim) {
         actual = actual.trim()
     }
-    if (Array.isArray(replace) && replace.length) {
-        if (replace.some(r => r.length !== 2)) {
-            throw new Error('The replace option needs to be an array containing one or more replacers [[searchValue, replaceValue]]');
+    if (typeof replace === 'object') {
+        const replacers = Array.isArray(replace)
+            ? [replace]
+            : Object.values(replace)
+
+        if (replacers.some(r => r.length !== 2)) {
+            throw new Error('Replacers need to have a searchValue and a replaceValue');
         }
 
-        for (const replacer of replace) {
+        for (const replacer of replacers) {
             const [searchValue, replaceValue] = replacer
             actual = actual.replace(searchValue, replaceValue as string)
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions
     return false
 }
 
-export const compareText = (actual: string, expected: string | RegExp, { ignoreCase = false, trim = true, containing = false }) => {
+export const compareText = (actual: string, expected: string | RegExp, { ignoreCase = false, trim = true, containing = false, atStart = false, atEnd = false, atIndex = undefined }: ExpectWebdriverIO.StringOptions) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -145,13 +145,34 @@ export const compareText = (actual: string, expected: string | RegExp, { ignoreC
         }
     }
 
+    if (atStart) {
+        return {
+            value: actual,
+            result: actual.startsWith(expected)
+        }
+    }
+
+    if (atEnd) {
+        return {
+            value: actual,
+            result: actual.endsWith(expected)
+        }
+    }
+
+    if (atIndex) {
+        return {
+            value: actual,
+            result: actual.substring(atIndex, actual.length).startsWith(expected)
+        }
+    }
+
     return {
         value: actual,
         result: actual === expected
     }
 }
 
-export const compareTextWithArray = (actual: string, expectedArray: Array<string | RegExp>, { ignoreCase = false, trim = false, containing = false }) => {
+export const compareTextWithArray = (actual: string, expectedArray: Array<string | RegExp>, { ignoreCase = false, trim = false, containing = false, atStart = false, atEnd = false, atIndex = undefined }: ExpectWebdriverIO.StringOptions) => {
     if (typeof actual !== 'string') {
         return {
             value: actual,
@@ -168,7 +189,22 @@ export const compareTextWithArray = (actual: string, expectedArray: Array<string
     }
 
     const textInArray = expectedArray.some((expected) => {
-        return expected instanceof RegExp ? !!actual.match(expected) : containing ? actual.includes(expected) : actual === expected
+        if (expected instanceof RegExp) {
+            return !!actual.match(expected)
+        }
+        if (containing) {
+            return actual.includes(expected)
+        }
+        if (atStart) {
+            return actual.startsWith(expected)
+        }
+        if (atEnd) {
+            return actual.endsWith(expected)
+        }
+        if (atIndex) {
+            return actual.substring(atIndex, actual.length).startsWith(expected)
+        }
+        return actual === expected
     })
     return {
         value: actual,

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -84,7 +84,7 @@ describe('toHaveText', () => {
         expect(result.pass).toBe(true)
     })
 
-    test('should return false if texts dont match', async () => {
+    test('should return false if texts don\'t match', async () => {
         const el: any = await $('sel')
         el._text = function (): string {
             return 'WebdriverIO'
@@ -101,6 +101,26 @@ describe('toHaveText', () => {
         }
 
         const result = await toHaveText.bind({ isNot: true })(el, 'WebdriverIO', { wait: 1 })
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return true if actual text + replace (string) matches the expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: ['Web', 'Browser'] })
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return true if actual text + replace (regex) matches the expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [/Web/, 'Browser'] })
         expect(result.pass).toBe(true)
     })
 
@@ -165,6 +185,32 @@ describe('toHaveText', () => {
         }
 
         const result = await toHaveText.call({}, el, ['WDIO', 'WebdriverIO', 'toto'], { trim: true })
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
+    test('success if array matches with text and replace (string)', async () => {
+        const el: any = await $('sel')
+        el._attempts = 0
+        el._text = function (): string {
+            this._attempts++
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: ['Web', 'Browser'] })
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
+    test('success if array matches with text and replace (regex)', async () => {
+        const el: any = await $('sel')
+        el._attempts = 0
+        el._text = function (): string {
+            this._attempts++
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [/Web/g, 'Browser'] })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -120,7 +120,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: { replaceWebWithBrowser: ['Web', 'Browser'] } })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [['Web', 'Browser']] })
         expect(result.pass).toBe(true)
     })
 
@@ -130,7 +130,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: { replaceWebWithBrowser: [/Web/, 'Browser'] } })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [[/Web/, 'Browser']] })
         expect(result.pass).toBe(true)
     })
 
@@ -207,7 +207,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: { replaceWebWithBrowser: ['Web', 'Browser'] } })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [['Web', 'Browser']] })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -220,7 +220,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: { replaceWebWithBrowser: [/Web/g, 'Browser'] } })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [[/Web/g, 'Browser']] })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -234,10 +234,10 @@ describe('toHaveText', () => {
         }
 
         const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], {
-            replace: {
-                replaceWebWithBrowser: [/Web/g, 'Browser'],
-                replaceUppercaseWithLowercase: [/[A-Z]g/, (match) => match.toLowerCase()],
-            },
+            replace: [
+                [/Web/g, 'Browser'],
+                [/[A-Z]g/, (match) => match.toLowerCase()],
+            ],
         })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -110,7 +110,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: ['Web', 'Browser'] })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [['Web', 'Browser']] })
         expect(result.pass).toBe(true)
     })
 
@@ -120,7 +120,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [/Web/, 'Browser'] })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [[/Web/, 'Browser']] })
         expect(result.pass).toBe(true)
     })
 
@@ -197,7 +197,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: ['Web', 'Browser'] })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [['Web', 'Browser']] })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -210,7 +210,25 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [/Web/g, 'Browser'] })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [[/Web/g, 'Browser']] })
+        expect(result.pass).toBe(true)
+        expect(el._attempts).toBe(1)
+    })
+
+    test('success if array matches with text and multiple replacers and one of the replacers is a function', async () => {
+        const el: any = await $('sel')
+        el._attempts = 0
+        el._text = function (): string {
+            this._attempts++
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], {
+            replace: [
+                [/Web/g, 'Browser'],
+                [/[A-Z]g/, (match) => match.toLowerCase()],
+            ],
+        })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -10,7 +10,7 @@ describe('toHaveText', () => {
     test('wait for success', async () => {
         const el: any = await $('sel')
         el._attempts = 2
-        el._text= function (): string {
+        el._text = function (): string {
             if (this._attempts > 0) {
                 this._attempts--
                 return ''
@@ -49,7 +49,7 @@ describe('toHaveText', () => {
     test('no wait - failure', async () => {
         const el: any = await $('sel')
         el._attempts = 0
-        el._text = function ():string {
+        el._text = function (): string {
             this._attempts++
             return 'webdriverio'
         }
@@ -101,6 +101,36 @@ describe('toHaveText', () => {
         }
 
         const result = await toHaveText.bind({ isNot: true })(el, 'WebdriverIO', { wait: 1 })
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return true if actual text starts with expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'Web', { atStart: true })
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return true if actual text ends with expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'IO', { atEnd: true })
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return true if actual text contains the expected text at the given index', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'iverIO', { atIndex: 5 })
         expect(result.pass).toBe(true)
     })
 
@@ -158,7 +188,7 @@ describe('toHaveText', () => {
         beforeEach(async () => {
             el = await $('sel')
             el._text = vi.fn().mockImplementation(() => {
-                return "This is example text"
+                return 'This is example text'
             })
         })
 
@@ -178,7 +208,9 @@ describe('toHaveText', () => {
         })
 
         test('success if array matches with text and ignoreCase', async () => {
-            const result = await toHaveText.call({}, el, ['ThIs Is ExAmPlE tExT', /Webdriver/i], { ignoreCase: true })
+            const result = await toHaveText.call({}, el, ['ThIs Is ExAmPlE tExT', /Webdriver/i], {
+                ignoreCase: true,
+            })
             expect(result.pass).toBe(true)
         })
 

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -104,13 +104,23 @@ describe('toHaveText', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('should return true if actual text + single replacer matches the expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: ['Web', 'Browser'] })
+        expect(result.pass).toBe(true)
+    })
+
     test('should return true if actual text + replace (string) matches the expected text', async () => {
         const el: any = await $('sel')
         el._text = function (): string {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [['Web', 'Browser']] })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: { replaceWebWithBrowser: ['Web', 'Browser'] } })
         expect(result.pass).toBe(true)
     })
 
@@ -120,7 +130,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: [[/Web/, 'Browser']] })
+        const result = await toHaveText.bind({})(el, 'BrowserdriverIO', { replace: { replaceWebWithBrowser: [/Web/, 'Browser'] } })
         expect(result.pass).toBe(true)
     })
 
@@ -197,7 +207,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [['Web', 'Browser']] })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: { replaceWebWithBrowser: ['Web', 'Browser'] } })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -210,7 +220,7 @@ describe('toHaveText', () => {
             return 'WebdriverIO'
         }
 
-        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: [[/Web/g, 'Browser']] })
+        const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], { replace: { replaceWebWithBrowser: [/Web/g, 'Browser'] } })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)
     })
@@ -224,10 +234,10 @@ describe('toHaveText', () => {
         }
 
         const result = await toHaveText.call({}, el, ['WDIO', 'BrowserdriverIO', 'toto'], {
-            replace: [
-                [/Web/g, 'Browser'],
-                [/[A-Z]g/, (match) => match.toLowerCase()],
-            ],
+            replace: {
+                replaceWebWithBrowser: [/Web/g, 'Browser'],
+                replaceUppercaseWithLowercase: [/[A-Z]g/, (match) => match.toLowerCase()],
+            },
         })
         expect(result.pass).toBe(true)
         expect(el._attempts).toBe(1)

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -44,6 +44,24 @@ declare namespace ExpectWebdriverIO {
         containing?: boolean
 
         /**
+         * expect actual value to start with the expected value
+         * Otherwise strict equal
+         */
+        atStart?: boolean,
+
+        /**
+         * expect actual value to end with the expected value
+         * Otherwise strict equal
+         */
+        atEnd?: boolean,
+
+        /**
+         * expect actual value to have the expected value at the given index (index starts at 0 not 1)
+         * Otherwise strict equal
+         */
+        atIndex?: number,
+
+        /**
          * might be helpful to force converting property value to string
          */
         asString?: boolean

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -73,7 +73,7 @@ declare namespace ExpectWebdriverIO {
          * replace the actual value (example: strip newlines from the value) and expect it to match the expected value
          * Otherwise strict equal
          */
-        replace?: [string | RegExp, string]
+        replace?: [string | RegExp, string | ((substring: string, ...args: any[]) => string)][]
 
         /**
          * might be helpful to force converting property value to string

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1,3 +1,7 @@
+type searchValue = string | RegExp
+type replaceValue = string | ((substring: string, ...args: any[]) => string)
+type Replacer = [searchValue, replaceValue]
+
 declare namespace ExpectWebdriverIO {
     function expect<T = unknown, R extends void | Promise<void> = void | Promise<void>>(
         actual: T
@@ -73,7 +77,7 @@ declare namespace ExpectWebdriverIO {
          * replace the actual value (example: strip newlines from the value) and expect it to match the expected value
          * Otherwise strict equal
          */
-        replace?: [string | RegExp, string | ((substring: string, ...args: any[]) => string)][]
+        replace?: Replacer | Record<string, Replacer>
 
         /**
          * might be helpful to force converting property value to string

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -77,7 +77,7 @@ declare namespace ExpectWebdriverIO {
          * replace the actual value (example: strip newlines from the value) and expect it to match the expected value
          * Otherwise strict equal
          */
-        replace?: Replacer | Record<string, Replacer>
+        replace?: Replacer | Replacer[]
 
         /**
          * might be helpful to force converting property value to string

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1,11 +1,19 @@
 declare namespace ExpectWebdriverIO {
-    function expect<T = unknown, R extends void | Promise<void> = void | Promise<void>>(actual: T): Matchers<R, T>
+    function expect<T = unknown, R extends void | Promise<void> = void | Promise<void>>(
+        actual: T
+    ): Matchers<R, T>
     function setOptions(options: DefaultOptions): void
     function getConfig(): any
-    const matchers: Record<string, ((actual: any, ...expected: any[]) => Promise<{
-        pass: boolean;
-        message(): string;
-    }>)>
+    const matchers: Record<
+        string,
+        (
+            actual: any,
+            ...expected: any[]
+        ) => Promise<{
+            pass: boolean
+            message(): string
+        }>
+    >
 
     interface DefaultOptions {
         /**
@@ -47,19 +55,25 @@ declare namespace ExpectWebdriverIO {
          * expect actual value to start with the expected value
          * Otherwise strict equal
          */
-        atStart?: boolean,
+        atStart?: boolean
 
         /**
          * expect actual value to end with the expected value
          * Otherwise strict equal
          */
-        atEnd?: boolean,
+        atEnd?: boolean
 
         /**
          * expect actual value to have the expected value at the given index (index starts at 0 not 1)
          * Otherwise strict equal
          */
-        atIndex?: number,
+        atIndex?: number
+
+        /**
+         * replace the actual value (example: strip newlines from the value) and expect it to match the expected value
+         * Otherwise strict equal
+         */
+        replace?: [string | RegExp, string]
 
         /**
          * might be helpful to force converting property value to string
@@ -107,7 +121,11 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttribute(attribute: string, value?: string | RegExp, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttribute(
+            attribute: string,
+            value?: string | RegExp,
+            options?: ExpectWebdriverIO.StringOptions
+        ): R
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
@@ -159,7 +177,11 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `getProperty`
          */
-        toHaveElementProperty(property: string | RegExp, value?: any, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementProperty(
+            property: string | RegExp,
+            value?: any,
+            options?: ExpectWebdriverIO.StringOptions
+        ): R
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
@@ -243,17 +265,23 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `getText`
          */
-        toHaveText(text: string | RegExp | Array<string | RegExp>, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveText(
+            text: string | RegExp | Array<string | RegExp>,
+            options?: ExpectWebdriverIO.StringOptions
+        ): R
         /**
          * `WebdriverIO.Element` -> `getText`
          * Element's text includes the text provided
          */
-        toHaveTextContaining(text: string | RegExp | Array<string | RegExp>, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTextContaining(
+            text: string | RegExp | Array<string | RegExp>,
+            options?: ExpectWebdriverIO.StringOptions
+        ): R
 
         /**
-        * `WebdriverIO.Element` -> `getAttribute("style")`
-        */
-        toHaveStyle(style: { [key: string]: string; }, options?: ExpectWebdriverIO.StringOptions): R
+         * `WebdriverIO.Element` -> `getAttribute("style")`
+         */
+        toHaveStyle(style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions): R
 
         // ===== browser only =====
         /**


### PR DESCRIPTION
With this PR it becomes possible to verify if a text starts with, ends with specific text but also verify text at a given index.

It also adds the option to replace the actual value, this allows you to strip out things like newlines, or make all character upper/lower case, etc.

Fixes #1296