### PR TITLE
refactor(typings): revert change

### DIFF
--- a/types/standalone.d.ts
+++ b/types/standalone.d.ts
@@ -8,7 +8,7 @@ declare namespace ExpectWebdriverIO {
     }
 
     type Expect = {
-        <T = unknown>(actual: T): Matchers<Promise<void>, T>
+        <T = unknown>(actual: T): Matchers<void, T>
         extend(map: Record<string, Function>): void
     } & AsymmetricMatchers
 


### PR DESCRIPTION
Reverts the following change https://github.com/webdriverio/expect-webdriverio/pull/1888, as it causes other non WDIO matchers to return `Promise` type although they don't. 

For now I will fix this issue on my end by using `patch-package` with following patch, I tried committing this to the repo but it causes the jasmine typings tests to fail.

```diff
diff --git a/node_modules/expect-webdriverio/types/expect-webdriverio.d.ts b/node_modules/expect-webdriverio/types/expect-webdriverio.d.ts
index f97eab1..0546ce1 100644
--- a/node_modules/expect-webdriverio/types/expect-webdriverio.d.ts
+++ b/node_modules/expect-webdriverio/types/expect-webdriverio.d.ts
@@ -65,33 +65,33 @@ declare namespace ExpectWebdriverIO {
         /**
          * `WebdriverIO.Element` -> `isDisplayed`
          */
-        toBeDisplayed(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeDisplayed(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `isDisplayed`
          */
-        toBeVisible(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeVisible(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toExist(options?: ExpectWebdriverIO.CommandOptions): R
+        toExist(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toBePresent(options?: ExpectWebdriverIO.CommandOptions): R
+        toBePresent(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `isExisting`
          */
-        toBeExisting(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeExisting(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttribute(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttribute(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          */
-        toHaveAttr(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveAttr(attribute: string, value?: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute`
@@ -101,7 +101,7 @@ declare namespace ExpectWebdriverIO {
             attribute: string,
             contains: string,
             options?: ExpectWebdriverIO.StringOptions
-        ): R
+        ): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getAttribute`
          * Element's attribute includes the value.
@@ -110,91 +110,91 @@ declare namespace ExpectWebdriverIO {
             attribute: string,
             contains: string,
             options?: ExpectWebdriverIO.StringOptions
-        ): R
+        ): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClass` instead.
          */
-        toHaveClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClass(className: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          */
-        toHaveElementClass(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClass(className: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * @deprecated since v1.3.1 - use `toHaveElementClassContaining` instead.
          * Element's class includes the className.
          */
-        toHaveClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` class
          * Element's class includes the className.
          */
-        toHaveElementClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementClassContaining(className: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getProperty`
          * @deprecated since v1.3.1 - use `toHaveElementProperty` instead.
          */
-        toHaveProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getProperty`
          */
-        toHaveElementProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveElementProperty(property: string, value?: any, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveValue(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValue(value: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          * Element's value includes the value.
          */
-        toHaveValueContaining(value: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveValueContaining(value: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isClickable`
          */
-        toBeClickable(options?: ExpectWebdriverIO.StringOptions): R
+        toBeClickable(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `!isEnabled`
          */
-        toBeDisabled(options?: ExpectWebdriverIO.StringOptions): R
+        toBeDisabled(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isDisplayedInViewport`
          */
-        toBeDisplayedInViewport(options?: ExpectWebdriverIO.StringOptions): R
+        toBeDisplayedInViewport(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `isDisplayedInViewport`
          */
-        toBeVisibleInViewport(options?: ExpectWebdriverIO.StringOptions): R
+        toBeVisibleInViewport(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isEnabled`
          */
-        toBeEnabled(options?: ExpectWebdriverIO.StringOptions): R
+        toBeEnabled(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isFocused`
          */
-        toBeFocused(options?: ExpectWebdriverIO.StringOptions): R
+        toBeFocused(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isSelected`
          */
-        toBeSelected(options?: ExpectWebdriverIO.StringOptions): R
+        toBeSelected(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `isSelected`
          */
-        toBeChecked(options?: ExpectWebdriverIO.StringOptions): R
+        toBeChecked(options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `$$('./*').length`
@@ -203,67 +203,67 @@ declare namespace ExpectWebdriverIO {
         toHaveChildren(
             size?: number | ExpectWebdriverIO.NumberOptions,
             options?: ExpectWebdriverIO.NumberOptions
-        ): R
+        ): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveHref(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHref(href: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          */
-        toHaveLink(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLink(href: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveHrefContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveHrefContaining(href: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getAttribute` href
          * Element's href includes the value provided
          */
-        toHaveLinkContaining(href: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveLinkContaining(href: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getProperty` value
          */
-        toHaveId(id: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveId(id: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Element` -> `getText`
          */
-        toHaveText(text: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveText(text: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
         /**
          * `WebdriverIO.Element` -> `getText`
          * Element's text includes the text provided
          */
-        toHaveTextContaining(text: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTextContaining(text: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         // ===== browser only =====
         /**
          * `WebdriverIO.Browser` -> `getUrl`
          */
-        toHaveUrl(url: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveUrl(url: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         // ===== browser only =====
         /**
          * `WebdriverIO.Browser` -> `getUrl`
          * Browser's url includes the provided text
          */
-        toHaveUrlContaining(url: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveUrlContaining(url: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         /**
          * `WebdriverIO.Browser` -> `getTitle`
          */
-        toHaveTitle(title: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTitle(title: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         // ===== browser only =====
         /**
          * `WebdriverIO.Browser` -> `getTitle`
          * Browser's title includes the provided text
          */
-        toHaveTitleContaining(title: string, options?: ExpectWebdriverIO.StringOptions): R
+        toHaveTitleContaining(title: string, options?: ExpectWebdriverIO.StringOptions): Promise<R>;
 
         // ===== $$ only =====
         /**
@@ -273,14 +273,14 @@ declare namespace ExpectWebdriverIO {
         toBeElementsArrayOfSize(
             size: number | ExpectWebdriverIO.NumberOptions,
             options?: ExpectWebdriverIO.NumberOptions
-        ): R
+        ): Promise<R>;
 
         // ==== network mock ====
 
         /**
          * Check that `WebdriverIO.Mock` was called
          */
-        toBeRequested(options?: ExpectWebdriverIO.CommandOptions): R
+        toBeRequested(options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
 
         /**
          * Check that `WebdriverIO.Mock` was called N times
@@ -288,12 +288,12 @@ declare namespace ExpectWebdriverIO {
         toBeRequestedTimes(
             times: number | ExpectWebdriverIO.NumberOptions,
             options?: ExpectWebdriverIO.NumberOptions
-        ): R
+        ): Promise<R>;
 
         /**
          * Check that `WebdriverIO.Mock` was called with the specific parameters
          */
-        toBeRequestedWith(requestedWith: RequestedWith, options?: ExpectWebdriverIO.CommandOptions): R
+        toBeRequestedWith(requestedWith: RequestedWith, options?: ExpectWebdriverIO.CommandOptions): Promise<R>;
     }
 
     type RequestedWith = {

```