### PR TITLE
fix: extend toHaveElementClass matcher to accept an array 

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -291,13 +291,14 @@ await expect(myInput).toHaveAttr('class', expect.stringContaining('form'))
 
 ### toHaveElementClass
 
-Checks if an element has a certain class name.
+Checks if an element has a certain class name. It can also be called with an array as a parameter when the element can have multiple class names.
 
 ##### Usage
 
 ```js
 const myInput = await $('input')
 await expect(myInput).toHaveElementClass('form-control', { message: 'Not a form control!', })
+await expect(myInput).toHaveElementClass(['form-control' , 'select'])
 ```
 
 ### toHaveElementClassContaining

--- a/docs/API.md
+++ b/docs/API.md
@@ -291,14 +291,15 @@ await expect(myInput).toHaveAttr('class', expect.stringContaining('form'))
 
 ### toHaveElementClass
 
-Checks if an element has a certain class name. It can also be called with an array as a parameter when the element can have multiple class names.
+Checks if an element has a single class name. Can also be called with an array as a parameter when the element can have multiple class names.
 
 ##### Usage
 
 ```js
-const myInput = await $('input')
-await expect(myInput).toHaveElementClass('form-control', { message: 'Not a form control!', })
-await expect(myInput).toHaveElementClass(['form-control' , 'select'])
+// <button id="main" class="btn btn-large">
+const myButton = await $('#main')
+await expect(myButton).toHaveElementClass('btn', { message: 'Not found!', })
+await expect(myButton).toHaveElementClass(['btn' , 'btn-large'])
 ```
 
 ### toHaveElementClassContaining

--- a/docs/API.md
+++ b/docs/API.md
@@ -298,7 +298,7 @@ Checks if an element has a single class name. Can also be called with an array a
 ```js
 // <button id="main" class="btn btn-large">
 const myButton = await $('#main')
-await expect(myButton).toHaveElementClass('btn', { message: 'Not found!', })
+await expect(myButton).toHaveElementClass('btn')
 await expect(myButton).toHaveElementClass(['btn' , 'btn-large'])
 ```
 

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -54,6 +54,12 @@ describe('toHaveElementClass', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('failure if the classes do not match', async () => {
+        const result = await toHaveElementClass.call({}, el, "someclass", {message: "Not found!"})
+        expect(result.pass).toBe(false)
+        expect(getExpectMessage(result.message())).toContain('Not found!')
+    })
+
     test('failure if array does not match with class', async () => {
         const result = await toHaveElementClass.call({}, el, ["someclass", "anotherclass"])
         expect(result.pass).toBe(false)

--- a/test/matchers/element/toHaveElementClass.test.ts
+++ b/test/matchers/element/toHaveElementClass.test.ts
@@ -1,8 +1,8 @@
-import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils.js'
 import { toHaveElementClass, toHaveElementClassContaining } from '../../../src/matchers/element/toHaveClass.js'
+import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils.js'
 
 vi.mock('@wdio/globals')
 
@@ -49,6 +49,16 @@ describe('toHaveElementClass', () => {
         expect(result.pass).toBe(true)
     })
 
+    test('success if array matches with class', async () => {
+        const result = await toHaveElementClass.call({}, el, ["some-class", "yet-another-class"])
+        expect(result.pass).toBe(true)
+    })
+
+    test('failure if array does not match with class', async () => {
+        const result = await toHaveElementClass.call({}, el, ["someclass", "anotherclass"])
+        expect(result.pass).toBe(false)
+    })
+
     describe('options', () => {
         test('should fail when class is not a string', async () => {
             el.getAttribute = vi.fn().mockImplementation(() => {
@@ -73,6 +83,11 @@ describe('toHaveElementClass', () => {
 
         test('should pass if containing', async () => {
             const result = await toHaveElementClass.call({}, el, "some", {containing: true})
+            expect(result.pass).toBe(true)
+        })
+
+        test('should pass if array ignores the case', async () => {
+            const result = await toHaveElementClass.call({}, el, ["sOme-ClAsS", "anOther-ClAsS"], {ignoreCase: true})
             expect(result.pass).toBe(true)
         })
     })


### PR DESCRIPTION
I'm trying to close issue #1505.