### PR TITLE
(docs): add docs for visual matchers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -694,6 +694,63 @@ await expect(browser).toHaveUrl(/webdriver\.io/)
 await expect(elem).toHaveElementClass(/Container/i)
 ```
 
+## Visual Matchers
+
+<!--
+    These matchers aren't implemented in the `expect-webdriverio` project and can be found
+    here: https://github.com/webdriverio-community/visual-testing/blob/e10f7005c1533f5b06811888a9cbb9020e6e765e/packages/service/src/matcher.ts
+-->
+
+The following matcher are implemented as part of the `@wdio/visual-service` plugin and only available when the service is set up. Make sure you follow the [set-up instructions](/docs/visual-testing) accordingly.
+
+### toMatchElementSnapshot
+
+Checks that if given element matches with snapshot of baseline.
+
+##### Usage
+
+```js
+await expect($('.hero__title-logo')).toMatchElementSnapshot('wdioLogo', 0, {
+    // options
+})
+```
+
+### toMatchScreenSnapshot
+
+Checks that if current screen matches with snapshot of baseline.
+
+##### Usage
+
+```js
+await expect(browser).toMatchScreenSnapshot('partialPage', 0, {
+    // options
+})
+```
+
+### toMatchScreenSnapshot
+
+Checks that if the full page screenshot matches with snapshot of baseline.
+
+##### Usage
+
+```js
+await expect(browser).toMatchFullPageSnapshot('fullPage', 0, {
+    // options
+})
+```
+
+### toMatchScreenSnapshot
+
+Checks that if the full page screenshot including tab marks matches with snapshot of baseline.
+
+##### Usage
+
+```js
+await expect(browser).toMatchTabbablePageSnapshot('tabbable', 0, {
+    // options
+})
+```
+
 ## Default Matchers
 
 In addition to the `expect-webdriverio` matchers you can use builtin Jest's [expect](https://jestjs.io/docs/en/expect) assertions or [expect/expectAsync](https://jasmine.github.io/api/3.5/global.html#expect) for Jasmine.

--- a/docs/API.md
+++ b/docs/API.md
@@ -715,6 +715,20 @@ await expect($('.hero__title-logo')).toMatchElementSnapshot('wdioLogo', 0, {
 })
 ```
 
+The expected result is by default `0`, so you can write the same assertion as:
+
+```js
+await expect($('.hero__title-logo')).toMatchElementSnapshot('wdioLogo', {
+    // options
+})
+```
+
+or not pass in any options at all:
+
+```js
+await expect($('.hero__title-logo')).toMatchElementSnapshot()
+```
+
 ### toMatchScreenSnapshot
 
 Checks that if current screen matches with snapshot of baseline.
@@ -725,6 +739,20 @@ Checks that if current screen matches with snapshot of baseline.
 await expect(browser).toMatchScreenSnapshot('partialPage', 0, {
     // options
 })
+```
+
+The expected result is by default `0`, so you can write the same assertion as:
+
+```js
+await expect(browser).toMatchScreenSnapshot('partialPage', {
+    // options
+})
+```
+
+or not pass in any options at all:
+
+```js
+await expect(browser).toMatchScreenSnapshot('partialPage')
 ```
 
 ### toMatchFullPageSnapshot
@@ -739,6 +767,20 @@ await expect(browser).toMatchFullPageSnapshot('fullPage', 0, {
 })
 ```
 
+The expected result is by default `0`, so you can write the same assertion as:
+
+```js
+await expect(browser).toMatchFullPageSnapshot('fullPage', {
+    // options
+})
+```
+
+or not pass in any options at all:
+
+```js
+await expect(browser).toMatchFullPageSnapshot('fullPage')
+```
+
 ### toMatchTabbablePageSnapshot
 
 Checks that if the full page screenshot including tab marks matches with snapshot of baseline.
@@ -749,6 +791,20 @@ Checks that if the full page screenshot including tab marks matches with snapsho
 await expect(browser).toMatchTabbablePageSnapshot('tabbable', 0, {
     // options
 })
+```
+
+The expected result is by default `0`, so you can write the same assertion as:
+
+```js
+await expect(browser).toMatchTabbablePageSnapshot('tabbable', {
+    // options
+})
+```
+
+or not pass in any options at all:
+
+```js
+await expect(browser).toMatchTabbablePageSnapshot('tabbable')
 ```
 
 ## Default Matchers

--- a/docs/API.md
+++ b/docs/API.md
@@ -727,7 +727,7 @@ await expect(browser).toMatchScreenSnapshot('partialPage', 0, {
 })
 ```
 
-### toMatchScreenSnapshot
+### toMatchFullPageSnapshot
 
 Checks that if the full page screenshot matches with snapshot of baseline.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -739,7 +739,7 @@ await expect(browser).toMatchFullPageSnapshot('fullPage', 0, {
 })
 ```
 
-### toMatchScreenSnapshot
+### toMatchTabbablePageSnapshot
 
 Checks that if the full page screenshot including tab marks matches with snapshot of baseline.
 


### PR DESCRIPTION
Adding documentation for visual matchers.

See implementation in https://github.com/webdriverio/visual-testing/pull/141