### PR TITLE
Fix import of the softAssert library

### DIFF
--- a/src/softAssertService.ts
+++ b/src/softAssertService.ts
@@ -1,6 +1,6 @@
 import type { Services } from '@wdio/types'
 import type { Frameworks } from '@wdio/types'
-import { SoftAssertService } from './softAssert'
+import { SoftAssertService } from './softAssert.js'
 
 export interface SoftAssertionServiceOptions {
     autoAssertOnTestEnd?: boolean;


### PR DESCRIPTION
Depending on your platform and configuration, it is possible that the `softAssert` fails to be imported, due to missing `.js` extension:

```
2025-06-02T10:26:27.134Z ERROR @wdio/config:ConfigParser: Failed loading configuration file: file:///C:/Path/To/Repo/wdio.conf.js: Cannot find module 'C:\Path\To\Repo\node_modules\expect-webdriverio\lib\softAssert' imported from C:\Path\To\Repo\node_modules\expect-webdriverio\lib\softAssertService.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'C:\Path\To\Repo\node_modules\expect-webdriverio\lib\softAssert' imported from C:\Path\To\Repo\node_modules\expect-webdriverio\lib\softAssertService.js
```

Imports with extensions are used everywhere in the project, so they should be used here as well.