### PR TITLE
fix: allow for checking non-existent elements

### DIFF
--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -30,7 +30,7 @@ export async function toHaveAttributeAndValue(received: ChainablePromiseElement,
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let attr
     const pass = await waitUntil(async () => {
         const result = await executeCommand.call(this, el, conditionAttrAndValue, options, [attribute, value, options])

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -48,7 +48,7 @@ export async function toHaveChildren(
         ? { eq: expectedValue } as ExpectWebdriverIO.NumberOptions
         : expectedValue || {}
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let children
     const pass = await waitUntil(async () => {
         const result = await executeCommand.call(this, el, condition, numberOptions, [numberOptions])

--- a/src/matchers/element/toHaveClass.ts
+++ b/src/matchers/element/toHaveClass.ts
@@ -53,7 +53,7 @@ export async function toHaveElementClass(
 
     const attribute = 'class'
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let attr
 
     const pass = await waitUntil(async () => {

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -35,7 +35,7 @@ export async function toHaveComputedLabel(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualLabel
 
     const pass = await waitUntil(

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -35,7 +35,7 @@ export async function toHaveComputedRole(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualRole
 
     const pass = await waitUntil(

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -49,7 +49,7 @@ export async function toHaveElementProperty(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let prop: any
     const pass = await waitUntil(
         async () => {

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -32,9 +32,9 @@ export async function toHaveHTML(
     })
 
     let el = 'getElement' in received
-        ? await received.getElement()
+        ? await received?.getElement()
         : 'getElements' in received
-            ? await received.getElements()
+            ? await received?.getElements()
             : received
     let actualHTML
 

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -30,7 +30,7 @@ export async function toHaveHeight(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualHeight
 
     const pass = await waitUntil(

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -28,7 +28,7 @@ export async function toHaveSize(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualSize
 
     const pass = await waitUntil(

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -26,7 +26,7 @@ export async function toHaveStyle(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualStyle
 
     const pass = await waitUntil(async () => {

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -53,9 +53,9 @@ export async function toHaveText(
     })
 
     let el = 'getElement' in received
-        ? await received.getElement()
+        ? await received?.getElement()
         : 'getElements' in received
-            ? await received.getElements()
+            ? await received?.getElements()
             : received
     let actualText
 

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -30,7 +30,7 @@ export async function toHaveWidth(
         options,
     })
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     let actualWidth
 
     const pass = await waitUntil(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ async function executeCommandBe(
 ): Promise<ExpectWebdriverIO.AssertionResult> {
     const { isNot, expectation, verb = 'be' } = this
 
-    let el = await received.getElement()
+    let el = await received?.getElement()
     const pass = await waitUntil(
         async () => {
             const result = await executeCommand.call(


### PR DESCRIPTION
The `wdio-electron-service` DOM tests [are failing](https://github.com/webdriverio-community/wdio-electron-service/actions/runs/10258147238/job/28380513158?pr=704) on the non-existent element test.  I traced the issue back to this line where an error is thrown when the target element does not exist.