### PR TITLE
fix expect import

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import isEqual from 'lodash.isequal'
 import type { ParsedCSSValue } from 'webdriverio'
-import expect from 'expect'
+
+import { expect } from './index.js'
 
 import { DEFAULT_OPTIONS } from './constants.js'
 import type { WdioElementMaybePromise } from './types.js'


### PR DESCRIPTION
Fix error : `TypeError: expect.stringContaining is not a function` 