### PR TITLE
fix(types): `ChainablePromiseArray` and `ChainablePromiseElement` resolved to any

### DIFF
--- a/jasmine.d.ts
+++ b/jasmine.d.ts
@@ -1,6 +1,5 @@
-/// <reference types="expect-webdriverio/types/expect-webdriverio"/>
+/// <reference types="./types/expect-webdriverio.d.ts"/>
 
 declare namespace jasmine {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
+    interface AsyncMatchers<T, _U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "run-s test:*",
     "test:lint": "eslint .",
     "test:unit": "vitest --run",
-    "test:types": "node test-types/copy && npm run ts && npm run clean:tests",
+    "test:types": "node test-types/copy && npm run ts && npm run clean:tests && npm run tsc:root-types",
     "ts": "run-s ts:*",
     "ts:default": "cd test-types/default && tsc -p ./tsconfig.json --incremental",
     "ts:jest": "cd test-types/jest && tsc -p ./tsconfig.json --incremental",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "clean:build": "rimraf ./lib",
     "clean:tests": "rimraf test-types/**/node_modules && rimraf test-types/**/dist",
     "compile": "tsc --build tsconfig.build.json",
+    "tsc:root-types": "tsc jasmine.d.ts jest.d.ts",
     "test": "run-s test:*",
     "test:lint": "eslint .",
     "test:unit": "vitest --run",

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -26,7 +26,7 @@ async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string,
     return compareText(attr, value, options)
 }
 
-export async function toHaveAttributeAndValue(received: ChainablePromiseElement, attribute: string, value: string | RegExp | ExpectWebdriverIO.PartialMatcher, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
+export async function toHaveAttributeAndValue(received: WdioElementMaybePromise, attribute: string, value: string | RegExp | ExpectWebdriverIO.PartialMatcher, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
@@ -49,11 +49,11 @@ export async function toHaveAttributeAndValue(received: ChainablePromiseElement,
     } as ExpectWebdriverIO.AssertionResult
 }
 
-async function toHaveAttributeFn(received: ChainablePromiseElement | WebdriverIO.Element, attribute: string) {
+async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: string) {
     const isNot = this.isNot
     const { expectation = 'attribute', verb = 'have' } = this
 
-    let el = await received
+    let el = await received?.getElement()
 
     const pass = await waitUntil(async () => {
         const result = await executeCommand.call(this, el, conditionAttr, {}, [attribute])

--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="./expect-webdriverio.js"/>
 
-type ChainablePromiseElement = import('webdriverio').ChainablePromiseElement<WebdriverIO.Element>
-type ChainablePromiseArray = import('webdriverio').ChainablePromiseArray<WebdriverIO.Element>
+type ChainablePromiseElement = import('webdriverio').ChainablePromiseElement
+type ChainablePromiseArray = import('webdriverio').ChainablePromiseArray
 
 declare namespace ExpectWebdriverIO {
     interface Matchers<R extends void | Promise<void>, T> extends Readonly<import('expect').Matchers<R>> {


### PR DESCRIPTION
As described in the [issue](https://github.com/webdriverio/expect-webdriverio/issues/1871), we are fixing `ChainablePromiseArray` and `ChainablePromiseElement` resolved to any caused by the unexpected generics.
![image](https://github.com/user-attachments/assets/1ee04bfc-e5c4-407c-bb87-7c287812c130)

Also, `jasmine.d.ts` started to show an error, so I aligned it with the same value as `jest.d.ts`
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/60d4a80f-f2b6-4d2c-9715-3c5c268acb69" />

To uncover problems in `d.ts` file at the root, I added a tsc command on it as a quick win. 