### PR TITLE
fix: handle array return values in multiremote for toHaveText and toH…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2226,6 +2227,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3026,6 +3028,7 @@
       "integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.50.1",
@@ -3065,6 +3068,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -3501,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -3626,6 +3631,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4115,6 +4121,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5106,6 +5113,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7006,6 +7014,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9482,6 +9491,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9614,6 +9624,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9689,6 +9700,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -9861,6 +9873,7 @@
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.21.0.tgz",
       "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -1,4 +1,4 @@
-import { waitUntil, enhanceError, compareText } from '../../utils.js'
+import { waitUntil, enhanceError, compareText, compareTextWithArray } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 
 export async function toHaveTitle(
@@ -17,9 +17,20 @@ export async function toHaveTitle(
 
     let actual
     const pass = await waitUntil(async () => {
-        actual = await browser.getTitle()
+        const result = await browser.getTitle()
+        actual = result
 
-        return compareText(actual, expectedValue, options).result
+        if (Array.isArray(result)) {
+            const results = result.map((item) => {
+                return Array.isArray(expectedValue)
+                    ? compareTextWithArray(item, expectedValue, options).result
+                    : compareText(item, expectedValue, options).result
+            })
+
+            return results.every((res) => res)
+        }
+
+        return compareText(result, expectedValue, options).result
     }, isNot, options)
 
     const message = enhanceError('window', expectedValue, actual, this, verb, expectation, '', options)

--- a/src/matchers/browser/toHaveUrl.ts
+++ b/src/matchers/browser/toHaveUrl.ts
@@ -1,4 +1,4 @@
-import { waitUntil, enhanceError, compareText } from '../../utils.js'
+import { waitUntil, enhanceError, compareText, compareTextWithArray } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 
 export async function toHaveUrl(
@@ -17,9 +17,20 @@ export async function toHaveUrl(
 
     let actual
     const pass = await waitUntil(async () => {
-        actual = await browser.getUrl()
+        const result = await browser.getUrl()
+        actual = result
 
-        return compareText(actual, expectedValue, options).result
+        if (Array.isArray(result)) {
+            const results = result.map((item) => {
+                return Array.isArray(expectedValue)
+                    ? compareTextWithArray(item, expectedValue, options).result
+                    : compareText(item, expectedValue, options).result
+            })
+
+            return results.every((res) => res)
+        }
+
+        return compareText(result, expectedValue, options).result
     }, isNot, options)
 
     const message = enhanceError('window', expectedValue, actual, this, verb, expectation, '', options)

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -25,10 +25,21 @@ async function condition(el: WebdriverIO.Element | WebdriverIO.ElementArray, tex
         checkAllValuesMatchCondition = resultArray.every(Boolean)
     } else {
         const actualText = await (el as WebdriverIO.Element).getText()
-        actualTextArray.push(actualText)
-        checkAllValuesMatchCondition = Array.isArray(text)
-            ? compareTextWithArray(actualText, text, options).result
-            : compareText(actualText, text, options).result
+        if (Array.isArray(actualText)) {
+            for (const value of actualText) {
+                actualTextArray.push(value)
+                const result = Array.isArray(text)
+                    ? compareTextWithArray(value, text, options).result
+                    : compareText(value, text, options).result
+                resultArray.push(result)
+            }
+            checkAllValuesMatchCondition = resultArray.every(Boolean)
+        } else {
+            actualTextArray.push(actualText)
+            checkAllValuesMatchCondition = Array.isArray(text)
+                ? compareTextWithArray(actualText, text, options).result
+                : compareText(actualText, text, options).result
+        }
     }
 
     return {


### PR DESCRIPTION

toHaveText
 to detect if getText() returns an array. If so, it iterates over the results and verifies that all instances match the expectation.

toHaveTitle
 to handle array returns from browser.getTitle() similarly.

Added support for mixed expectations using array syntax.

tested it against the repo given in the issue #1966 

and this should fix #106 too