### PR TITLE
fix case in-sensitive for array using matcher

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -222,7 +222,7 @@ export const compareText = (
 
 export const compareTextWithArray = (
     actual: string,
-    expectedArray: Array<string | RegExp>,
+    expectedArray: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher>,
     {
         ignoreCase = false,
         trim = false,
@@ -248,7 +248,17 @@ export const compareTextWithArray = (
     }
     if (ignoreCase) {
         actual = actual.toLowerCase()
-        expectedArray = expectedArray.map((item) => (typeof item !== 'string' ? item : item.toLowerCase()))
+        expectedArray = expectedArray.map((item) => {
+            if (typeof item === 'string') {
+                return item.toLowerCase()
+            }
+            if (isStringContainingMatcher(item)) {
+                return (item.toString() === 'StringContaining'
+                    ? expect.stringContaining(item.sample?.toString().toLowerCase())
+                    : expect.not.stringContaining(item.sample?.toString().toLowerCase())) as ExpectWebdriverIO.PartialMatcher
+            }
+            return item
+        })
     }
 
     const textInArray = expectedArray.some((expected) => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -57,20 +57,41 @@ describe('utils', () => {
 
         test('should pass if wrong case and using ignoreCase', () => {
             expect(compareTextWithArray(' FOO ', ['foO', 'bar'], { trim: true, ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', ['foO', 'BAR'], { trim: true, ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', ['foOo', 'BAR'], { trim: true, ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' FOO ', ['foOO', 'bar'], { trim: true, ignoreCase: true }).result).toBe(false)
         })
 
         test('should pass if string contains and using containing', () => {
-            expect(compareTextWithArray('qwe_AsD_zxc', ['foo', 'zxc'], { ignoreCase: true, containing: true }).result).toBe(true)
+            expect(compareTextWithArray('qwe_AsD_zxc', ['foo', 'ZXC'], { ignoreCase: true, containing: true }).result).toBe(true)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxc'], { ignoreCase: true, containing: true }).result).toBe(true)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: true }).result).toBe(false)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: false }).result).toBe(false)
         })
 
         test('should support asymmetric matchers', () => {
             expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.stringContaining('oobb')], {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.stringContaining('oo')], {}).result).toBe(true)
             expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')] , {}).result).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.not.stringContaining('oo')] , {}).result).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.not.stringContaining('oobb')] , {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oobb'), expect.not.stringContaining('oo')] , {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oof'), expect.not.stringContaining('oobb')] , {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.not.stringContaining('foo')] , {}).result).toBe(false)
         })
 
         test('should support asymmetric matchers and using ignoreCase', () => {
-            expect(compareTextWithArray('FOO', [expect.stringContaining('oo'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray('FOO', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')] , { ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' FOO ', [expect.stringContaining('foo'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' FOO ', [expect.not.stringContaining('foo'), expect.stringContaining('oobb')] , { ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.stringContaining('oobb')] , { ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'),'oobb'] , { ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('OO'), expect.not.stringContaining('FOOO')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OOO')], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).result).toBe(false)
         })
     })
 


### PR DESCRIPTION
Fix the ignoreCase option for matcher in an array.