### PR TITLE
fix: require `.js` extension once integrated in wdio

### DIFF
--- a/src/matchers/snapshot.ts
+++ b/src/matchers/snapshot.ts
@@ -3,7 +3,7 @@ import type { AssertionError } from 'node:assert'
 
 import { expect } from 'expect'
 import { stripSnapshotIndentation } from '@vitest/snapshot'
-import { SnapshotService } from '../snapshot'
+import { SnapshotService } from '../snapshot.js'
 
 interface InlineSnapshotOptions {
     inlineSnapshot: string


### PR DESCRIPTION
Fix an error once integrated in wdio following the release of 5.6.0. Impact of https://github.com/webdriverio/expect-webdriverio/pull/1863 . See https://github.com/webdriverio/webdriverio/pull/14953#issuecomment-3688196530