### PR TITLE
fix: use a type alias for Service instance

### DIFF
--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1,3 +1,5 @@
+type ServiceInstance =  import('@wdio/types').Services.ServiceInstance;
+
 declare namespace ExpectWebdriverIO {
     const expect: ExpectWebdriverIO.Expect
     function setOptions(options: DefaultOptions): void
@@ -9,7 +11,7 @@ declare namespace ExpectWebdriverIO {
     }
 
     class SnapshotService {
-        static initiate(options: SnapshotServiceArgs): import('@wdio/types').Services.ServiceInstance & {
+        static initiate(options: SnapshotServiceArgs): ServiceInstance & {
             results: import('@vitest/snapshot').SnapshotResult[]
         }
     }
@@ -35,7 +37,7 @@ declare namespace ExpectWebdriverIO {
         autoAssertOnTestEnd?: boolean;
     }
 
-    class SoftAssertionService implements import('@wdio/types').Services.ServiceInstance {
+    class SoftAssertionService implements ServiceInstance {
         constructor(serviceOptions?: SoftAssertionServiceOptions, capabilities?: any, config?: any);
         beforeTest(test: import('@wdio/types').Frameworks.Test): void;
         beforeStep(step: import('@wdio/types').Frameworks.PickleStep, scenario: import('@wdio/types').Frameworks.Scenario): void;


### PR DESCRIPTION
dts-bundle-generator isn't able to handle imports immediately following the `implements` keyword:

    Error: Cannot find symbol for node "Services" in "import('@wdio/types').Services"

So just use a type alias.