### PR TITLE
docs: update README WebdriverIO peer version reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 1. `npm install expect` (**Jasmine** and **Jest** users should skip this step)
 2. `npm install expect-webdriverio`
 
-NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v8.0.0` or higher is required!
+NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0-alpha.350` or higher is required!
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 1. `npm install expect` (**Jasmine** and **Jest** users should skip this step)
 2. `npm install expect-webdriverio`
 
-NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0-alpha.350` or higher is required!
+NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0` or higher is required!
 
 ## Usage
 


### PR DESCRIPTION
This PR should resolve issue #1635 (__Clarification on required `webdriverio` version__)

Just a one-liner change to the README in this repo.

```diff
-NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v8.0.0` or higher is required!
+NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0-alpha.350` or higher is required!
```

This should now match what's in the `package.json`

```json
  "peerDependencies": {
    "@wdio/globals": "^9.0.0-alpha.350",
    "@wdio/logger": "^9.0.0-alpha.350",
    "webdriverio": "^9.0.0-alpha.350"
  },
```