### PR TITLE
Changed `AsymmetricMatchers` to an interface

### DIFF
--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -15,7 +15,7 @@ declare namespace ExpectWebdriverIO {
         extend(map: Record<string, Function>): void
     } & AsymmetricMatchers
 
-    type AsymmetricMatchers = {
+    interface AsymmetricMatchers {
         any(expectedObject: any): PartialMatcher
         anything(): PartialMatcher
         arrayContaining(sample: Array<unknown>): PartialMatcher


### PR DESCRIPTION
Changed `AsymmetricMatchers` to an interface to allow for extension by downstream users.

This change will allow users to extend the `expect` type like so:

```ts
declare global {
  export namespace ExpectWebdriverIO {
    interface AsymmetricMatchers {
      toBeWithinRange(floor: number, ceiling: number): PartialMatcher;
    }
  }
}
```