### PR TITLE
chore(deps): replace deprecated lodash.isequal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,11 @@
       "dependencies": {
         "@vitest/snapshot": "^3.2.4",
         "expect": "^30.0.0",
-        "jest-matcher-utils": "^30.0.0",
-        "lodash.isequal": "^4.5.0"
+        "jest-matcher-utils": "^30.0.0"
       },
       "devDependencies": {
         "@types/debug": "^4.1.12",
         "@types/jest": "^30.0.0",
-        "@types/lodash.isequal": "^4.5.8",
         "@types/node": "^24.0.3",
         "@vitest/coverage-v8": "^3.2.4",
         "@wdio/eslint": "^0.1.1",
@@ -2158,23 +2156,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
-      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -7173,7 +7154,9 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^3.2.4",
+        "deep-eql": "^5.0.2",
         "expect": "^30.0.0",
         "jest-matcher-utils": "^30.0.0"
       },
@@ -4293,7 +4294,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@vitest/snapshot": "^3.2.4",
+    "deep-eql": "^5.0.2",
     "expect": "^30.0.0",
     "jest-matcher-utils": "^30.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -62,13 +62,11 @@
   "dependencies": {
     "@vitest/snapshot": "^3.2.4",
     "expect": "^30.0.0",
-    "jest-matcher-utils": "^30.0.0",
-    "lodash.isequal": "^4.5.0"
+    "jest-matcher-utils": "^30.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
     "@types/jest": "^30.0.0",
-    "@types/lodash.isequal": "^4.5.8",
     "@types/node": "^24.0.3",
     "@vitest/coverage-v8": "^3.2.4",
     "@wdio/eslint": "^0.1.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
-import { isDeepStrictEqual } from 'node:util'
-
+import deepEql from 'deep-eql'
 import type { ParsedCSSValue } from 'webdriverio'
 
 import { expect } from 'expect'
@@ -306,7 +305,7 @@ export const compareObject = (actual: object | number, expected: string | number
 
     return {
         value: actual,
-        result: isDeepStrictEqual(actual, expected),
+        result: deepEql(actual, expected),
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import isEqual from 'lodash.isequal'
+import { isDeepStrictEqual } from 'node:util'
+
 import type { ParsedCSSValue } from 'webdriverio'
 
 import { expect } from 'expect'
@@ -305,7 +306,7 @@ export const compareObject = (actual: object | number, expected: string | number
 
     return {
         value: actual,
-        result: isEqual(actual, expected),
+        result: isDeepStrictEqual(actual, expected),
     }
 }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { compareNumbers, compareText, compareTextWithArray } from '../src/utils.js'
+import { compareNumbers, compareObject, compareText, compareTextWithArray } from '../src/utils.js'
 
 describe('utils', () => {
     describe('compareText', () => {
@@ -133,6 +133,29 @@ describe('utils', () => {
             const lte = 9
             const gte = 1
             expect(compareNumbers(actual, { lte, gte })).toBe(false)
+        })
+    })
+
+    describe('compareObject', () => {
+        test('should pass if the objects are equal', () => {
+            expect(compareObject({ 'foo': 'bar' }, { 'foo': 'bar' }).result).toBe(true)
+        })
+
+        test('should pass if the objects are deep equal', () => {
+            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'bar': 'baz' } }).result).toBe(true)
+        })
+
+        test('should fail if the objects are not equal', () => {
+            expect(compareObject({ 'foo': 'bar' }, { 'baz': 'quux' }).result).toBe(false)
+        })
+
+        test('should fail if the objects are only shallow equal', () => {
+            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'baz': 'quux' } }).result).toBe(false)
+        })
+
+        test('should fail if the actual value is a number or array', () => {
+            expect(compareObject(10, { 'foo': 'bar' }).result).toBe(false)
+            expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).result).toBe(false)
         })
     })
 })


### PR DESCRIPTION
`lodash.isequal` is deprecated:

<img width="890" height="47" alt="image" src="https://github.com/user-attachments/assets/bd83f746-cb76-44db-83bb-39255204cb49" />

This PR replaces it with the suggested `util.isDeepStrictEqual` method.