### PR TITLE
Tentative first using Promise only for Type that requires it

### DIFF
--- a/test-types/jest/types.test.ts
+++ b/test-types/jest/types.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/// <reference types="@wdio/globals" />
+/// <reference types="../../types/expect-webdriverio.d.ts" />
+
+import { describe } from 'node:test'
+
+describe('type assertions', () => {
+    const wdioExpect = ExpectWebdriverIO.expect
+
+    describe('browser type assertions', () => {
+        const browser: WebdriverIO.Browser = {} as unknown as WebdriverIO.Browser
+        it('should not have ts errors and be able to await the promise', async () => {
+            const browserExpectHaveUrlIsPromiseVoid: Promise<void> = wdioExpect(browser).toHaveUrl('https://example.com')
+            await browserExpectHaveUrlIsPromiseVoid
+        })
+
+        it('should have ts errors and not need to await the promise', async () => {
+            // @ts-expect-error
+            const browserExpectHaveUrlIsPromiseVoid: void = wdioExpect(browser).toHaveUrl('https://example.com')
+        })
+    })
+
+    describe('element type assertions', () => {
+        const element: WebdriverIO.Element = {} as unknown as WebdriverIO.Element
+        it('should not have ts errors and be able to await the promise', async () => {
+            // expect no ts errors
+            const expectToBeIsNotPromiseVoid: Promise<void> = wdioExpect(element).toBeDisabled()
+            await expectToBeIsNotPromiseVoid
+        })
+
+        it('should have ts errors when typing to void', async () => {
+            // @ts-expect-error
+            const expectToBeIsVoid: void = wdioExpect(element).toBeDisabled()
+        })
+    })
+
+    describe('boolean type assertions', () => {
+        it('should not have ts errors when typing to void', async () => {
+            // Expect no ts errors
+            const expectToBeIsVoid: void = wdioExpect(true).toBe(true)
+        })
+
+        it('should have ts errors when typing to Promise', async () => {
+            //@ts-expect-error
+            const expectToBeIsNotPromiseVoid: Promise<void> = wdioExpect(true).toBe(true)
+        })
+    })
+
+    describe('string type assertions', () => {
+        it('should not have ts errors when typing to void', async () => {
+            // Expect no ts errors
+            const expectToBeIsVoid: void = wdioExpect('test').toBe('test')
+        })
+
+        it('should have ts errors when typing to Promise', async () => {
+            //@ts-expect-error
+            const expectToBeIsNotPromiseVoid: Promise<void> = wdioExpect('test').toBe('test')
+        })
+    })
+})

--- a/test-types/types.test.ts
+++ b/test-types/types.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/// <reference types="@wdio/globals" />
+/// <reference types="../types/expect-webdriverio.d.ts" />
+import { describe } from 'node:test'
+
+describe('type assertions', () => {
+    const wdioExpect = ExpectWebdriverIO.expect
+
+    describe('browser type assertions', () => {
+        const browser: WebdriverIO.Browser = {} as unknown as WebdriverIO.Browser
+        it('should not have ts errors and be able to await the promise', async () => {
+            const browserExpectHaveUrlIsPromiseVoid: Promise<void> = wdioExpect(browser).toHaveUrl('https://example.com')
+            await browserExpectHaveUrlIsPromiseVoid
+        })
+
+        it('should have ts errors and not need to await the promise', async () => {
+            // @ts-expect-error
+            const browserExpectHaveUrlIsPromiseVoid: void = wdioExpect(browser).toHaveUrl('https://example.com')
+        })
+    })
+
+    describe('element type assertions', () => {
+        const element: WebdriverIO.Element = {} as unknown as WebdriverIO.Element
+        it('should not have ts errors and be able to await the promise', async () => {
+            // expect no ts errors
+            const expectToBeIsNotPromiseVoid: Promise<void> = wdioExpect(element).toBeDisabled()
+            await expectToBeIsNotPromiseVoid
+        })
+
+        it('should have ts errors when typing to void', async () => {
+            // @ts-expect-error
+            const expectToBeIsVoid: void = wdioExpect(element).toBeDisabled()
+        })
+    })
+})

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -5,6 +5,7 @@ type PickleStep = import('@wdio/types').Frameworks.PickleStep;
 type Scenario = import('@wdio/types').Frameworks.Scenario;
 type SnapshotResult = import('@vitest/snapshot').SnapshotResult;
 type SnapshotUpdateState = import('@vitest/snapshot').SnapshotUpdateState;
+type PromiseLikeExpect = WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.MultiRemoteBrowser | WebdriverIO.MultiRemoteElement
 
 declare namespace ExpectWebdriverIO {
     const expect: ExpectWebdriverIO.Expect
@@ -188,7 +189,6 @@ declare namespace ExpectWebdriverIO {
         gte?: number
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R, T> {
         // ===== $ or $$ =====
         /**
@@ -491,7 +491,7 @@ declare namespace ExpectWebdriverIO {
      *  - R: the type of the return value, e.g. Promise<void> or void
      */
     interface Expect {
-        <T = unknown, R extends void | Promise<void> = void | Promise<void>>(actual: T): Matchers<R, T>
+        <T = unknown, R = T extends PromiseLikeExpect ? Promise<void> : void>(actual: T): Matchers<R, T>
 
         /**
          * Creates a soft assertion wrapper around standard expect

--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,10 +1,9 @@
 /// <reference types="./expect-webdriverio.js"/>
 
-type ChainablePromiseElement = import('webdriverio').ChainablePromiseElement<WebdriverIO.Element>
-type ChainablePromiseArray = import('webdriverio').ChainablePromiseArray<WebdriverIO.Element>
+type PromiseLikeExpect = WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.MultiRemoteBrowser | WebdriverIO.MultiRemoteElement
 
 declare namespace ExpectWebdriverIO {
-    interface Matchers<R extends void | Promise<void>, T> extends Readonly<import('expect').Matchers<R>> {
+    interface Matchers<R = T extends PromiseLikeExpect ? Promise<void> : void, T> extends Readonly<import('expect').Matchers<R>> {
         not: Matchers<R, T>
         resolves: Matchers<R, T>
         rejects: Matchers<R, T>
@@ -16,7 +15,7 @@ declare namespace ExpectWebdriverIO {
      *  - R: the type of the return value, e.g. Promise<void> or void
      */
     type Expect = {
-        <T = unknown, R extends void | Promise<void> = void | Promise<void>>(actual: T): Matchers<R, T>
+        <T = unknown, R = T extends PromiseLikeExpect ? Promise<void> : void>(actual: T): Matchers<R, T>
         extend(map: Record<string, Function>): void
     } & AsymmetricMatchers
 


### PR DESCRIPTION
Fix the Matcher types so that when doing non-promise type matching, it infers to `void` instead of `Promise<void>`