### PR TITLE
refactor: compare with `undefined` directly instead of using `typeof`

### DIFF
--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -82,7 +82,7 @@ export async function toHaveAttribute(
         options,
     })
 
-    const result = typeof value !== 'undefined'
+    const result = value !== undefined
         // Name and value is passed in e.g. el.toHaveAttribute('attr', 'value', (opts))
         ? await toHaveAttributeAndValue.call(this, received, attribute, value, options)
         // Only name is passed in e.g. el.toHaveAttribute('attr')

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -88,7 +88,7 @@ export async function toBeRequestedWith(
  * is actual method matching an expected method or methods
  */
 const methodMatcher = (method: string, expected?: string | Array<string>) => {
-    if (typeof expected === 'undefined') {
+    if (expected === undefined) {
         return true
     }
     if (!Array.isArray(expected)) {
@@ -108,7 +108,7 @@ const methodMatcher = (method: string, expected?: string | Array<string>) => {
  * is actual statusCode matching an expected statusCode or statusCodes
  */
 const statusCodeMatcher = (statusCode: number, expected?: number | Array<number>) => {
-    if (typeof expected === 'undefined') {
+    if (expected === undefined) {
         return true
     }
     if (!Array.isArray(expected)) {
@@ -124,7 +124,7 @@ const urlMatcher = (
     url: string,
     expected?: string | ExpectWebdriverIO.PartialMatcher | ((url: string) => boolean)
 ) => {
-    if (typeof expected === 'undefined') {
+    if (expected === undefined) {
         return true
     }
     if (typeof expected === 'function') {
@@ -148,7 +148,7 @@ const headersMatcher = (
      * if header matcher is an empty object, match with no headers
      */
     if (
-        typeof expected === 'undefined' ||
+        expected === undefined ||
         typeof expected === 'object' && Object.keys(expected).length === 0
     ) {
         return true
@@ -267,7 +267,7 @@ const minifyRequestMock = (
     },
     requestedWith?: ExpectWebdriverIO.RequestedWith
 ) => {
-    if (typeof requestMock === 'undefined') {
+    if (requestMock === undefined) {
         return requestMock
     }
 
@@ -320,7 +320,7 @@ const requestedWithParamToString = (
         | undefined,
     transformFn?: (param: ExpectWebdriverIO.JsonCompatible) => ExpectWebdriverIO.JsonCompatible | string
 ) => {
-    if (typeof param === 'undefined') {
+    if (param === undefined) {
         return
     }
 
@@ -394,7 +394,7 @@ const shortenString = (str: string, limit = STR_LIMIT) => {
 
 const deleteUndefinedValues = (obj: Record<string, unknown>, baseline = obj) => {
     Object.keys(obj).forEach((k) => {
-        if (typeof baseline[k] === 'undefined') {
+        if (baseline[k] === undefined) {
             delete obj[k]
         }
     })


### PR DESCRIPTION
compare with `undefined` directly instead of using `typeof` to make more concise and easier to read