### PR TITLE
fix: missing type in array to have text

### DIFF
--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -351,7 +351,7 @@ declare namespace ExpectWebdriverIO {
          * ```
          */
         toHaveText(
-            text: string | RegExp | ExpectWebdriverIO.PartialMatcher | Array<string | RegExp>,
+            text: string | RegExp | ExpectWebdriverIO.PartialMatcher | Array<string | RegExp | ExpectWebdriverIO.PartialMatcher>,
             options?: ExpectWebdriverIO.StringOptions
         ): R
 


### PR DESCRIPTION
As described in issue: #1866 

This makes the following example valid by typescript:

```ts
await expect(elem).toHaveText([
    expect.stringContaining('test framework for Node.js'), 
    expect.stringContaining('Started')
])
```