### PR TITLE
(feat): keep track of registered matchers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,24 @@
 /// <reference types="../types/standalone.d.ts" />
 import { expect as expectLib } from 'expect'
+import type { RawMatcherFn } from './types.js'
 
 import wdioMatchers from './matchers.js'
 import { DEFAULT_OPTIONS } from './constants.js'
 
-expectLib.extend({ ...wdioMatchers })
+export const matchers = new Map<string, RawMatcherFn>()
+
+const extend = expectLib.extend
+expectLib.extend = (m) => {
+    if (!m || typeof m !== 'object') {
+        return
+    }
+
+    Object.entries(m).forEach(([name, matcher]) => matchers.set(name, matcher))
+    return extend(m)
+}
+
+expectLib.extend(wdioMatchers)
 export const expect = expectLib as unknown as ExpectWebdriverIO.Expect
-export const matchers = wdioMatchers
 export const getConfig = (): any => DEFAULT_OPTIONS
 export const setDefaultOptions = (options = {}): void => {
     Object.entries(options).forEach(([key, value]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+import type { ExpectationResult, MatcherContext } from 'expect'
+
 export type WdioElementMaybePromise =
     WebdriverIO.Element | WebdriverIO.ElementArray |
     Promise<WebdriverIO.Element> | Promise<WebdriverIO.ElementArray>
+
+export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
+    (this: Context, actual: any, ...expected: Array<any>): ExpectationResult;
+}

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -1,64 +1,74 @@
-import { test, expect } from 'vitest'
-import Matchers from '../src/matchers.js'
+import { test, expect, vi } from 'vitest'
+import { matchers, expect as expectLib } from '../src/index.js'
+
+const ALL_MATCHERS = [
+    // browser
+    'toHaveClipboardText',
+    'toHaveClipboardTextContaining',
+    'toHaveTitle',
+    'toHaveTitleContaining',
+    'toHaveUrl',
+    'toHaveUrlContaining',
+
+    // elements
+    'toBeElementsArrayOfSize',
+
+    // elements
+    'toBeClickable',
+    'toBeDisabled',
+    'toBeDisplayed',
+    'toBeDisplayedInViewport',
+    'toBeEnabled',
+    'toExist',
+    'toBeExisting',
+    'toBePresent',
+    'toBeFocused',
+    'toBeSelected',
+    'toBeChecked',
+    'toHaveAttributeAndValue',
+    'toHaveAttribute',
+    'toHaveAttributeContaining',
+    'toHaveAttrContaining',
+    'toHaveAttr',
+    'toHaveChildren',
+    'toHaveClass',
+    'toHaveElementClass',
+    'toHaveElementClassContaining',
+    'toHaveClassContaining',
+    'toHaveHref',
+    'toHaveLink',
+    'toHaveHrefContaining',
+    'toHaveLinkContaining',
+    'toHaveHTML',
+    'toHaveHTMLContaining',
+    'toHaveId',
+    'toHaveSize',
+    'toHaveElementProperty',
+    'toHaveText',
+    'toHaveTextContaining',
+    'toHaveValue',
+    'toHaveValueContaining',
+    'toHaveStyle',
+
+    // mock
+    'toBeRequested',
+    'toBeRequestedTimes',
+    'toBeRequestedWith',
+    'toBeRequestedWithResponse',
+
+    // snapshot
+    'toMatchSnapshot',
+    'toMatchInlineSnapshot'
+]
 
 test('matchers', () => {
-    expect(Object.keys(Matchers)).toEqual([
-        // browser
-        'toHaveClipboardText',
-        'toHaveClipboardTextContaining',
-        'toHaveTitle',
-        'toHaveTitleContaining',
-        'toHaveUrl',
-        'toHaveUrlContaining',
+    expect([...matchers.keys()]).toEqual(ALL_MATCHERS)
+})
 
-        // elements
-        'toBeElementsArrayOfSize',
-
-        // elements
-        'toBeClickable',
-        'toBeDisabled',
-        'toBeDisplayed',
-        'toBeDisplayedInViewport',
-        'toBeEnabled',
-        'toExist',
-        'toBeExisting',
-        'toBePresent',
-        'toBeFocused',
-        'toBeSelected',
-        'toBeChecked',
-        'toHaveAttributeAndValue',
-        'toHaveAttribute',
-        'toHaveAttributeContaining',
-        'toHaveAttrContaining',
-        'toHaveAttr',
-        'toHaveChildren',
-        'toHaveClass',
-        'toHaveElementClass',
-        'toHaveElementClassContaining',
-        'toHaveClassContaining',
-        'toHaveHref',
-        'toHaveLink',
-        'toHaveHrefContaining',
-        'toHaveLinkContaining',
-        'toHaveHTML',
-        'toHaveHTMLContaining',
-        'toHaveId',
-        'toHaveSize',
-        'toHaveElementProperty',
-        'toHaveText',
-        'toHaveTextContaining',
-        'toHaveValue',
-        'toHaveValueContaining',
-        'toHaveStyle',
-
-        // mock
-        'toBeRequested',
-        'toBeRequestedTimes',
-        'toBeRequestedWith',
-        'toBeRequestedWithResponse',
-
-        // snapshot
-        'toMatchSnapshot',
-        'toMatchInlineSnapshot'
-    ])
+test('allows to add matcher', () => {
+    const matcher: any = vi.fn((actual: any, expected: any) => ({ pass: actual === expected }))
+    expectLib.extend({ toBeCustom: matcher })
+    // @ts-expect-error not in types
+    expectLib('foo').toBeCustom('foo')
+    expect(matchers.keys()).toContain('toBeCustom')
 })


### PR DESCRIPTION
In case a service or other 3rd party plugin extends the WebdriverIO matcher, we want to be able to return an updated list of all registered matchers. For example if the visual service registers its visual matchers, we need an updated list when running component tests.