### PR TITLE
Main entry should not load global `expect` typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "exports": {
     ".": [
       {
-        "types": "./types/jest-global.d.ts",
+        "types": "./types/standalone.d.ts",
         "import": "./lib/index.js"
       },
       "./lib/index.js"
@@ -35,7 +35,7 @@
     ],
     "./types": "./types/jest-global.d.ts"
   },
-  "types": "./types/jest-global.d.ts",
+  "types": "./types/standalone.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
     "node": ">=16 || >=18 || >=20"


### PR DESCRIPTION
Fixes https://github.com/webdriverio/expect-webdriverio/issues/1492

Loading `jest-global.d.ts` in the TypeScript compilation makes `expect` global symbol available in type level.

Currently, just importing `"expect-webdriverio"` loads `jest-global.d.ts`. However, importing `"expect-webdriverio"` does not actually load `expect` in the runtime global scope.

Because of this mismatch, when using `"expect-webdriverio"`  as standalone npm package like `import {expect as myExpect} from "expect-webdriverio"`, TypeScript cannot emit error for the following broken script:

```
import {expect as myExpect} from 'expect-webdriverio';

expect(true).toBe(true);
```

- [TypeScript Playground link](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbwKYA8xIMbwIYGc4gCeAompjAL5wBmUEIcA5KulgLQDuSARgCZTAAbkgERGAbgBQ0oqVYwAFAEYAlADoYEAEJJlKqZID0huABUAFiKRxg+AHYQ4MQujgi6UOJajXuAV3hgOzgoPzsYUCQAGht4amxgABt8XCCMaxhva1s4BzgAIhZyfLgAc0SIbmxEuFxCEG4IRLU4AGUka3MYGDBcAC5jUuBMv241DHpDLj4BYVFDIvZp-iERYAhDMD9ExMMlABYATgA2SUXFVQ1tXVVxIA)


Note that I initially tried removing `ExpectWebdriverIO` namespace completely by simply relying on TypeScript modules (tsconfig.json with `declaration:true`) but I just realized that will be unacceptable breaking change so I kept the diff minimum.

## Verification

I built 1a7f734d2cc1e8a934dd204ab044ea2e13787c5a locally (`npm pack`) and tested with small project and confirmed that now global `expect` symbol properly causes type error while other typing are kept:

<img width="379" alt="verification" src="https://github.com/webdriverio/expect-webdriverio/assets/2931577/03b2d8cd-76ec-40d4-a73c-8dae949496e2">
