### PR TITLE
fix(expect): guard property definitions to avoid “Cannot redefine property” error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ type MatchersObject = Parameters<typeof expectLib.extend>[0]
 expectLib.extend(filteredMatchers as MatchersObject)
 
 // Extend the expect object with soft assertions
-const expectWithSoft = expectLib as unknown as ExpectWebdriverIO.Expect
+const expectWithSoft = expectLib as unknown as ExpectWebdriverIO.Expect & SoftHelpers
 
 type SoftHelpers = {
     soft: <T = unknown>(actual: T) => ReturnType<typeof createSoftExpect>


### PR DESCRIPTION
Checks for existing keys before calling `Object.defineProperty`
 to avoid `“Cannot redefine property”` errors when the module is
 evaluated multiple times or multiple SoftAssertionService
 instances run in the same process.

This makes `expect.soft` and its utility methods idempotent and prevents startup crashes.
