### PR TITLE
(bugfix): allow failing condition to fail with proper error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.9.3",
       "license": "MIT",
       "dependencies": {
-        "@vitest/snapshot": "^1.2.1",
+        "@vitest/snapshot": "^1.2.2",
         "expect": "^29.7.0",
         "jest-matcher-utils": "^29.7.0",
         "lodash.isequal": "^4.5.0"
@@ -18,17 +18,17 @@
         "@types/debug": "^4.1.12",
         "@types/jest": "^29.5.11",
         "@types/lodash.isequal": "^4.5.8",
-        "@types/node": "^20.10.6",
-        "@typescript-eslint/eslint-plugin": "^6.17.0",
-        "@typescript-eslint/parser": "^6.17.0",
-        "@vitest/coverage-v8": "^1.1.3",
-        "c8": "^9.0.0",
+        "@types/node": "^20.11.14",
+        "@typescript-eslint/eslint-plugin": "^6.20.0",
+        "@typescript-eslint/parser": "^6.20.0",
+        "@vitest/coverage-v8": "^1.2.2",
+        "c8": "^9.1.0",
         "eslint": "^8.56.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-unicorn": "^50.0.1",
-        "husky": "^9.0.6",
+        "husky": "^9.0.7",
         "npm-run-all": "^4.1.5",
-        "release-it": "^17.0.1",
+        "release-it": "^17.0.3",
         "rimraf": "^5.0.5",
         "shelljs": "^0.8.5",
         "typescript": "^5.3.3",
@@ -39,9 +39,9 @@
         "node": ">=16 || >=18 || >=20"
       },
       "optionalDependencies": {
-        "@wdio/globals": "^8.27.0",
-        "@wdio/logger": "^8.24.12",
-        "webdriverio": "^8.27.0"
+        "@wdio/globals": "^8.29.3",
+        "@wdio/logger": "^8.28.0",
+        "webdriverio": "^8.29.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1511,9 +1511,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "20.11.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.14.tgz",
+      "integrity": "sha512-w3yWCcwULefjP9DmDDsgUskrMoOy5Z8MiwKHr1FvqGPtx7CvJzQvxD7eKpxNtklQxLruxSXWddyeRtyud0RcXQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1574,16 +1574,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
-      "integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.20.0.tgz",
+      "integrity": "sha512-fTwGQUnjhoYHeSF6m5pWNkzmDDdsKELYrOBxhjMrofPqCkoC2k3B2wvGHFxa1CTIqkEn88nlW1HVMztjo2K8Hg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/type-utils": "6.19.1",
-        "@typescript-eslint/utils": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
+        "@typescript-eslint/scope-manager": "6.20.0",
+        "@typescript-eslint/type-utils": "6.20.0",
+        "@typescript-eslint/utils": "6.20.0",
+        "@typescript-eslint/visitor-keys": "6.20.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1609,15 +1609,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
-      "integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.20.0.tgz",
+      "integrity": "sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
+        "@typescript-eslint/scope-manager": "6.20.0",
+        "@typescript-eslint/types": "6.20.0",
+        "@typescript-eslint/typescript-estree": "6.20.0",
+        "@typescript-eslint/visitor-keys": "6.20.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1637,13 +1637,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
-      "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.20.0.tgz",
+      "integrity": "sha512-p4rvHQRDTI1tGGMDFQm+GtxP1ZHyAh64WANVoyEcNMpaTFn3ox/3CcgtIlELnRfKzSs/DwYlDccJEtr3O6qBvA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1"
+        "@typescript-eslint/types": "6.20.0",
+        "@typescript-eslint/visitor-keys": "6.20.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1654,13 +1654,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
-      "integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.20.0.tgz",
+      "integrity": "sha512-qnSobiJQb1F5JjN0YDRPHruQTrX7ICsmltXhkV536mp4idGAYrIyr47zF/JmkJtEcAVnIz4gUYJ7gOZa6SmN4g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "@typescript-eslint/utils": "6.19.1",
+        "@typescript-eslint/typescript-estree": "6.20.0",
+        "@typescript-eslint/utils": "6.20.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.20.0.tgz",
+      "integrity": "sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1694,13 +1694,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
-      "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.20.0.tgz",
+      "integrity": "sha512-RnRya9q5m6YYSpBN7IzKu9FmLcYtErkDkc8/dKv81I9QiLLtVBHrjz+Ev/crAqgMNW2FCsoZF4g2QUylMnJz+g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
+        "@typescript-eslint/types": "6.20.0",
+        "@typescript-eslint/visitor-keys": "6.20.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1722,17 +1722,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
-      "integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.20.0.tgz",
+      "integrity": "sha512-/EKuw+kRu2vAqCoDwDCBtDRU6CTKbUmwwI7SH7AashZ+W+7o8eiyy6V2cdOqN49KsTcASWsC5QeghYuRDTyOOg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/typescript-estree": "6.19.1",
+        "@typescript-eslint/scope-manager": "6.20.0",
+        "@typescript-eslint/types": "6.20.0",
+        "@typescript-eslint/typescript-estree": "6.20.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1747,12 +1747,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
-      "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.20.0.tgz",
+      "integrity": "sha512-E8Cp98kRe4gKHjJD4NExXKz/zOJ1A2hhZc+IMVD6i7w4yjIvh6VyuRI0gRtxAsXtoC35uGMaQ9rjI2zJaXDEAw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
+        "@typescript-eslint/types": "6.20.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1910,16 +1910,160 @@
       }
     },
     "node_modules/@wdio/globals": {
-      "version": "8.29.1",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.29.1.tgz",
-      "integrity": "sha512-F+fPnX75f44/crZDfQ2FYSino/IMIdbnQGLIkaH0VnoljVJIHuxnX4y5Zqr4yRgurL9DsZaH22cLHrPXaHUhPg==",
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.29.3.tgz",
+      "integrity": "sha512-WPRjPf1yiRYt7tUjctKiBLPOUnO8kHt2SUcsQ59E0gg9zGfUXKWupnrfa2qoOAiieSySUwutf/hjDi/yvTT4mA==",
       "optional": true,
       "engines": {
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
         "expect-webdriverio": "^4.9.3",
-        "webdriverio": "8.29.1"
+        "webdriverio": "8.29.3"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/@wdio/config": {
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.29.3.tgz",
+      "integrity": "sha512-9TvmQAq4fLGKvYHvBJI4uXmqosZJgKtFQkxTaONt7R2cptIhQ7Ju6w+9eUsd4gQ6H/tUlQOstsx6ROHGJTVfKg==",
+      "optional": true,
+      "dependencies": {
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.29.1",
+        "@wdio/utils": "8.29.3",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.0.0",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/@wdio/utils": {
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.29.3.tgz",
+      "integrity": "sha512-WnZ5vZrc0oKX0u6dteB9j04Yl2EUKBLi6GtRCNTRPTpCRYiGfqSLhs0pUddTNXye7gErlqIzsVwh64q19Z5KIQ==",
+      "optional": true,
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.28.0",
+        "@wdio/types": "8.29.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.3.5",
+        "geckodriver": "^4.3.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/webdriver": {
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.29.3.tgz",
+      "integrity": "sha512-VL9SNV4FBX/8ak45aS35SYYDWc6HLXsfbnhVJnPSku8DgfDbfG8g9bCKQckpQcP7Te8a81/XbbrCjZfuqhVHfA==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "8.29.3",
+        "@wdio/logger": "8.28.0",
+        "@wdio/protocols": "8.24.12",
+        "@wdio/types": "8.29.1",
+        "@wdio/utils": "8.29.3",
+        "deepmerge-ts": "^5.1.0",
+        "got": "^12.6.1",
+        "ky": "^0.33.0",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/globals/node_modules/webdriverio": {
+      "version": "8.29.3",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.29.3.tgz",
+      "integrity": "sha512-U8JQuBXSJhdSdSnDttekN3o6WCTf3o805HDncOYtRebFd3/4vy2PmYBOOhbY5lmEq7/ROA8KSbe7TfogWskzTQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/config": "8.29.3",
+        "@wdio/logger": "8.28.0",
+        "@wdio/protocols": "8.24.12",
+        "@wdio/repl": "8.24.12",
+        "@wdio/types": "8.29.1",
+        "@wdio/utils": "8.29.3",
+        "archiver": "^6.0.0",
+        "aria-query": "^5.0.0",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "devtools-protocol": "^0.0.1249869",
+        "grapheme-splitter": "^1.0.2",
+        "import-meta-resolve": "^4.0.0",
+        "is-plain-obj": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "minimatch": "^9.0.0",
+        "puppeteer-core": "^20.9.0",
+        "query-selector-shadow-dom": "^1.0.0",
+        "resq": "^1.9.1",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^11.0.1",
+        "webdriver": "8.29.3"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      },
+      "peerDependencies": {
+        "devtools": "^8.14.0"
+      },
+      "peerDependenciesMeta": {
+        "devtools": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wdio/logger": {
@@ -3492,11 +3636,10 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1245094",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1245094.tgz",
-      "integrity": "sha512-c7Tk8wCk2bw+wuQbl8vDh/7rDboWY8TEtcuHj5Q8S9E4F0AJMGJBnp+OqBCTI+xuVeGitQHt04/Rp3tzUStJxg==",
-      "devOptional": true,
-      "peer": true
+      "version": "0.0.1249869",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
+      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
+      "devOptional": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5338,9 +5481,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
-      "integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
+      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
       "dev": true,
       "bin": {
         "husky": "bin.js"
@@ -10716,12 +10859,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/webdriverio/node_modules/devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
-      "devOptional": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -61,17 +61,17 @@
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.11",
     "@types/lodash.isequal": "^4.5.8",
-    "@types/node": "^20.10.6",
-    "@typescript-eslint/eslint-plugin": "^6.17.0",
-    "@typescript-eslint/parser": "^6.17.0",
-    "@vitest/coverage-v8": "^1.1.3",
-    "c8": "^9.0.0",
+    "@types/node": "^20.11.14",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "@vitest/coverage-v8": "^1.2.2",
+    "c8": "^9.1.0",
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-unicorn": "^50.0.1",
-    "husky": "^9.0.6",
+    "husky": "^9.0.7",
     "npm-run-all": "^4.1.5",
-    "release-it": "^17.0.1",
+    "release-it": "^17.0.3",
     "rimraf": "^5.0.5",
     "shelljs": "^0.8.5",
     "typescript": "^5.3.3",
@@ -79,12 +79,12 @@
     "webdriverio": "8.29.1"
   },
   "optionalDependencies": {
-    "@wdio/globals": "^8.27.0",
-    "@wdio/logger": "^8.24.12",
-    "webdriverio": "^8.27.0"
+    "@wdio/globals": "^8.29.3",
+    "@wdio/logger": "^8.28.0",
+    "webdriverio": "^8.29.3"
   },
   "dependencies": {
-    "@vitest/snapshot": "^1.2.1",
+    "@vitest/snapshot": "^1.2.2",
     "expect": "^29.7.0",
     "jest-matcher-utils": "^29.7.0",
     "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "compile": "tsc --build tsconfig.build.json",
     "test": "run-s test:*",
     "test:lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test:unit": "vitest",
+    "test:unit": "vitest --run",
     "test:types": "node test-types/copy && npm run ts && npm run clean:tests",
     "ts": "run-s ts:*",
     "ts:default": "cd test-types/default && tsc -p ./tsconfig.json --incremental",

--- a/src/matchers/element/toBeClickable.ts
+++ b/src/matchers/element/toBeClickable.ts
@@ -12,13 +12,7 @@ export async function toBeClickable(
         options,
     })
 
-    const result = await executeCommandBe.call(this, received, async el => {
-        try {
-            return el.isClickable()
-        } catch {
-            return false
-        }
-    }, options)
+    const result = await executeCommandBe.call(this, received, el => el.isClickable(), options)
 
     await options.afterAssertion?.({
         matcherName: 'toBeClickable',

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -13,13 +13,7 @@ export async function toBeDisplayed(
         options,
     })
 
-    const result = await executeCommandBe.call(this, received, async el => {
-        try {
-            return el.isDisplayed()
-        } catch {
-            return false
-        }
-    }, options)
+    const result = await executeCommandBe.call(this, received, el => el.isDisplayed(), options)
 
     await options.afterAssertion?.({
         matcherName: 'toBeDisplayed',

--- a/src/matchers/element/toBeDisplayedInViewport.ts
+++ b/src/matchers/element/toBeDisplayedInViewport.ts
@@ -12,13 +12,7 @@ export async function toBeDisplayedInViewport(
         options,
     })
 
-    const result = await executeCommandBe.call(this, received, async el => {
-        try {
-            return el.isDisplayedInViewport()
-        } catch {
-            return false
-        }
-    }, options)
+    const result = await executeCommandBe.call(this, received, el => el.isDisplayedInViewport(), options)
 
     await options.afterAssertion?.({
         matcherName: 'toBeDisplayedInViewport',

--- a/src/matchers/element/toBeExisting.ts
+++ b/src/matchers/element/toBeExisting.ts
@@ -14,13 +14,7 @@ export async function toExist(
         options,
     })
 
-    const result = await executeCommandBe.call(this, received, async el => {
-        try {
-            return el.isExisting()
-        } catch {
-            return false
-        }
-    }, options)
+    const result = await executeCommandBe.call(this, received, el => el.isExisting(), options)
 
     await options.afterAssertion?.({
         matcherName: 'toExist',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,9 +30,10 @@ const waitUntil = async (
         return await condition()
     }
 
+    let error: Error | undefined
+
     // wait for condition to be truthy
     try {
-        let error
         const start = Date.now()
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -43,6 +44,7 @@ const waitUntil = async (
             error = undefined
             try {
                 const result = isNot !== (await condition())
+                error = undefined
                 if (result) {
                     break
                 }
@@ -59,6 +61,10 @@ const waitUntil = async (
 
         return !isNot
     } catch (err) {
+        if (error) {
+            throw error
+        }
+
         return isNot
     }
 }

--- a/test/matchers/beMatchers.test.ts
+++ b/test/matchers/beMatchers.test.ts
@@ -42,8 +42,8 @@ describe('be* matchers', () => {
                     throw new Error('some error')
                 }
 
-                const result = await fn.call({}, el)
-                expect(result.pass).toBe(false)
+                await expect(() => fn.call({}, el, 10, {}))
+                    .rejects.toThrow('some error')
             })
 
             test('success on the first attempt', async () => {

--- a/test/matchers/browserMatchers.test.ts
+++ b/test/matchers/browserMatchers.test.ts
@@ -40,8 +40,8 @@ describe('browser matchers', () => {
                     throw new Error('some error')
                 }
 
-                const result = await fn.call({}, browser, validText, { trim: false })
-                expect(result.pass).toBe(false)
+                await expect(() => fn.call({}, browser, validText, { trim: false }))
+                    .rejects.toThrow('some error')
             })
 
             test('success on the first attempt', async () => {

--- a/test/matchers/element/toBeDisabled.test.ts
+++ b/test/matchers/element/toBeDisabled.test.ts
@@ -44,8 +44,8 @@ describe('toBeDisabled', () => {
             throw new Error('some error')
         }
 
-        const result = await toBeDisabled.call({}, el)
-        expect(result.pass).toBe(false)
+        await expect(() => toBeDisabled.call({}, el))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveComputedLabel.test.ts
+++ b/test/matchers/element/toHaveComputedLabel.test.ts
@@ -42,8 +42,8 @@ describe('toHaveComputedLabel', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveComputedLabel.call({}, el, 'WebdriverIO', { ignoreCase: true })
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveComputedLabel.call({}, el, 'WebdriverIO', { ignoreCase: true }))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveComputedRole.test.ts
+++ b/test/matchers/element/toHaveComputedRole.test.ts
@@ -42,8 +42,8 @@ describe('toHaveComputedcomputed role', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveComputedRole.call({}, el, 'WebdriverIO', { ignoreCase: true })
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveComputedRole.call({}, el, 'WebdriverIO', { ignoreCase: true }))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveHTML.test.ts
+++ b/test/matchers/element/toHaveHTML.test.ts
@@ -42,8 +42,8 @@ describe('toHaveHTML', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveHTML.call({}, el, '<div>foo</div>', { ignoreCase: true })
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveHTML.call({}, el, '<div>foo</div>', { ignoreCase: true }))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveHeight.test.ts
+++ b/test/matchers/element/toHaveHeight.test.ts
@@ -48,8 +48,8 @@ describe('toHaveHeight', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveHeight.call({}, el, 10, {})
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveHeight.call({}, el, 10, {}))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveSize.test.ts
+++ b/test/matchers/element/toHaveSize.test.ts
@@ -42,8 +42,8 @@ describe('toHaveSize', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveSize.call({}, el, { width: 32, height: 32 }, {})
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveSize.call({}, el, { width: 32, height: 32 }, {}))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -59,8 +59,8 @@ describe('toHaveStyle', () => {
             }
             throw new Error('some error');
         })
-        const result = await toHaveStyle.call({}, el, mockStyle, { ignoreCase: true });
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveStyle.call({}, el, mockStyle, { ignoreCase: true }))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -42,8 +42,8 @@ describe('toHaveText', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveText.call({}, el, 'WebdriverIO', { ignoreCase: true })
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveText.call({}, el, 'WebdriverIO', { ignoreCase: true }))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/test/matchers/element/toHaveWidth.test.ts
+++ b/test/matchers/element/toHaveWidth.test.ts
@@ -48,8 +48,8 @@ describe('toHaveWidth', () => {
             throw new Error('some error')
         }
 
-        const result = await toHaveWidth.call({}, el, 10, {})
-        expect(result.pass).toBe(false)
+        await expect(() => toHaveWidth.call({}, el, 10, {}))
+            .rejects.toThrow('some error')
     })
 
     test('success on the first attempt', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,17 +8,29 @@ export default defineConfig({
          * not to ESM ported packages
          */
         exclude: [
-            'dist', '.idea', '.git', '.cache',
+            'dist', '.idea', '.git', '.cache', 'lib',
             '**/node_modules/**'
         ],
         testTimeout: 15 * 1000,
         coverage: {
             enabled: true,
-            exclude: ['**/build/**', '**/__fixtures__/**', '**/*.test.ts'],
-            lines: 92,
-            functions: 87,
-            branches: 89,
-            statements: 92
+            exclude: [
+                '**/build/**',
+                '**/__fixtures__/**',
+                '**/*.test.ts',
+                'lib',
+                'test-types',
+                '.eslintrc.cjs',
+                'jasmine.d.ts',
+                'jest.d.ts',
+                'types'
+            ],
+            thresholds: {
+                lines: 93,
+                functions: 87,
+                branches: 91,
+                statements: 93
+            }
         }
     }
 })


### PR DESCRIPTION
An assertion like this:

```ts
expect($('idontexist').toHaveText('foobar')
```

currently fails with:

```
Expected: foobar
Received: undefined
```

This patch makes sure we propagate the error properly to the user.