### PR TITLE
fix: Renaming U broke the augmentation

### DIFF
--- a/jasmine.d.ts
+++ b/jasmine.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="./types/expect-webdriverio.d.ts"/>
 
 declare namespace jasmine {
-    interface AsyncMatchers<T, _U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface AsyncMatchers<T, U> extends ExpectWebdriverIO.Matchers<Promise<void>, T> {}
 }


### PR DESCRIPTION
Small fix so that the async matcher gets applied as before since renaming U breaks the override of that method