### PR TITLE
support asymeyric matcher for array

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,12 +239,15 @@ export const compareTextWithArray = (
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
-        expectedArray = expectedArray.map((item) => (item instanceof RegExp ? item : item.toLowerCase()))
+        expectedArray = expectedArray.map((item) => (item instanceof RegExp || typeof item !== 'string' ? item : item.toLowerCase()))
     }
 
     const textInArray = expectedArray.some((expected) => {
         if (expected instanceof RegExp) {
             return !!actual.match(expected)
+        }
+        if (isAsymmeyricMatcher(expected)) {
+            return expected.asymmetricMatch(actual)
         }
         if (containing) {
             return actual.includes(expected)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ export const compareTextWithArray = (
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
-        expectedArray = expectedArray.map((item) => (item instanceof RegExp || typeof item !== 'string' ? item : item.toLowerCase()))
+        expectedArray = expectedArray.map((item) => (typeof item !== 'string' ? item : item.toLowerCase()))
     }
 
     const textInArray = expectedArray.some((expected) => {

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -307,6 +307,46 @@ describe('toHaveText', () => {
         expect(el._attempts).toBe(1)
     })
 
+    test('should return true if actual text contains the expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, expect.stringContaining('iverIO'), {})
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return false if actual text does not contain the expected text', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, expect.stringContaining('WDIO'), {})
+        expect(result.pass).toBe(false)
+    })
+
+    test('should return true if actual text contains one of the expected texts', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, [expect.stringContaining('iverIO'), expect.stringContaining('WDIO')], {})
+        expect(result.pass).toBe(true)
+    })
+
+    test('should return false if actual text does not contain the expected texts', async () => {
+        const el: any = await $('sel')
+        el._text = function (): string {
+            return 'WebdriverIO'
+        }
+
+        const result = await toHaveText.bind({})(el, [expect.stringContaining('EXAMPLE'), expect.stringContaining('WDIO')], {})
+        expect(result.pass).toBe(false)
+    })
+
     describe('with RegExp', () => {
         let el: any
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -53,6 +53,16 @@ describe('utils', () => {
         test('should pass if string contains and using containing', () => {
             expect(compareTextWithArray('qwe_AsD_zxc', ['foo', 'zxc'], { ignoreCase: true, containing: true }).result).toBe(true)
         })
+
+        test('should support asymmetric matchers', () => {
+            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.stringContaining('oobb')], {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')] , {}).result).toBe(false)
+        })
+
+        test('should support asymmetric matchers and using ignoreCase', () => {
+            expect(compareTextWithArray('FOO', [expect.stringContaining('oo'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray('FOO', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')] , { ignoreCase: true }).result).toBe(false)
+        })
     })
 
     describe('compareNumbers', () => {


### PR DESCRIPTION
Add support asymeyric matcher for an array used with toHaveText API.

Currently this code doesn't work:
```
 await expect(await $('>>>#newTaskButton')).toHaveText(
    [
      expect.stringContaining('ne task'),
      expect.stringContaining('ndew task'),
      expect.stringContaining('new taskk'),
    ],
    {
      ignoreCase: true,
    }
  );
```

With this fix, that works now.