### PR TITLE
fix case-insensitive with stringContaining matcher

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import isEqual from 'lodash.isequal'
 import type { ParsedCSSValue } from 'webdriverio'
+import expect from 'expect'
 
 import { DEFAULT_OPTIONS } from './constants.js'
 import type { WdioElementMaybePromise } from './types.js'
@@ -16,6 +17,10 @@ const asymmetricMatcher =
 
 export function isAsymmeyricMatcher(expected: any): expected is ExpectWebdriverIO.PartialMatcher {
     return typeof expected === 'object' && '$$typeof' in expected && expected.$$typeof === asymmetricMatcher && expected.asymmetricMatch
+}
+
+function isStringContainingMatcher(expected: any): expected is ExpectWebdriverIO.PartialMatcher {
+    return isAsymmeyricMatcher(expected) && ['StringContaining', 'StringNotContaining'].includes(expected.toString())
 }
 
 /**
@@ -159,6 +164,10 @@ export const compareText = (
         actual = actual.toLowerCase()
         if (typeof expected === 'string') {
             expected = expected.toLowerCase()
+        } else if (isStringContainingMatcher(expected)) {
+            expected = (expected.toString() === 'StringContaining'
+                ? expect.stringContaining(expected.sample?.toString().toLowerCase())
+                : expect.not.stringContaining(expected.sample?.toString().toLowerCase())) as ExpectWebdriverIO.PartialMatcher   
         }
     }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -21,6 +21,7 @@ describe('utils', () => {
 
         test('should pass if same word but wrong case and using ignoreCase', () => {
             expect(compareText(' FOO ', 'foo', { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' foo ', 'FOO', { ignoreCase: true }).result).toBe(true)
         })
 
         test('should pass if string contains expected and using containing', () => {
@@ -30,6 +31,14 @@ describe('utils', () => {
         test('should support asymmetric matchers', () => {
             expect(compareText('foo', expect.stringContaining('oo'), {}).result).toBe(true)
             expect(compareText('foo', expect.not.stringContaining('oo'), {}).result).toBe(false)
+        })
+
+        test('should support asymmetric matchers and using ignoreCase', () => {
+            expect(compareText(' FOO ', expect.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' FOO ', expect.not.stringContaining('foo'), { ignoreCase: true }).result).toBe(false)
+            expect(compareText(' Foo ', expect.stringContaining('FOO'), { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' Foo ', expect.not.stringContaining('FOO'), { ignoreCase: true }).result).toBe(false)
+            expect(compareText(' foo ', expect.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
         })
     })
 

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -560,6 +560,7 @@ declare namespace ExpectWebdriverIO {
         sample?: any
         $$typeof: symbol
         asymmetricMatch(...args: any[]): boolean
+        toString(): string
     }
 }
 


### PR DESCRIPTION
Fix #1532 