### PR TITLE
feat: Alpha Support for Multi-remote Browser

### DIFF
--- a/docs/MultiRemote.md
+++ b/docs/MultiRemote.md
@@ -1,0 +1,83 @@
+# MultiRemote Support (Alpha)
+
+Multi-remote support is in active development.
+
+## Usage
+
+By default, multi-remote queries (e.g., `getTitle`) fetch data from all remotes, simplifying tests where browsers share behavior.
+
+Use the typed global constants:
+```ts
+import { multiremotebrowser } from '@wdio/globals' 
+...
+await expect(multiRemoteBrowser).toXX()
+```
+Note: `multiRemoteBrowser` is used in examples pending a planned rename.
+
+
+Assuming the below multi-remote Wdio configuration:
+```ts
+export const config: WebdriverIO.MultiremoteConfig = {
+    ...
+    capabilities: {
+        myChromeBrowser: {
+            capabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': { args: ['--headless'] }
+            }
+        },
+        myFirefoxBrowser: {
+            capabilities: {
+                browserName: 'firefox',
+                'moz:firefoxOptions': { args: ['-headless'] }
+            }
+        } 
+    },
+    ...
+}
+```
+
+## Single Expected Value
+To test all remotes against the same value, pass a single expected value.
+```ts
+    await expect(multiRemoteBrowser).toHaveTitle('My Site Title')
+```
+
+## Multiple Expected Values
+For differing remotes, pass an array of expected values.
+  - Note: Values must match the configuration order.
+```ts
+    await expect(multiRemoteBrowser).toHaveTitle(['My Chrome Site Title', 'My Firefox Site Title'])
+```
+
+## **NOT IMPLEMENTED** Per Remote Expected Value
+To test specific remotes, map instance names to expected values.
+
+```ts
+    // Test both defined remotes with specific values
+    await expect(multiRemoteBrowser).toHaveTitle({
+        'myChromeBrowser' : 'My Chrome Site Title', 
+        'myFirefoxBrowser' : 'My Firefox Site Title'
+    })
+```
+
+To assert a single remote and skip others:
+```ts
+    await expect(multiRemoteBrowser).toHaveTitle({
+        'myFirefoxBrowser' : 'My Firefox Site Title'
+    })
+```
+
+To assert all remotes with a default value, overriding specific ones:
+```ts
+    await expect(multiRemoteBrowser).toHaveTitle({
+        default : 'My Default Site Title',
+        'myFirefoxBrowser' : 'My Firefox Site Title'
+    })
+```
+
+## Limitations
+- Options (e.g., `StringOptions`) apply globally.
+- Alpha support is limited to the `toHaveTitle` browser matcher.
+- Element matchers are planned.
+- Assertions currently throw on the first error. Future updates will report errors as failures.

--- a/docs/MultiRemote.md
+++ b/docs/MultiRemote.md
@@ -80,7 +80,8 @@ To assert all remotes with a default value, overriding specific ones:
 - Options (e.g., `StringOptions`) apply globally.
 - Alpha support is limited to the `toHaveTitle` browser matcher.
 - Element matchers are planned.
-- Assertions currently throw on the first error. Future updates will report errors as failures.
+- Assertions currently throw on the first error. Future updates will report thrown errors as failures and if all remotes are in error it will throw.
+- SoftAssertions, snapshot services and network matchers might come after.
 
 ## Alternatives
 

--- a/docs/MultiRemote.md
+++ b/docs/MultiRemote.md
@@ -81,3 +81,26 @@ To assert all remotes with a default value, overriding specific ones:
 - Alpha support is limited to the `toHaveTitle` browser matcher.
 - Element matchers are planned.
 - Assertions currently throw on the first error. Future updates will report errors as failures.
+
+## Alternative
+
+Since multi-remote are still simple browser, there is other way to assert using the instance list on the multi-remote
+
+### Parametrized Tests
+Using parametrized feature of your assertion librairie, we can iterate on the instance of the multi-remote
+
+Mocha parametrized example
+```ts
+    describe('Multiremote test', async () => {
+        multiRemoteBrowser.instances.forEach(function (instance) {
+            describe(`Test ${instance}`, function () {
+                it('should have title "The Internet"', async function () {
+                    const browser = multiRemoteBrowser.getInstance(instance)
+                    await browser.url('https://the-internet.herokuapp.com/login')
+                    
+                    await expect(browser).toHaveTitle("The Internet");
+                })
+            });
+        });
+    });
+```

--- a/docs/MultiRemote.md
+++ b/docs/MultiRemote.md
@@ -8,14 +8,14 @@ By default, multi-remote queries (e.g., `getTitle`) fetch data from all remotes,
 
 Use the typed global constants:
 ```ts
-import { multiremotebrowser } from '@wdio/globals' 
+import { multiremotebrowser as multiRemoteBrowser } from '@wdio/globals' 
 ...
-await expect(multiRemoteBrowser).toXX()
+await expect(multiRemoteBrowser).toHaveTitle('...')
 ```
 Note: `multiRemoteBrowser` is used in examples pending a planned rename.
 
 
-Assuming the below multi-remote Wdio configuration:
+Assuming the following WebdriverIO multi-remote configuration:
 ```ts
 export const config: WebdriverIO.MultiremoteConfig = {
     ...
@@ -82,25 +82,37 @@ To assert all remotes with a default value, overriding specific ones:
 - Element matchers are planned.
 - Assertions currently throw on the first error. Future updates will report errors as failures.
 
-## Alternative
+## Alternatives
 
-Since multi-remote are still simple browser, there is other way to assert using the instance list on the multi-remote
+Since multi-remote instances are standard browsers, you can also assert by iterating over the instance list.
 
-### Parametrized Tests
-Using parametrized feature of your assertion librairie, we can iterate on the instance of the multi-remote
+### Parameterized Tests
+Using the parameterized feature of your test framework, you can iterate over the multi-remote instances.
 
-Mocha parametrized example
+Mocha Parameterized Example
 ```ts
     describe('Multiremote test', async () => {
         multiRemoteBrowser.instances.forEach(function (instance) {
             describe(`Test ${instance}`, function () {
                 it('should have title "The Internet"', async function () {
                     const browser = multiRemoteBrowser.getInstance(instance)
-                    await browser.url('https://the-internet.herokuapp.com/login')
+                    await browser.url('https://mysite.com')
                     
-                    await expect(browser).toHaveTitle("The Internet");
+                    await expect(browser).toHaveTitle("The Internet")
                 })
-            });
-        });
-    });
+            })
+        })
+    })
 ```
+### Direct Instance Access
+By extending the WebdriverIO `namespace` in TypeScript (see [documentation](https://webdriver.io/docs/multiremote/#extending-typescript-types)), you can directly access each instance and use `expect` on them.
+
+```ts
+    it('should have title per browsers', async () => {
+        await multiRemoteBrowser.url('https://mysite.com')
+
+        await expect(multiRemoteBrowser.myChromeBrowser).toHaveTitle('The Internet')
+        await expect(multiRemoteBrowser.myFirefoxBrowser).toHaveTitle('The Internet')
+    }) 
+```
+

--- a/docs/MultiRemote.md
+++ b/docs/MultiRemote.md
@@ -4,7 +4,7 @@ Multi-remote support is in active development.
 
 ## Usage
 
-By default, multi-remote queries (e.g., `getTitle`) fetch data from all remotes, simplifying tests where browsers share behavior.
+By default, multi-remote matchers fetch data (e.g., `getTitle`) from all remotes, simplifying tests where browsers share the same behavior.
 
 Use the typed global constants:
 ```ts
@@ -36,6 +36,18 @@ export const config: WebdriverIO.MultiremoteConfig = {
     ...
 }
 ```
+
+And an `it` test like:
+```ts
+import { multiremotebrowser as multiRemoteBrowser } from '@wdio/globals' 
+
+it('should have title "My Site Title"', async function () {
+    await multiRemoteBrowser.url('https://mysite.com')
+    
+    // ... assertions
+})
+```            
+
 
 ## Single Expected Value
 To test all remotes against the same value, pass a single expected value.
@@ -80,7 +92,7 @@ To assert all remotes with a default value, overriding specific ones:
 - Options (e.g., `StringOptions`) apply globally.
 - Alpha support is limited to the `toHaveTitle` browser matcher.
 - Element matchers are planned.
-- Assertions currently throw on the first error. Future updates will report thrown errors as failures and if all remotes are in error it will throw.
+- Assertions currently throw on the first error. Future updates will report thrown errors as failures, and will only throw if all remotes fail.
 - SoftAssertions, snapshot services and network matchers might come after.
 
 ## Alternatives
@@ -95,25 +107,49 @@ Mocha Parameterized Example
     describe('Multiremote test', async () => {
         multiRemoteBrowser.instances.forEach(function (instance) {
             describe(`Test ${instance}`, function () {
-                it('should have title "The Internet"', async function () {
+                it('should have title "My Site Title"', async function () {
                     const browser = multiRemoteBrowser.getInstance(instance)
                     await browser.url('https://mysite.com')
                     
-                    await expect(browser).toHaveTitle("The Internet")
+                    await expect(browser).toHaveTitle("My Site Title")
                 })
             })
         })
     })
 ```
-### Direct Instance Access
+### Direct Instance Access (TypeScript)
 By extending the WebdriverIO `namespace` in TypeScript (see [documentation](https://webdriver.io/docs/multiremote/#extending-typescript-types)), you can directly access each instance and use `expect` on them.
 
 ```ts
     it('should have title per browsers', async () => {
         await multiRemoteBrowser.url('https://mysite.com')
 
-        await expect(multiRemoteBrowser.myChromeBrowser).toHaveTitle('The Internet')
-        await expect(multiRemoteBrowser.myFirefoxBrowser).toHaveTitle('The Internet')
+        await expect(multiRemoteBrowser.myChromeBrowser).toHaveTitle('My Chrome Site Title')
+        await expect(multiRemoteBrowser.myFirefoxBrowser).toHaveTitle('My Firefox Site Title')
     }) 
 ```
 
+Required configuration:
+
+File `type.d.ts`
+```ts
+declare namespace WebdriverIO {
+    interface MultiRemoteBrowser {
+        myChromeBrowser: WebdriverIO.Browser
+        myFirefoxBrowser: WebdriverIO.Browser
+    }
+}
+```
+
+In `tsconfig.json`
+```json
+{
+  "compilerOptions": {
+    ...
+  },
+  "include": [
+    ...
+    "type.d.ts"
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "ts:jasmine-async": "cd test-types/jasmine-async && tsc --project ./tsconfig.json",
     "checks:all": "npm run build && npm run compile && npm run tsc:root-types && npm run test && npm run ts",
     "watch": "npm run compile -- --watch",
-    "prepare": "husky install",
-    "checks:all": "npm run build && npm run compile && npm run tsc:root-types && npm run test && npm run ts"
+    "prepare": "husky install"
   },
   "dependencies": {
     "@vitest/snapshot": "^4.0.16",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "ts:jasmine-async": "cd test-types/jasmine-async && tsc --project ./tsconfig.json",
     "checks:all": "npm run build && npm run compile && npm run tsc:root-types && npm run test && npm run ts",
     "watch": "npm run compile -- --watch",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "checks:all": "npm run build && npm run compile && npm run tsc:root-types && npm run test && npm run ts"
   },
   "dependencies": {
     "@vitest/snapshot": "^4.0.16",

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -27,8 +27,6 @@ export async function toHaveTitle(
     const { expectation = 'title', verb = 'have', isNot } = this
     const context = { expectation, verb, isNot, isMultiRemote: browser.isMultiremote }
 
-    console.log('toHaveTitle', { expectedValue, isNot, options })
-
     await options.beforeAssertion?.({
         matcherName: 'toHaveTitle',
         expectedValue,

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -52,7 +52,7 @@ export async function toHaveTitle(
     )
 
     const message = browser.isMultiremote
-        ? enhanceMultiRemoteError('window', expectedValue, results, { expectation, verb, isNot }, '', options)
+        ? enhanceMultiRemoteError('window', results, { expectation, verb, isNot }, '', options)
         : enhanceError('window', expectedValue, actual, this, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -35,12 +35,10 @@ export async function toHaveTitle(
         options,
     })
 
-    let actual: string | string[] = ''
-
     const browsers = getInstancesWithExpected(browser, expectedValue)
 
     const conditions = Object.entries(browsers).map(([instance, { browser, expectedValue: expected }]) => async () => {
-        actual = await browser.getTitle()
+        const actual = await browser.getTitle()
 
         const result = compareText(actual, expected as ExpectedValueType, options)
         result.instance = instance

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -1,7 +1,7 @@
-import { compareText, waitUntilResult } from '../../utils.js'
+import { compareText, waitUntilResultSucceed } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { MaybeArray } from '../../util/multiRemoteUtil.js'
-import {  getInstancesWithExpected } from '../../util/multiRemoteUtil.js'
+import {  mapExpectedValueWithInstances } from '../../util/multiRemoteUtil.js'
 import { formatFailureMessage } from '../../util/formatMessage.js'
 
 type ExpectedValueType = string | RegExp | WdioAsymmetricMatcher<string>
@@ -33,17 +33,17 @@ export async function toHaveTitle(
         options,
     })
 
-    const browsers = getInstancesWithExpected(browser, expectedValue)
+    const browsersWithExpected = mapExpectedValueWithInstances(browser, expectedValue)
 
-    const conditions = Object.entries(browsers).map(([instance, { browser, expectedValue: expected }]) => async () => {
+    const conditions = Object.entries(browsersWithExpected).map(([instanceName, { browser, expectedValue: expected }]) => async () => {
         const actual = await browser.getTitle()
 
-        const result = compareText(actual, expected as ExpectedValueType, options)
-        result.instance = instance
+        const result = compareText(actual, expected, options)
+        result.instance = instanceName
         return result
     })
 
-    const conditionsResults = await waitUntilResult(
+    const conditionsResults = await waitUntilResultSucceed(
         conditions,
         isNot,
         options,

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -37,6 +37,7 @@ export async function toHaveTitle(
 
     let actual: string | string[] = ''
     let results: CompareResult<string>[] = []
+    // TODO: dprevost - try to leverage multiple conditions in waitUntil for each remote to not repeat fetch when they succeed.
     const pass = await waitUntil(
         async () => {
             actual = await browser.getTitle()

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -93,7 +93,6 @@ export const enhanceError = (
 
 export const enhanceMultiRemoteError = (
     subject: string | WebdriverIO.Element | WebdriverIO.ElementArray,
-    expected: unknown | unknown[],
     results: CompareResult<unknown>[],
     context: ExpectWebdriverIO.MatcherContext,
     arg2 = '',
@@ -101,8 +100,6 @@ export const enhanceMultiRemoteError = (
 
     const { isNot = false, expectation } = context
     let { verb } = context
-
-    console.log('enhanceMultiRemoteError', { subject, expected, results, isNot, verb, expectation, arg2 })
 
     subject = typeof subject === 'string' ? subject : getSelectors(subject)
 
@@ -119,6 +116,7 @@ export const enhanceMultiRemoteError = (
     let msg = ''
     for (const result of failedResults) {
         const actual = result.value
+        const expected = result.expected
 
         let diffString = isNot && equals(actual, expected)
             ? `${EXPECTED_LABEL}: ${printExpected(expected)}\n${RECEIVED_LABEL}: ${printReceived(actual)}`

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -151,7 +151,7 @@ export const formatFailureMessage = (
         /**
          * Example of below message (multi-remote + isNot case):
          * ```
-         * Expect window to have title for remote "browserA"
+         * Expect window not to have title for remote "browserA"
          *
          * Expected not: "some Title text"
          * Received: "some Wrong Title text"

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -87,13 +87,22 @@ export const enhanceError = (
         arg2 = ` ${arg2}`
     }
 
+    /**
+     * Example of below message:
+     * Expect window to have title
+     *
+     * Expected: "some Title text"
+     * Received: "some Wrong Title text"
+     */
     const msg = `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain}\n\n${diffString}`
     return msg
 }
 
+export type BrowserCompareResult = { instance: string; result: CompareResult<string> }
+
 export const enhanceMultiRemoteError = (
     subject: string | WebdriverIO.Element | WebdriverIO.ElementArray,
-    results: CompareResult<unknown>[],
+    compareResults: BrowserCompareResult[],
     context: ExpectWebdriverIO.MatcherContext,
     arg2 = '',
     { message = '', containing = false }): string => {
@@ -111,12 +120,12 @@ export const enhanceMultiRemoteError = (
     if (verb) {
         verb += ' '
     }
-    const failedResults = results.filter(result => !result.result)
+    const failedResults = compareResults.filter(({ result }) => result.result === isNot)
 
     let msg = ''
-    for (const result of failedResults) {
-        const actual = result.value
-        const expected = result.expected
+    for (const browserResult of failedResults) {
+        const { value: actual, expected } = browserResult.result
+        const instanceName = browserResult.instance
 
         let diffString = isNot && equals(actual, expected)
             ? `${EXPECTED_LABEL}: ${printExpected(expected)}\n${RECEIVED_LABEL}: ${printReceived(actual)}`
@@ -136,7 +145,14 @@ export const enhanceMultiRemoteError = (
             arg2 = ` ${arg2}`
         }
 
-        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain}\n\n${diffString}\n\n`
+        /**
+         * Example of below message:
+         * Expect window to have title
+         *
+         * Expected: "some Title text"
+         * Received: "some Wrong Title text"
+         */
+        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain} for remote "${instanceName}"\n\n${diffString}\n\n`
 
     }
     return msg.trim()

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -102,7 +102,7 @@ export const formatFailureMessage = (
     subject: string | WebdriverIO.Element | WebdriverIO.ElementArray,
     compareResults: CompareResult<string, string | RegExp | WdioAsymmetricMatcher<string>>[],
     context: ExpectWebdriverIO.MatcherContext,
-    arg2 = '',
+    expectedValueArg2 = '',
     { message = '', containing = false }): string => {
 
     const { isNot = false, expectation } = context
@@ -138,8 +138,8 @@ export const formatFailureMessage = (
             message += '\n'
         }
 
-        if (arg2) {
-            arg2 = ` ${arg2}`
+        if (expectedValueArg2) {
+            expectedValueArg2 = ` ${expectedValueArg2}`
         }
 
         const mulitRemoteContext = context.isMultiRemote  ? ` for remote "${instanceName}"` : ''
@@ -154,7 +154,7 @@ export const formatFailureMessage = (
          *
          * ```
          */
-        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain}${mulitRemoteContext}\n\n${diffString}\n\n`
+        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${expectedValueArg2}${contain}${mulitRemoteContext}\n\n${diffString}\n\n`
     }
     return msg.trim()
 }

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -138,10 +138,10 @@ export const enhanceMultiRemoteError = (
             arg2 = ` ${arg2}`
         }
 
-        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain}\n\n${diffString}`
+        msg += `${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${arg2}${contain}\n\n${diffString}\n\n`
 
     }
-    return msg
+    return msg.trim()
 }
 
 export const enhanceErrorBe = (

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -98,6 +98,10 @@ export const enhanceError = (
     return msg
 }
 
+/**
+ * Formats failure message for multiple compare results
+ * TODO multi-remote support: Replace enhanceError with this one everywhere
+ */
 export const formatFailureMessage = (
     subject: string | WebdriverIO.Element | WebdriverIO.ElementArray,
     compareResults: CompareResult<string, string | RegExp | WdioAsymmetricMatcher<string>>[],

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -42,6 +42,8 @@ export const getSelectors = (el: WebdriverIO.Element | WdioElements) => {
 
 const not = (isNot: boolean): string => `${isNot ? 'not ' : ''}`
 
+const startSpace = (word = ''): string | undefined => word ? ` ${word}` : word
+
 export const enhanceError = (
     subject: string | WebdriverIO.Element | WdioElements,
     expected: unknown,
@@ -107,19 +109,12 @@ export const formatFailureMessage = (
     expectedValueArgument2 = '',
     { message = '', containing = false } = {}): string => {
 
-    const { isNot = false, expectation, useNotInLabel = true } = context
-    let { verb } = context
+    const { isNot = false, expectation, useNotInLabel = true, verb } = context
 
     subject = typeof subject === 'string' ? subject : getSelectors(subject)
 
-    let contain = ''
-    if (containing) {
-        contain = ' containing'
-    }
-
-    if (verb) {
-        verb += ' '
-    }
+    const contain = containing ? 'containing' : ''
+    const customMessage = message ? `${message}\n` : ''
 
     const label =  {
         expected: isNot && useNotInLabel ? 'Expected [not]' : 'Expected',
@@ -138,19 +133,12 @@ ${label.expected}: ${printExpected(expected)}
 ${label.received}: ${printReceived(actual)}`
             : printDiffOrStringify(expected, actual, label.expected, label.received, true)
 
-        if (message) {
-            message += '\n'
-        }
-
-        if (expectedValueArgument2) {
-            expectedValueArgument2 = ` ${expectedValueArgument2}`
-        }
-
-        const mulitRemoteContext = context.isMultiRemote  ? ` for remote "${instanceName}"` : ''
+        const mulitRemoteContext = context.isMultiRemote  ? `for remote "${instanceName}"` : ''
 
         /**
-         * Example of below message (multi-remote + isNot case):
+         * Example of below message (custom message + multi-remote + isNot case):
          * ```
+         * My custom error message
          * Expect window not to have title for remote "browserA"
          *
          * Expected not: "some Title text"
@@ -159,7 +147,7 @@ ${label.received}: ${printReceived(actual)}`
          * ```
          */
         msg += `\
-${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${expectedValueArgument2}${contain}${mulitRemoteContext}
+${customMessage}Expect ${subject} ${not(isNot)}to${startSpace(verb)}${startSpace(expectation)}${startSpace(expectedValueArgument2)}${startSpace(contain)}${startSpace(mulitRemoteContext)}
 
 ${diffString}
 

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -1,6 +1,4 @@
 import type { Browser } from 'webdriverio'
-import type { CompareResult } from '../utils'
-import { compareText } from '../utils'
 
 export const toArray = <T>(value: T | T[] | MaybeArray<T>): T[] => (Array.isArray(value) ? value : [value])
 
@@ -8,42 +6,6 @@ export type MaybeArray<T> = T | T[]
 
 export function isArray<T>(value: unknown): value is T[] {
     return Array.isArray(value)
-}
-
-export const compareMultiRemoteText = (
-    actual: MaybeArray<string>,
-    expected: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string>>,
-    options: ExpectWebdriverIO.StringOptions,
-): CompareResult<string>[] => {
-    if (!Array.isArray(actual) && typeof actual !== 'string') {
-        return [{
-            value: actual,
-            result: false,
-            expected
-        }]
-    }
-    if (Array.isArray(expected) && expected.length !== actual.length) {
-        // TODO: review in the future to support partial multi remote comparisons
-        return [{
-            value: `Multi-value length mismatch expected ${expected.length} but got ${actual.length}`,
-            result: false,
-            expected
-        }]
-    }
-
-    const actualArray = toArray(actual)
-
-    // Use array or fill to match actual length when expected is a single value
-    const expectedArray = Array.isArray(expected) ? expected : Array(actualArray.length).fill(expected, 0, actualArray.length)
-
-    const results: CompareResult<string>[] = []
-    for (let i = 0; i < actualArray.length; i++) {
-        const actualText = actualArray[i]
-        const expectedText = expectedArray[i]
-        results.push(compareText(actualText, expectedText, options))
-    }
-
-    return results
 }
 
 export const isMultiremote = (browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser): browser is WebdriverIO.MultiRemoteBrowser => {
@@ -57,7 +19,7 @@ export const getInstancesWithExpected = <T>(browsers: WebdriverIO.Browser | Webd
                 throw new Error(`Expected values length (${expectedValues.length}) does not match number of browser instances (${browsers.instances.length}) in multiremote setup.`)
             }
         }
-        // TODO dprevost add support for object like { default: 'title', browserA: 'titleA', browserB: 'titleB' } later
+        // TODO multi-remote support: add support for object like { default: 'title', browserA: 'titleA', browserB: 'titleB' } later
 
         const browsersWithExpected = browsers.instances.reduce((acc, instance, index) => {
             const browser = browsers.getInstance(instance)
@@ -68,5 +30,6 @@ export const getInstancesWithExpected = <T>(browsers: WebdriverIO.Browser | Webd
         return browsersWithExpected
     }
 
+    // TODO multi-remote support: using default could clash if someone use name default, to review later
     return { default: { browser: browsers, expectedValue: expectedValues } }
 }

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -8,15 +8,15 @@ export function isArray<T>(value: unknown): value is T[] {
     return Array.isArray(value)
 }
 
-export const isMultiremote = (browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser): browser is WebdriverIO.MultiRemoteBrowser => {
+export const isMultiRemote = (browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser): browser is WebdriverIO.MultiRemoteBrowser => {
     return (browser as WebdriverIO.MultiRemoteBrowser).isMultiremote === true
 }
 
 export const getInstancesWithExpected = <T>(browsers: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, expectedValues: T): Record<string, { browser: Browser; expectedValue: T; }>  => {
-    if (isMultiremote(browsers)) {
+    if (isMultiRemote(browsers)) {
         if (Array.isArray(expectedValues)) {
             if (expectedValues.length !== browsers.instances.length) {
-                throw new Error(`Expected values length (${expectedValues.length}) does not match number of browser instances (${browsers.instances.length}) in multiremote setup.`)
+                throw new Error(`Expected values length (${expectedValues.length}) does not match number of browser instances (${browsers.instances.length}) in multi-remote setup.`)
             }
         }
         // TODO multi-remote support: add support for object like { default: 'title', browserA: 'titleA', browserB: 'titleB' } later

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -1,0 +1,42 @@
+import type { CompareResult } from '../utils'
+import { compareText } from '../utils'
+
+export const toArray = <T>(value: T | T[] | MaybeArray<T>): T[] => (Array.isArray(value) ? value : [value])
+
+export type MaybeArray<T> = T | T[]
+
+export function isArray<T>(value: unknown): value is T[] {
+    return Array.isArray(value)
+}
+
+export const compareMultiRemoteText = (
+    actual: MaybeArray<string>,
+    expected: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string>>,
+    options: ExpectWebdriverIO.StringOptions,
+): CompareResult<string>[] => {
+    if (!Array.isArray(actual) && typeof actual !== 'string') {
+        return [{
+            value: actual,
+            result: false,
+        }]
+    }
+    if (Array.isArray(expected) && expected.length !== actual.length) {
+        // TODO: review in the future to support partial multi remote comparisons
+        return [{
+            value: `Multi-value length mismatch expected ${expected.length} but got ${actual.length}`,
+            result: false,
+        }]
+    }
+
+    const actualArray = toArray(actual)
+    const expectedArray = toArray(expected)
+
+    const results: CompareResult<string>[] = []
+    for (let i = 0; i < actualArray.length; i++) {
+        const actualText = actualArray[i]
+        const expectedText = expectedArray[i]
+        results.push(compareText(actualText, expectedText, options))
+    }
+
+    return results
+}

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -1,3 +1,4 @@
+import type { Browser } from 'webdriverio'
 import type { CompareResult } from '../utils'
 import { compareText } from '../utils'
 
@@ -43,4 +44,29 @@ export const compareMultiRemoteText = (
     }
 
     return results
+}
+
+export const isMultiremote = (browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser): browser is WebdriverIO.MultiRemoteBrowser => {
+    return (browser as WebdriverIO.MultiRemoteBrowser).isMultiremote === true
+}
+
+export const getInstancesWithExpected = <T>(browsers: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser, expectedValues: T): Record<string, { browser: Browser; expectedValue: T; }>  => {
+    if (isMultiremote(browsers)) {
+        if (Array.isArray(expectedValues)) {
+            if (expectedValues.length !== browsers.instances.length) {
+                throw new Error(`Expected values length (${expectedValues.length}) does not match number of browser instances (${browsers.instances.length}) in multiremote setup.`)
+            }
+        }
+        // TODO dprevost add support for object like { default: 'title', browserA: 'titleA', browserB: 'titleB' } later
+
+        const browsersWithExpected = browsers.instances.reduce((acc, instance, index) => {
+            const browser = browsers.getInstance(instance)
+            const expectedValue = Array.isArray(expectedValues) ? expectedValues[index] : expectedValues
+            acc[instance] = { browser, expectedValue }
+            return acc
+        }, {} as Record<string,  { browser: WebdriverIO.Browser, expectedValue: T }>)
+        return browsersWithExpected
+    }
+
+    return { default: { browser: browsers, expectedValue: expectedValues } }
 }

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -29,7 +29,9 @@ export const compareMultiRemoteText = (
     }
 
     const actualArray = toArray(actual)
-    const expectedArray = toArray(expected)
+
+    // Use array or fill to match actual length when expected is a single value
+    const expectedArray = Array.isArray(expected) ? expected : Array(actualArray.length).fill(expected, 0, actualArray.length)
 
     const results: CompareResult<string>[] = []
     for (let i = 0; i < actualArray.length; i++) {

--- a/src/util/multiRemoteUtil.ts
+++ b/src/util/multiRemoteUtil.ts
@@ -18,6 +18,7 @@ export const compareMultiRemoteText = (
         return [{
             value: actual,
             result: false,
+            expected
         }]
     }
     if (Array.isArray(expected) && expected.length !== actual.length) {
@@ -25,6 +26,7 @@ export const compareMultiRemoteText = (
         return [{
             value: `Multi-value length mismatch expected ${expected.length} but got ${actual.length}`,
             result: false,
+            expected
         }]
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ const waitUntilResult = async <A = unknown, E = unknown>(
 ): Promise<{ pass: boolean, results: CompareResult<A, E>[] }> => {
     /**
      * Using array algorithm to handle both single and multiple conditions uniformly
-     * Tehcnically this is an o2(n) operation but pratically, we process either a single promise with Array or an Array of promises
+     * Technically, this is an o(n3) operation, but practically, we process either a single promise with Array or an Array of promises. Review later if we can simplify and only have an array of promises
      */
     const conditions = toArray(condition)
     // single attempt
@@ -81,7 +81,7 @@ const waitUntilResult = async <A = unknown, E = unknown>(
         try {
             const pendingConditions = allConditionsResults.filter(({ results }) => !results.every((result) => result.result))
 
-            // TODO dprevost: verify how to handle errors for each condition
+            // TODO multi-remote support: handle errors per remote more gracefully, so we report failures and throws if all remotes are in errors (and therefore still throw when not multi-remote)
             await Promise.all(
                 pendingConditions.map(async (pendingResult) => {
                     const results = toArray(await pendingResult.condition())

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,14 +49,14 @@ function isStringContainingMatcher(expected: unknown): expected is WdioAsymmetri
  * @param isNot     https://jestjs.io/docs/expect#thisisnot
  * @param options   wait, interval, etc
  */
-const waitUntilResult = async <A = unknown, E = unknown>(
+const waitUntilResultSucceed = async <A = unknown, E = unknown>(
     condition: (() => Promise<CompareResult<A, E> | CompareResult<A, E>[]>) | (() => Promise<CompareResult<A, E>>)[],
     isNot = false,
     { wait = DEFAULT_OPTIONS.wait, interval = DEFAULT_OPTIONS.interval } = {},
 ): Promise<{ pass: boolean, results: CompareResult<A, E>[] }> => {
     /**
      * Using array algorithm to handle both single and multiple conditions uniformly
-     * Technically, this is an o(n3) operation, but practically, we process either a single promise with Array or an Array of promises. Review later if we can simplify and only have an array of promises
+     * Technically, this is an o(n3) operation, but practically, we process either a single promise returning Array or an Array of promises. Review later if we can simplify and only have an array of promises
      */
     const conditions = toArray(condition)
     // single attempt
@@ -257,7 +257,7 @@ export const compareText = (
                 expectedValue.toString() === 'StringContaining'
                     ? expect.stringContaining(expectedValue.sample?.toString().toLowerCase())
                     : expect.not.stringContaining(expectedValue.sample?.toString().toLowerCase())
-            ) as WdioAsymmetricMatcher<string>
+            ) satisfies Partial<WdioAsymmetricMatcher<string>> as WdioAsymmetricMatcher<string>
         }
     }
 
@@ -469,7 +469,7 @@ function aliasFn(
 
 export {
     aliasFn, compareNumbers, enhanceError, executeCommand,
-    executeCommandBe, numberError, waitUntil, waitUntilResult, wrapExpectedWithArray
+    executeCommandBe, numberError, waitUntil, waitUntilResultSucceed, wrapExpectedWithArray
 }
 
 function replaceActual(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,22 +20,23 @@ export type CompareResult<A = unknown, E = unknown> = {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const asymmetricMatcher =
-    typeof Symbol === 'function' && Symbol.for ? Symbol.for('jest.asymmetricMatcher') : 0x13_57_a5
+    typeof Symbol === 'function' && Symbol.for
+        ? Symbol.for('jest.asymmetricMatcher')
+        : 0x13_57_a5
 
 export function isAsymmetricMatcher(expected: unknown): expected is WdioAsymmetricMatcher<unknown> {
-    return (typeof expected === 'object' &&
+    return (
+        typeof expected === 'object' &&
         expected &&
         '$$typeof' in expected &&
         'asymmetricMatch' in expected &&
         expected.$$typeof === asymmetricMatcher &&
-        Boolean(expected.asymmetricMatch)) as boolean
+        Boolean(expected.asymmetricMatch)
+    ) as boolean
 }
 
 function isStringContainingMatcher(expected: unknown): expected is WdioAsymmetricMatcher<unknown> {
-    return (
-        isAsymmetricMatcher(expected) &&
-        ['StringContaining', 'StringNotContaining'].includes(expected.toString())
-    )
+    return isAsymmetricMatcher(expected) && ['StringContaining', 'StringNotContaining'].includes(expected.toString())
 }
 
 /**
@@ -169,7 +170,7 @@ const waitUntil = async (
 async function executeCommandBe(
     received: WdioElementMaybePromise,
     command: (el: WebdriverIO.Element) => Promise<boolean>,
-    options: ExpectWebdriverIO.CommandOptions,
+    options: ExpectWebdriverIO.CommandOptions
 ): ExpectWebdriverIO.AsyncAssertionResult {
     const { isNot, expectation, verb = 'be' } = this
 
@@ -180,13 +181,13 @@ async function executeCommandBe(
                 this,
                 el,
                 async (element) => ({ result: await command(element as WebdriverIO.Element) }),
-                options,
+                options
             )
             el = result.el as WebdriverIO.Element
             return result.success
         },
         isNot,
-        options,
+        options
     )
 
     const message = enhanceErrorBe(el, pass, this, verb, expectation, options)
@@ -221,28 +222,18 @@ const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions
     return false
 }
 
-const DEFAULT_STRING_OPTIONS: ExpectWebdriverIO.StringOptions = {
-    ignoreCase: false,
-    trim: true,
-    containing: false,
-    atStart: false,
-    atEnd: false,
-    atIndex: undefined,
-    replace: undefined,
-}
-
 export const compareText = (
     actual: string,
     expected: string | RegExp | WdioAsymmetricMatcher<string>,
     {
-        ignoreCase = DEFAULT_STRING_OPTIONS.ignoreCase,
-        trim = DEFAULT_STRING_OPTIONS.trim,
-        containing = DEFAULT_STRING_OPTIONS.containing,
-        atStart = DEFAULT_STRING_OPTIONS.atStart,
-        atEnd = DEFAULT_STRING_OPTIONS.atEnd,
-        atIndex = DEFAULT_STRING_OPTIONS.atIndex,
-        replace = DEFAULT_STRING_OPTIONS.replace,
-    }: ExpectWebdriverIO.StringOptions,
+        ignoreCase = false,
+        trim = true,
+        containing = false,
+        atStart = false,
+        atEnd = false,
+        atIndex,
+        replace,
+    }: ExpectWebdriverIO.StringOptions
 ): CompareResult<string, string | RegExp | WdioAsymmetricMatcher<string>> => {
     const compareResult: CompareResult<string, string | RegExp | WdioAsymmetricMatcher<string>> = { value: actual, actual, expected, result: false }
     let value = actual
@@ -337,7 +328,7 @@ export const compareTextWithArray = (
         atEnd = false,
         atIndex,
         replace,
-    }: ExpectWebdriverIO.StringOptions,
+    }: ExpectWebdriverIO.StringOptions
 ) => {
     if (typeof actual !== 'string') {
         return {
@@ -421,7 +412,7 @@ export const compareStyle = async (
         atEnd = false,
         atIndex,
         replace,
-    }: ExpectWebdriverIO.StringOptions,
+    }: ExpectWebdriverIO.StringOptions
 ) => {
     let result = true
     const actual: Record<string, string | undefined> = {}
@@ -480,23 +471,16 @@ function aliasFn(
 }
 
 export {
-    aliasFn,
-    compareNumbers,
-    enhanceError,
-    executeCommand,
-    executeCommandBe,
-    numberError,
-    waitUntil,
-    waitUntilResult,
-    wrapExpectedWithArray,
+    aliasFn, compareNumbers, enhanceError, executeCommand,
+    executeCommandBe, numberError, waitUntil, waitUntilResult, wrapExpectedWithArray
 }
 
 function replaceActual(
     replace: [string | RegExp, string | Function] | Array<[string | RegExp, string | Function]>,
-    actual: string,
+    actual: string
 ) {
     const hasMultipleReplacers = (replace as [string | RegExp, string | Function][]).every((r) =>
-        Array.isArray(r),
+        Array.isArray(r)
     )
     const replacers = hasMultipleReplacers
         ? (replace as [string | RegExp, string | Function][])

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -350,11 +350,9 @@ export const compareTextWithArray = (
                 return item.toLowerCase()
             }
             if (isStringContainingMatcher(item)) {
-                return (
-                    item.toString() === 'StringContaining'
-                        ? expect.stringContaining(item.sample?.toString().toLowerCase())
-                        : expect.not.stringContaining(item.sample?.toString().toLowerCase())
-                ) as WdioAsymmetricMatcher<string>
+                return (item.toString() === 'StringContaining'
+                    ? expect.stringContaining(item.sample?.toString().toLowerCase())
+                    : expect.not.stringContaining(item.sample?.toString().toLowerCase())) as WdioAsymmetricMatcher<string>
             }
             return item
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,9 @@ import { wrapExpectedWithArray } from './util/elementsUtil.js'
 import { executeCommand } from './util/executeCommand.js'
 import { enhanceError, enhanceErrorBe, numberError } from './util/formatMessage.js'
 
-export type CompareResult<T = unknown> = {
-    value: T
+export type CompareResult<T = unknown, E = unknown> = {
+    value: T // actual
+    expected: E
     result: boolean
 }
 
@@ -168,6 +169,7 @@ export const compareText = (
         return {
             value: actual,
             result: false,
+            expected,
         }
     }
 
@@ -195,6 +197,7 @@ export const compareText = (
         return {
             value: actual,
             result,
+            expected,
         }
     }
 
@@ -202,12 +205,14 @@ export const compareText = (
         return {
             value: actual,
             result: !!actual.match(expected),
+            expected,
         }
     }
     if (containing) {
         return {
             value: actual,
             result: actual.includes(expected),
+            expected,
         }
     }
 
@@ -215,6 +220,7 @@ export const compareText = (
         return {
             value: actual,
             result: actual.startsWith(expected),
+            expected,
         }
     }
 
@@ -222,6 +228,7 @@ export const compareText = (
         return {
             value: actual,
             result: actual.endsWith(expected),
+            expected,
         }
     }
 
@@ -229,12 +236,14 @@ export const compareText = (
         return {
             value: actual,
             result: actual.substring(atIndex, actual.length).startsWith(expected),
+            expected,
         }
     }
 
     return {
         value: actual,
         result: actual === expected,
+        expected,
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,7 @@ function isStringContainingMatcher(expected: unknown): expected is WdioAsymmetri
  * When using negated condition (isNot=true), we wait for all conditions to be true first, then we negate the real value if it takes time to show up.
  * TODO multi-remote support: replace waitUntil in other matchers with this function
  *
- * @param condition function to that should return true when condition is met
+ * @param condition function(s) that should return compare result(s) when resolved
  * @param isNot     https://jestjs.io/docs/expect#thisisnot
  * @param options   wait, interval, etc
  */
@@ -86,8 +86,7 @@ const waitUntilResult = async <A = unknown, E = unknown>(
             // TODO multi-remote support: handle errors per remote more gracefully, so we report failures and throws if all remotes are in errors (and therefore still throw when not multi-remote)
             await Promise.all(
                 pendingConditions.map(async (pendingResult) => {
-                    const results = toArray(await pendingResult.condition())
-                    pendingResult.results = results
+                    pendingResult.results = toArray(await pendingResult.condition())
                 }),
             )
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import type { WdioElementMaybePromise } from './types.js'
 import { wrapExpectedWithArray } from './util/elementsUtil.js'
 import { executeCommand } from './util/executeCommand.js'
 import { enhanceError, enhanceErrorBe, numberError } from './util/formatMessage.js'
+import { toArray } from './util/multiRemoteUtil.js'
 
 export type CompareResult<A = unknown, E = unknown> = {
     value: A // actual but sometimes modified (e.g. trimmed, lowercased, etc)
@@ -111,19 +112,17 @@ const waitUntilResult = async <A = unknown, E = unknown>(
 
     return { pass, results: allResults }
 }
+
 /**
- * Wait for condition to succeed
- * For multiple remotes, all conditions must be met
- * When using negated condition (isNot=true), we wait for all conditions to be true first, then we negate the real value if it takes time to show up.
- *
- * @param condition function to that should return true when condition is met
+ * wait for expectation to succeed
+ * @param condition function
  * @param isNot     https://jestjs.io/docs/expect#thisisnot
  * @param options   wait, interval, etc
  */
 const waitUntil = async (
     condition: () => Promise<boolean>,
     isNot = false,
-    { wait = DEFAULT_OPTIONS.wait, interval = DEFAULT_OPTIONS.interval } = {},
+    { wait = DEFAULT_OPTIONS.wait, interval = DEFAULT_OPTIONS.interval } = {}
 ): Promise<boolean> => {
     // single attempt
     if (wait === 0) {

--- a/test-types/mocha/types-mocha.test.ts
+++ b/test-types/mocha/types-mocha.test.ts
@@ -162,6 +162,52 @@ describe('type assertions', () => {
             })
         })
 
+        describe('toBeDisplayed', () => {
+            const options: ExpectWebdriverIO.ToBeDisplayedOptions = {
+                withinViewport: true,
+                contentVisibilityAuto: true,
+                opacityProperty: true,
+                wait: 0,
+                visibilityProperty: true,
+                message: 'Custom error message'
+            }
+            it('should be supported correctly', async () => {
+                // Element
+                expectPromiseVoid = expect(element).toBeDisplayed()
+                expectPromiseVoid = expect(element).not.toBeDisplayed()
+                expectPromiseVoid = expect(element).toBeDisplayed(options)
+                expectPromiseVoid = expect(element).not.toBeDisplayed(options)
+
+                // Element array
+                expectPromiseVoid = expect(elementArray).toBeDisplayed()
+                expectPromiseVoid = expect(elementArray).not.toBeDisplayed()
+
+                // Chainable element
+                expectPromiseVoid = expect(chainableElement).toBeDisplayed()
+                expectPromiseVoid = expect(chainableElement).not.toBeDisplayed()
+
+                // Chainable element array
+                expectPromiseVoid = expect(chainableArray).toBeDisplayed()
+                expectPromiseVoid = expect(chainableArray).not.toBeDisplayed()
+
+                // @ts-expect-error
+                expectVoid = expect(element).toBeDisplayed()
+                // @ts-expect-error
+                expectVoid = expect(element).not.toBeDisplayed()
+            })
+
+            it('should have ts errors when actual is not an element', async () => {
+                // @ts-expect-error
+                await expect(browser).toBeDisplayed()
+                // @ts-expect-error
+                await expect(browser).not.toBeDisplayed()
+                // @ts-expect-error
+                await expect(true).toBeDisplayed()
+                // @ts-expect-error
+                await expect(true).not.toBeDisplayed()
+            })
+        })
+
         describe('toHaveText', () => {
             it('should be supported correctly', async () => {
                 expectPromiseVoid = expect(element).toHaveText('text')

--- a/test-types/mocha/types-mocha.test.ts
+++ b/test-types/mocha/types-mocha.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { multiremotebrowser } from '@wdio/globals'
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 
 describe('type assertions', () => {
@@ -10,6 +11,8 @@ describe('type assertions', () => {
     const elements: WebdriverIO.Element[] = [] as unknown as WebdriverIO.Element[]
 
     const networkMock: WebdriverIO.Mock = {} as unknown as WebdriverIO.Mock
+
+    const multiRemoteBrowser: WebdriverIO.MultiRemoteBrowser = multiremotebrowser
 
     // Type assertions
     let expectPromiseVoid: Promise<void>
@@ -53,21 +56,59 @@ describe('type assertions', () => {
         })
 
         describe('toHaveTitle', () => {
-            it('should be supported correctly', async () => {
-                expectPromiseVoid = expect(browser).toHaveTitle('https://example.com')
-                expectPromiseVoid = expect(browser).not.toHaveTitle('https://example.com')
+            describe('Browser', () => {
+                it('should be supported correctly', async () => {
+                    expectPromiseVoid = expect(browser).toHaveTitle('https://example.com')
+                    expectPromiseVoid = expect(browser).not.toHaveTitle('https://example.com')
 
-                // Asymmetric matchers
-                expectPromiseVoid = expect(browser).toHaveTitle(expect.stringContaining('WebdriverIO'))
-                expectPromiseVoid = expect(browser).toHaveTitle(expect.any(String))
-                expectPromiseVoid = expect(browser).toHaveTitle(expect.anything())
+                    // Asymmetric matchers
+                    expectPromiseVoid = expect(browser).toHaveTitle(expect.stringContaining('WebdriverIO'))
+                    expectPromiseVoid = expect(browser).toHaveTitle(expect.any(String))
+                    expectPromiseVoid = expect(browser).toHaveTitle(expect.anything())
 
-                // @ts-expect-error
-                expectVoid = expect(browser).toHaveTitle('https://example.com')
-                // @ts-expect-error
-                expectVoid = expect(browser).not.toHaveTitle('https://example.com')
-                // @ts-expect-error
-                expectVoid = expect(browser).toHaveTitle(expect.stringContaining('WebdriverIO'))
+                    // @ts-expect-error
+                    expectVoid = expect(browser).toHaveTitle('https://example.com')
+                    // @ts-expect-error
+                    expectVoid = expect(browser).not.toHaveTitle('https://example.com')
+                    // @ts-expect-error
+                    expectVoid = expect(browser).toHaveTitle(expect.stringContaining('WebdriverIO'))
+                })
+            })
+
+            describe('Multi-remote Browser', () => {
+                it('should be supported correctly by default', async () => {
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle('https://example.com')
+                    expectPromiseVoid = expect(multiRemoteBrowser).not.toHaveTitle('https://example.com')
+
+                    // Asymmetric matchers
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle(expect.stringContaining('WebdriverIO'))
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle(expect.any(String))
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle(expect.anything())
+
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).toHaveTitle('https://example.com')
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).not.toHaveTitle('https://example.com')
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).toHaveTitle(expect.stringContaining('WebdriverIO'))
+                })
+
+                it('should be supported correctly with multiple expect values', async () => {
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle(['https://example.com', 'https://example.org'])
+                    expectPromiseVoid = expect(multiRemoteBrowser).not.toHaveTitle(['https://example.com', 'https://example.org'])
+
+                    // Asymmetric matchers
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle([expect.stringContaining('WebdriverIO'), expect.stringContaining('Example')])
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle([expect.any(String), expect.any(String)])
+                    expectPromiseVoid = expect(multiRemoteBrowser).toHaveTitle([expect.anything(), expect.anything()])
+
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).toHaveTitle(['https://example.com', 'https://example.org'])
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).not.toHaveTitle(['https://example.com', 'https://example.org'])
+                    // @ts-expect-error
+                    expectVoid = expect(multiRemoteBrowser).toHaveTitle([expect.stringContaining('WebdriverIO'), expect.stringContaining('Example')])
+                })
             })
 
             it('should have ts errors when actual is not a Browser element', async () => {

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -5,6 +5,13 @@ import { toHaveTitle } from '../../../src/matchers/browser/toHaveTitle'
 const beforeAssertion = vi.fn()
 const afterAssertion = vi.fn()
 
+const browserA = { getTitle: vi.fn().mockResolvedValue('browserA Title') } as unknown as WebdriverIO.Browser
+const browserB = { getTitle: vi.fn().mockResolvedValue('browserB Title') } as unknown as WebdriverIO.Browser
+const multiRemoteBrowserInstances: Record<string, WebdriverIO.Browser> = {
+    'browserA':  browserA,
+    'browserB':  browserB,
+}
+
 vi.mock('@wdio/globals', () => ({
     browser: {
         getTitle: vi.fn().mockResolvedValue(''),
@@ -12,6 +19,14 @@ vi.mock('@wdio/globals', () => ({
     multiremotebrowser: {
         isMultiremote: true,
         getTitle: vi.fn().mockResolvedValue(['']),
+        instances: ['browserA'],
+        getInstance: (name: string) => {
+            const instance = multiRemoteBrowserInstances[name]
+            if (!instance) {
+                throw new Error(`No such instance: ${name}`)
+            }
+            return instance
+        }
     }
 }))
 
@@ -124,7 +139,13 @@ Received: "some Wrong Title text"`
             })
         })
 
-        describe('given multiple remote browsers', async () => {
+        describe('Multi Remote Browsers', async () => {
+            beforeEach(async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([goodTitle])
+                multiremotebrowser.instances = ['browserA']
+                browserA.getTitle = vi.fn().mockResolvedValue(goodTitle)
+                browserB.getTitle = vi.fn().mockResolvedValue(goodTitle)
+            })
 
             describe('given one expected value', async () => {
                 const goodTitles = [goodTitle, goodTitle]
@@ -138,41 +159,141 @@ Received: "some Wrong Title text"`
                     expect(result.pass).toBe(true)
                 })
 
-                test('when failure for one browser', async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle])
+                test('when failure', async () => {
+                    browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
                     const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
 
                     expect(result.pass).toBe(false)
-                    expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
                     )
                 })
 
-                test('when failure for multiple browsers', async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
-                    const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+            describe('given multiple remote browsers', async () => {
+                beforeEach(async () => {
+                    multiremotebrowser.instances = ['browserA', 'browserB']
+                    browserA.getTitle = vi.fn().mockResolvedValue(goodTitle)
+                    browserB.getTitle = vi.fn().mockResolvedValue(goodTitle)
+                })
 
                     expect(result.pass).toBe(false)
                     expect(result.message()).toEqual(`Expect window to have title
+
+                    test('when success', async () => {
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                        expect(result.pass).toBe(true)
+                    })
+
+                    test('when failure for browserA', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                        )
+                    })
+
+                    test('when failure for browserB', async () => {
+                        browserB.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title for remote "browserB"
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                        )
+                    })
+
+                    test('when failure for multiple browsers', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
 
 Expected: "some Title text"
 Received: "some Wrong Title text"
 
-Expect window to have title
+Expect window to have title for remote "browserB"
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
-                    )
+                        )
+                    })
+
+                    describe('given before/after assertion hooks and options', async () => {
+                        const options = {
+                            ignoreCase: true,
+                            beforeAssertion,
+                            afterAssertion,
+                        } satisfies ExpectWebdriverIO.StringOptions
+
+                        test('when success', async () => {
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                goodTitle,
+                                options,
+                            )
+                            expect(result.pass).toBe(true)
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: goodTitle,
+                                options,
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: goodTitle,
+                                options,
+                                result,
+                            })
+                        })
+
+                        test('when failure', async () => {
+                            browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                goodTitle,
+                                options,
+                            )
+
+                            expect(result.pass).toBe(false)
+                            expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
+
+Expected: "some title text"
+Received: "some wrong title text"`
+                            )
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: goodTitle,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: goodTitle,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                                result,
+                            })
+                        })
+                    })
                 })
 
-                describe('given before/after assertion hooks and options', async () => {
-                    const options = {
-                        ignoreCase: true,
-                        beforeAssertion,
-                        afterAssertion,
-                    } satisfies ExpectWebdriverIO.StringOptions
+                describe('given multiple expected values', async () => {
+                    const goodTitle2 = `${goodTitle} 2`
+                    // const goodTitles = [goodTitle, goodTitle2]
+                    const expectedValues = [goodTitle, goodTitle2]
+
+                    beforeEach(async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(goodTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(goodTitle2)
+                    })
 
                     test('when success', async () => {
                         const result = await defaultContext.toHaveTitle(
@@ -194,18 +315,83 @@ Received: "some Wrong Title text"`
                         })
                     })
 
-                    test('when failure', async () => {
-                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
-                        const result = await defaultContext.toHaveTitle(
-                            multiremotebrowser,
-                            goodTitle,
-                            options,
-                        )
+                    test('when failure for one browser', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
 
                         expect(result.pass).toBe(false)
-                        expect(result.message()).toEqual(`Expect window to have title
+                        expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                        )
+
+                    test('when failure for multiple browsers', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
+
+Expected: "some Title text"
+Received: "some Wrong Title text"
+
+Expect window to have title for remote "browserB"
+
+Expected: "some Title text 2"
+Received: "some Wrong Title text"`
+                        )
+                    })
+
+                    describe('given before/after assertion hooks and options', async () => {
+                        const options = {
+                            ignoreCase: true,
+                            beforeAssertion,
+                            afterAssertion,
+                        } satisfies ExpectWebdriverIO.StringOptions
+
+                        test('when success', async () => {
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                expectedValues,
+                                options,
+                            )
+                            expect(result.pass).toBe(true)
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: expectedValues,
+                                options,
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: expectedValues,
+                                options,
+                                result,
+                            })
+                        })
+
+                        test('when failure', async () => {
+                            browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                            browserB.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                expectedValues,
+                                options,
+                            )
+
+                            expect(result.pass).toBe(false)
+                            expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
 
 Expected: "some title text"
+Received: "some wrong title text"
+
+Expect window to have title for remote "browserB"
+
+Expected: "some title text 2"
 Received: "some wrong title text"`
                         )
                         expect(beforeAssertion).toBeCalledWith({
@@ -260,10 +446,30 @@ Received: "some Wrong Title text"`
 Expected: "some Title text"
 Received: "some Wrong Title text"
 
-Expect window to have title
+        describe('Multi Remote Browsers', async () => {
+            beforeEach(async () => {
+                browserA.getTitle = vi.fn().mockResolvedValue(aTitle)
+                browserB.getTitle = vi.fn().mockResolvedValue(aTitle)
+                multiremotebrowser.instances = ['browserA']
+            })
 
-Expected: "some Title text 2"
-Received: "some Wrong Title text"`
+            describe('given default usage', async () => {
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser,  negatedExpectedTitle)
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('when failure', async () => {
+                    browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedTitle)
+
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
                     )
                 })
 
@@ -274,41 +480,153 @@ Received: "some Wrong Title text"`
                         afterAssertion,
                     } satisfies ExpectWebdriverIO.StringOptions
 
+                beforeEach(async () => {
+                    multiremotebrowser.instances = ['browserA', 'browserB']
+                })
+
+                describe('given one expected value', async () => {
+
+                    beforeEach(async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(aTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(aTitle)
+                    })
+
                     test('when success', async () => {
-                        const result = await defaultContext.toHaveTitle(
-                            multiremotebrowser,
-                            expectedValues,
-                            options,
-                        )
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedTitle)
+
                         expect(result.pass).toBe(true)
-                        expect(beforeAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: expectedValues,
-                            options,
+                    })
+
+                    test('when failure for one browser', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([negatedExpectedTitle, aTitle])
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedTitle)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
+                        )
+                    })
+
+                    test('when failure for multiple browsers', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedTitle)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"
+
+Expect window not to have title for remote "browserB"
+
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
+                        )
+                    })
+
+                    describe('given before/after assertion hooks and options', async () => {
+                        const options = {
+                            ignoreCase: true,
+                            beforeAssertion,
+                            afterAssertion,
+                        } satisfies ExpectWebdriverIO.StringOptions
+
+                        test('when success', async () => {
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                negatedExpectedTitle,
+                                options,
+                            )
+                            expect(result.pass).toBe(true)
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedTitle,
+                                options,
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedTitle,
+                                options,
+                                result,
+                            })
                         })
-                        expect(afterAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: expectedValues,
-                            options,
-                            result,
+
+                        test('when failure', async () => {
+                            browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                negatedExpectedTitle,
+                                options,
+                            )
+
+                            expect(result.pass).toBe(false)
+                            expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some title text not expected to be"
+Received      : "some title text not expected to be"`
+                            )
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedTitle,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedTitle,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                                result,
+                            })
                         })
                     })
 
-                    test('when failure', async () => {
-                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
-                        const result = await defaultContext.toHaveTitle(
-                            multiremotebrowser,
-                            expectedValues,
-                            options,
-                        )
+                describe('given multiple expected values', async () => {
+                    const aTitle2 = `${aTitle} 2`
+                    const negatedExpectedTitle2 = `${aTitle2} not expected to be`
+                    const negatedExpectedValues = [negatedExpectedTitle, negatedExpectedTitle2]
+
+                    beforeEach(async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(aTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(aTitle2)
+                    })
+
+                    test('when success', async () => {
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedValues)
+
+                        expect(result.pass).toBe(true)
+                    })
+
+                    test('when failure for one browser', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedValues)
 
                         expect(result.pass).toBe(false)
-                        expect(result.message()).toEqual(`Expect window to have title
+                        expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
+                        )
+
+                    test('when failure for multiple browsers', async () => {
+                        browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+                        browserB.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle2)
+
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedValues)
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
 
 Expected: "some title text"
 Received: "some wrong title text"
 
-Expect window to have title
+Expect window not to have title for remote "browserB"
 
 Expected: "some title text 2"
 Received: "some wrong title text"`
@@ -318,11 +636,33 @@ Received: "some wrong title text"`
                             expectedValue: expectedValues,
                             options: { ignoreCase: true, beforeAssertion, afterAssertion },
                         })
-                        expect(afterAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: expectedValues,
-                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
-                            result,
+
+                        test('when failure', async () => {
+                            browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                negatedExpectedValues,
+                                options,
+                            )
+
+                            expect(result.pass).toBe(false)
+                            expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
+
+Expected [not]: "some title text not expected to be"
+Received      : "some title text not expected to be"`
+                            )
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedValues,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedValues,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                                result,
+                            })
                         })
                     })
                 })

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -123,6 +123,49 @@ Received: "some Wrong Title text"`
                 )
             })
         })
+
+        describe('given multiple remote browsers', async () => {
+            const goodTitles = [goodTitle, goodTitle]
+
+            beforeEach(async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
+            })
+
+            test('when success', async () => {
+                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('when failure for one browser', async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle])
+                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                )
+            })
+
+            test('when failure for multiple browsers', async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
+                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"
+
+Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                )
+            })
+        })
         describe('given before/after assertion hooks and options', async () => {
             const options = {
                 ignoreCase: true,

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -1,0 +1,181 @@
+import { vi, test, expect, describe, beforeEach } from 'vitest'
+import { browser, multiremotebrowser } from '@wdio/globals'
+import { toHaveTitle } from '../../../src/matchers/browser/toHaveTitle'
+
+const beforeAssertion = vi.fn()
+const afterAssertion = vi.fn()
+
+vi.mock('@wdio/globals', () => ({
+    browser: {
+        getTitle: vi.fn().mockResolvedValue(''),
+    },
+    multiremotebrowser: {
+        isMultiremote: true,
+        getTitle: vi.fn().mockResolvedValue(['']),
+    }
+}))
+
+describe('toHaveTitle', async () => {
+    const defaultContext = { isNot: false, toHaveTitle }
+    const goodTitle = 'some Title text'
+    const wrongTitle = 'some Wrong Title text'
+
+    beforeEach(async () => {
+        beforeAssertion.mockClear()
+        afterAssertion.mockClear()
+    })
+
+    describe('Browser', async () => {
+        beforeEach(async () => {
+            browser.getTitle = vi.fn().mockResolvedValue(goodTitle)
+        })
+
+        describe('given default usage', async () => {
+            test('when success', async () => {
+                const result = await defaultContext.toHaveTitle(browser, goodTitle)
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('when failure', async () => {
+                browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                const result = await defaultContext.toHaveTitle(browser, goodTitle)
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                )
+            })
+        })
+
+        describe('given before/after assertion hooks and options', async () => {
+            const options = {
+                ignoreCase: true,
+                beforeAssertion,
+                afterAssertion,
+            } satisfies ExpectWebdriverIO.StringOptions
+
+            test('when success', async () => {
+                const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
+
+                expect(result.pass).toBe(true)
+                expect(beforeAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options,
+                })
+                expect(afterAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options,
+                    result,
+                })
+            })
+
+            test('when failure', async () => {
+                browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                )
+                expect(beforeAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                })
+                expect(afterAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    result,
+                })
+            })
+        })
+    })
+
+    describe('Multi Remote Browsers', async () => {
+        beforeEach(async () => {
+            multiremotebrowser.getTitle = vi.fn().mockResolvedValue([goodTitle])
+        })
+
+        describe('given default usage', async () => {
+            test('when success', async () => {
+                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('when failure', async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
+                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"`
+                )
+            })
+        })
+        describe('given before/after assertion hooks and options', async () => {
+            const options = {
+                ignoreCase: true,
+                beforeAssertion,
+                afterAssertion,
+            } satisfies ExpectWebdriverIO.StringOptions
+
+            test('when success', async () => {
+                const result = await defaultContext.toHaveTitle(
+                    multiremotebrowser,
+                    'some Title text',
+                    options,
+                )
+                expect(result.pass).toBe(true)
+                expect(beforeAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: 'some Title text',
+                    options,
+                })
+                expect(afterAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: 'some Title text',
+                    options,
+                    result,
+                })
+            })
+
+            test('when failure', async () => {
+                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
+                const result = await defaultContext.toHaveTitle(
+                    multiremotebrowser,
+                    goodTitle,
+                    options,
+                )
+
+                expect(result.pass).toBe(false)
+                expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some wrong title text"`
+                )
+                expect(beforeAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                })
+                expect(afterAssertion).toBeCalledWith({
+                    matcherName: 'toHaveTitle',
+                    expectedValue: goodTitle,
+                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    result,
+                })
+            })
+        })
+    })
+})

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -267,8 +267,8 @@ Received: "some Wrong Title text"`
                             expect(result.pass).toBe(false)
                             expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
 
-Expected: "some title text"
-Received: "some wrong title text"`
+Expected: "some Title text"
+Received: "some Wrong Title text"`
                             )
                             expect(beforeAssertion).toBeCalledWith({
                                 matcherName: 'toHaveTitle',
@@ -386,18 +386,25 @@ Received: "some Wrong Title text"`
                             expect(result.pass).toBe(false)
                             expect(result.message()).toEqual(`Expect window to have title for remote "browserA"
 
-Expected: "some title text"
-Received: "some wrong title text"
+Expected: "some Title text"
+Received: "some Wrong Title text"
 
 Expect window to have title for remote "browserB"
 
-Expected: "some title text 2"
-Received: "some wrong title text"`
-                        )
-                        expect(beforeAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: goodTitle,
-                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+Expected: "some Title text 2"
+Received: "some Wrong Title text"`
+                            )
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: expectedValues,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: expectedValues,
+                                options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                                result,
+                            })
                         })
                         expect(afterAssertion).toBeCalledWith({
                             matcherName: 'toHaveTitle',
@@ -569,8 +576,8 @@ Received      : "some Title text not expected to be"`
                             expect(result.pass).toBe(false)
                             expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
 
-Expected [not]: "some title text not expected to be"
-Received      : "some title text not expected to be"`
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
                             )
                             expect(beforeAssertion).toBeCalledWith({
                                 matcherName: 'toHaveTitle',
@@ -649,8 +656,8 @@ Received: "some wrong title text"`
                             expect(result.pass).toBe(false)
                             expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
 
-Expected [not]: "some title text not expected to be"
-Received      : "some title text not expected to be"`
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
                             )
                             expect(beforeAssertion).toBeCalledWith({
                                 matcherName: 'toHaveTitle',

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -125,36 +125,37 @@ Received: "some Wrong Title text"`
         })
 
         describe('given multiple remote browsers', async () => {
-            const goodTitles = [goodTitle, goodTitle]
 
-            beforeEach(async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
-            })
+            describe('given one expected value', async () => {
+                const goodTitles = [goodTitle, goodTitle]
+                beforeEach(async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
+                })
 
-            test('when success', async () => {
-                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
 
-                expect(result.pass).toBe(true)
-            })
+                    expect(result.pass).toBe(true)
+                })
 
-            test('when failure for one browser', async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle])
-                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+                test('when failure for one browser', async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle])
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
 
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
-                )
-            })
+                    )
+                })
 
-            test('when failure for multiple browsers', async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
-                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
+                test('when failure for multiple browsers', async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
 
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
 
 Expected: "some Title text"
 Received: "some Wrong Title text"
@@ -163,60 +164,167 @@ Expect window to have title
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
-                )
-            })
-        })
-        describe('given before/after assertion hooks and options', async () => {
-            const options = {
-                ignoreCase: true,
-                beforeAssertion,
-                afterAssertion,
-            } satisfies ExpectWebdriverIO.StringOptions
-
-            test('when success', async () => {
-                const result = await defaultContext.toHaveTitle(
-                    multiremotebrowser,
-                    'some Title text',
-                    options,
-                )
-                expect(result.pass).toBe(true)
-                expect(beforeAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: 'some Title text',
-                    options,
+                    )
                 })
-                expect(afterAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: 'some Title text',
-                    options,
-                    result,
+
+                describe('given before/after assertion hooks and options', async () => {
+                    const options = {
+                        ignoreCase: true,
+                        beforeAssertion,
+                        afterAssertion,
+                    } satisfies ExpectWebdriverIO.StringOptions
+
+                    test('when success', async () => {
+                        const result = await defaultContext.toHaveTitle(
+                            multiremotebrowser,
+                            goodTitle,
+                            options,
+                        )
+                        expect(result.pass).toBe(true)
+                        expect(beforeAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: goodTitle,
+                            options,
+                        })
+                        expect(afterAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: goodTitle,
+                            options,
+                            result,
+                        })
+                    })
+
+                    test('when failure', async () => {
+                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
+                        const result = await defaultContext.toHaveTitle(
+                            multiremotebrowser,
+                            goodTitle,
+                            options,
+                        )
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some title text"
+Received: "some wrong title text"`
+                        )
+                        expect(beforeAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: goodTitle,
+                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                        })
+                        expect(afterAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: goodTitle,
+                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            result,
+                        })
+                    })
                 })
             })
 
-            test('when failure', async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
-                const result = await defaultContext.toHaveTitle(
-                    multiremotebrowser,
-                    goodTitle,
-                    options,
-                )
+            describe('given multiple expected values', async () => {
+                const goodTitle2 = `${goodTitle} 2`
+                const goodTitles = [goodTitle, goodTitle2]
+                const expectedValues = [goodTitle, goodTitle2]
 
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
+                beforeEach(async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
+                })
+
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('when failure for one browser', async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle2])
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
 
 Expected: "some Title text"
-Received: "some wrong title text"`
-                )
-                expect(beforeAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+Received: "some Wrong Title text"`
+                    )
                 })
-                expect(afterAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
-                    result,
+
+                test('when failure for multiple browsers', async () => {
+                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
+                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some Title text"
+Received: "some Wrong Title text"
+
+Expect window to have title
+
+Expected: "some Title text 2"
+Received: "some Wrong Title text"`
+                    )
+                })
+
+                describe('given before/after assertion hooks and options', async () => {
+                    const options = {
+                        ignoreCase: true,
+                        beforeAssertion,
+                        afterAssertion,
+                    } satisfies ExpectWebdriverIO.StringOptions
+
+                    test('when success', async () => {
+                        const result = await defaultContext.toHaveTitle(
+                            multiremotebrowser,
+                            expectedValues,
+                            options,
+                        )
+                        expect(result.pass).toBe(true)
+                        expect(beforeAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: expectedValues,
+                            options,
+                        })
+                        expect(afterAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: expectedValues,
+                            options,
+                            result,
+                        })
+                    })
+
+                    test('when failure', async () => {
+                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
+                        const result = await defaultContext.toHaveTitle(
+                            multiremotebrowser,
+                            expectedValues,
+                            options,
+                        )
+
+                        expect(result.pass).toBe(false)
+                        expect(result.message()).toEqual(`Expect window to have title
+
+Expected: "some title text"
+Received: "some wrong title text"
+
+Expect window to have title
+
+Expected: "some title text 2"
+Received: "some wrong title text"`
+                        )
+                        expect(beforeAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: expectedValues,
+                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                        })
+                        expect(afterAssertion).toBeCalledWith({
+                            matcherName: 'toHaveTitle',
+                            expectedValue: expectedValues,
+                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                            result,
+                        })
+                    })
                 })
             })
         })

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -256,7 +256,6 @@ Received: "some Wrong Title text"`
 
                 describe('given multiple expected values', async () => {
                     const goodTitle2 = `${goodTitle} 2`
-                    // const goodTitles = [goodTitle, goodTitle2]
                     const expectedValues = [goodTitle, goodTitle2]
 
                     beforeEach(async () => {

--- a/test/matchers/browser/toHaveTitle.test.ts
+++ b/test/matchers/browser/toHaveTitle.test.ts
@@ -18,7 +18,6 @@ vi.mock('@wdio/globals', () => ({
     },
     multiremotebrowser: {
         isMultiremote: true,
-        getTitle: vi.fn().mockResolvedValue(['']),
         instances: ['browserA'],
         getInstance: (name: string) => {
             const instance = multiRemoteBrowserInstances[name]
@@ -31,128 +30,98 @@ vi.mock('@wdio/globals', () => ({
 }))
 
 describe('toHaveTitle', async () => {
-    const defaultContext = { isNot: false, toHaveTitle }
-    const goodTitle = 'some Title text'
-    const wrongTitle = 'some Wrong Title text'
+    describe('given isNot false', async () => {
+        const defaultContext = { isNot: false, toHaveTitle }
+        const goodTitle = 'some Title text'
+        const wrongTitle = 'some Wrong Title text'
 
-    beforeEach(async () => {
-        beforeAssertion.mockClear()
-        afterAssertion.mockClear()
-    })
-
-    describe('Browser', async () => {
         beforeEach(async () => {
-            browser.getTitle = vi.fn().mockResolvedValue(goodTitle)
+            beforeAssertion.mockClear()
+            afterAssertion.mockClear()
         })
 
-        describe('given default usage', async () => {
-            test('when success', async () => {
-                const result = await defaultContext.toHaveTitle(browser, goodTitle)
-
-                expect(result.pass).toBe(true)
+        describe('Browser', async () => {
+            beforeEach(async () => {
+                browser.getTitle = vi.fn().mockResolvedValue(goodTitle)
             })
 
-            test('when failure', async () => {
-                browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
-                const result = await defaultContext.toHaveTitle(browser, goodTitle)
+            describe('given default usage', async () => {
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(browser, goodTitle)
 
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.pass).toBe(true)
+                })
+
+                test('when failure', async () => {
+                    browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                    const result = await defaultContext.toHaveTitle(browser, goodTitle)
+
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
-                )
-            })
-        })
-
-        describe('given before/after assertion hooks and options', async () => {
-            const options = {
-                ignoreCase: true,
-                beforeAssertion,
-                afterAssertion,
-            } satisfies ExpectWebdriverIO.StringOptions
-
-            test('when success', async () => {
-                const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
-
-                expect(result.pass).toBe(true)
-                expect(beforeAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options,
-                })
-                expect(afterAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options,
-                    result,
+                    )
                 })
             })
 
-            test('when failure', async () => {
-                browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
-                const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
+            describe('given before/after assertion hooks and options', async () => {
+                const options = {
+                    ignoreCase: true,
+                    beforeAssertion,
+                    afterAssertion,
+                } satisfies ExpectWebdriverIO.StringOptions
 
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
+
+                    expect(result.pass).toBe(true)
+                    expect(beforeAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: goodTitle,
+                        options,
+                    })
+                    expect(afterAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: goodTitle,
+                        options,
+                        result,
+                    })
+                })
+
+                test('when failure', async () => {
+                    browser.getTitle = vi.fn().mockResolvedValue(wrongTitle)
+                    const result = await defaultContext.toHaveTitle(browser, goodTitle, options)
+
+                    expect(result.pass).toBe(false)
+                    expect(result.message()).toEqual(`Expect window to have title
 
 Expected: "some Title text"
 Received: "some Wrong Title text"`
-                )
-                expect(beforeAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    )
+                    expect(beforeAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: goodTitle,
+                        options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    })
+                    expect(afterAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: goodTitle,
+                        options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                        result,
+                    })
                 })
-                expect(afterAssertion).toBeCalledWith({
-                    matcherName: 'toHaveTitle',
-                    expectedValue: goodTitle,
-                    options: { ignoreCase: true, beforeAssertion, afterAssertion },
-                    result,
-                })
-            })
-        })
-    })
-
-    describe('Multi Remote Browsers', async () => {
-        beforeEach(async () => {
-            multiremotebrowser.getTitle = vi.fn().mockResolvedValue([goodTitle])
-        })
-
-        describe('given default usage', async () => {
-            test('when success', async () => {
-                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
-
-                expect(result.pass).toBe(true)
-            })
-
-            test('when failure', async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle])
-                const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
-
-                expect(result.pass).toBe(false)
-                expect(result.message()).toEqual(`Expect window to have title
-
-Expected: "some Title text"
-Received: "some Wrong Title text"`
-                )
             })
         })
 
         describe('Multi Remote Browsers', async () => {
             beforeEach(async () => {
-                multiremotebrowser.getTitle = vi.fn().mockResolvedValue([goodTitle])
                 multiremotebrowser.instances = ['browserA']
                 browserA.getTitle = vi.fn().mockResolvedValue(goodTitle)
                 browserB.getTitle = vi.fn().mockResolvedValue(goodTitle)
             })
 
-            describe('given one expected value', async () => {
-                const goodTitles = [goodTitle, goodTitle]
-                beforeEach(async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
-                })
-
+            describe('given default usage', async () => {
                 test('when success', async () => {
                     const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
 
@@ -170,6 +139,7 @@ Expected: "some Title text"
 Received: "some Wrong Title text"`
                     )
                 })
+            })
 
             describe('given multiple remote browsers', async () => {
                 beforeEach(async () => {
@@ -178,8 +148,7 @@ Received: "some Wrong Title text"`
                     browserB.getTitle = vi.fn().mockResolvedValue(goodTitle)
                 })
 
-                    expect(result.pass).toBe(false)
-                    expect(result.message()).toEqual(`Expect window to have title
+                describe('given one expected value', async () => {
 
                     test('when success', async () => {
                         const result = await defaultContext.toHaveTitle(multiremotebrowser, goodTitle)
@@ -296,23 +265,9 @@ Received: "some Wrong Title text"`
                     })
 
                     test('when success', async () => {
-                        const result = await defaultContext.toHaveTitle(
-                            multiremotebrowser,
-                            goodTitle,
-                            options,
-                        )
+                        const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+
                         expect(result.pass).toBe(true)
-                        expect(beforeAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: goodTitle,
-                            options,
-                        })
-                        expect(afterAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: goodTitle,
-                            options,
-                            result,
-                        })
                     })
 
                     test('when failure for one browser', async () => {
@@ -326,6 +281,7 @@ Received: "some Wrong Title text"`
 Expected: "some Title text"
 Received: "some Wrong Title text"`
                         )
+                    })
 
                     test('when failure for multiple browsers', async () => {
                         browserA.getTitle = vi.fn().mockResolvedValue(wrongTitle)
@@ -406,52 +362,95 @@ Received: "some Wrong Title text"`
                                 result,
                             })
                         })
-                        expect(afterAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: goodTitle,
-                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
-                            result,
-                        })
                     })
                 })
             })
+        })
+    })
 
-            describe('given multiple expected values', async () => {
-                const goodTitle2 = `${goodTitle} 2`
-                const goodTitles = [goodTitle, goodTitle2]
-                const expectedValues = [goodTitle, goodTitle2]
+    describe('given isNot true', async () => {
+        const defaultContext = { isNot: true, toHaveTitle }
+        const aTitle = 'some Title text'
+        const negatedExpectedTitle = 'some Title text not expected to be'
 
-                beforeEach(async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue(goodTitles)
-                })
+        beforeEach(async () => {
+            beforeAssertion.mockClear()
+            afterAssertion.mockClear()
+        })
 
+        describe('Browser', async () => {
+            beforeEach(async () => {
+                browser.getTitle = vi.fn().mockResolvedValue(aTitle)
+            })
+
+            describe('given default usage', async () => {
                 test('when success', async () => {
-                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+                    const result = await defaultContext.toHaveTitle(browser, negatedExpectedTitle)
 
                     expect(result.pass).toBe(true)
                 })
 
-                test('when failure for one browser', async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, goodTitle2])
-                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+                test('when failure', async () => {
+                    browser.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+                    const result = await defaultContext.toHaveTitle(browser, negatedExpectedTitle)
 
                     expect(result.pass).toBe(false)
-                    expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.message()).toEqual(`Expect window not to have title
 
-Expected: "some Title text"
-Received: "some Wrong Title text"`
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
                     )
                 })
+            })
 
-                test('when failure for multiple browsers', async () => {
-                    multiremotebrowser.getTitle = vi.fn().mockResolvedValue([wrongTitle, wrongTitle])
-                    const result = await defaultContext.toHaveTitle(multiremotebrowser, expectedValues)
+            describe('given before/after assertion hooks and options', async () => {
+                const options = {
+                    ignoreCase: true,
+                    beforeAssertion,
+                    afterAssertion,
+                } satisfies ExpectWebdriverIO.StringOptions
+
+                test('when success', async () => {
+                    const result = await defaultContext.toHaveTitle(browser, negatedExpectedTitle, options)
+
+                    expect(result.pass).toBe(true)
+                    expect(beforeAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: negatedExpectedTitle,
+                        options,
+                    })
+                    expect(afterAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: negatedExpectedTitle,
+                        options,
+                        result,
+                    })
+                })
+
+                test('when failure', async () => {
+                    browser.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
+                    const result = await defaultContext.toHaveTitle(browser, negatedExpectedTitle, options)
 
                     expect(result.pass).toBe(false)
-                    expect(result.message()).toEqual(`Expect window to have title
+                    expect(result.message()).toEqual(`Expect window not to have title
 
-Expected: "some Title text"
-Received: "some Wrong Title text"
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"`
+                    )
+                    expect(beforeAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: negatedExpectedTitle,
+                        options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    })
+                    expect(afterAssertion).toBeCalledWith({
+                        matcherName: 'toHaveTitle',
+                        expectedValue: negatedExpectedTitle,
+                        options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                        result,
+                    })
+                })
+            })
+        })
 
         describe('Multi Remote Browsers', async () => {
             beforeEach(async () => {
@@ -479,13 +478,9 @@ Expected [not]: "some Title text not expected to be"
 Received      : "some Title text not expected to be"`
                     )
                 })
+            })
 
-                describe('given before/after assertion hooks and options', async () => {
-                    const options = {
-                        ignoreCase: true,
-                        beforeAssertion,
-                        afterAssertion,
-                    } satisfies ExpectWebdriverIO.StringOptions
+            describe('given multiple remote browsers', async () => {
 
                 beforeEach(async () => {
                     multiremotebrowser.instances = ['browserA', 'browserB']
@@ -507,7 +502,6 @@ Received      : "some Title text not expected to be"`
                     test('when failure for one browser', async () => {
                         browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
 
-                        multiremotebrowser.getTitle = vi.fn().mockResolvedValue([negatedExpectedTitle, aTitle])
                         const result = await defaultContext.toHaveTitle(multiremotebrowser, negatedExpectedTitle)
 
                         expect(result.pass).toBe(false)
@@ -592,6 +586,7 @@ Received      : "some Title text not expected to be"`
                             })
                         })
                     })
+                })
 
                 describe('given multiple expected values', async () => {
                     const aTitle2 = `${aTitle} 2`
@@ -620,6 +615,7 @@ Received      : "some Title text not expected to be"`
 Expected [not]: "some Title text not expected to be"
 Received      : "some Title text not expected to be"`
                         )
+                    })
 
                     test('when failure for multiple browsers', async () => {
                         browserA.getTitle = vi.fn().mockResolvedValue(negatedExpectedTitle)
@@ -630,18 +626,41 @@ Received      : "some Title text not expected to be"`
                         expect(result.pass).toBe(false)
                         expect(result.message()).toEqual(`Expect window not to have title for remote "browserA"
 
-Expected: "some title text"
-Received: "some wrong title text"
+Expected [not]: "some Title text not expected to be"
+Received      : "some Title text not expected to be"
 
 Expect window not to have title for remote "browserB"
 
-Expected: "some title text 2"
-Received: "some wrong title text"`
+Expected [not]: "some Title text 2 not expected to be"
+Received      : "some Title text 2 not expected to be"`
                         )
-                        expect(beforeAssertion).toBeCalledWith({
-                            matcherName: 'toHaveTitle',
-                            expectedValue: expectedValues,
-                            options: { ignoreCase: true, beforeAssertion, afterAssertion },
+                    })
+
+                    describe('given before/after assertion hooks and options', async () => {
+                        const options = {
+                            ignoreCase: true,
+                            beforeAssertion,
+                            afterAssertion,
+                        } satisfies ExpectWebdriverIO.StringOptions
+
+                        test('when success', async () => {
+                            const result = await defaultContext.toHaveTitle(
+                                multiremotebrowser,
+                                negatedExpectedValues,
+                                options,
+                            )
+                            expect(result.pass).toBe(true)
+                            expect(beforeAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedValues,
+                                options,
+                            })
+                            expect(afterAssertion).toBeCalledWith({
+                                matcherName: 'toHaveTitle',
+                                expectedValue: negatedExpectedValues,
+                                options,
+                                result,
+                            })
                         })
 
                         test('when failure', async () => {

--- a/test/matchers/browserMatchers.test.ts
+++ b/test/matchers/browserMatchers.test.ts
@@ -1,12 +1,12 @@
 import { vi, test, describe, expect } from 'vitest'
 import { browser } from '@wdio/globals'
 
-import { getExpectMessage, matcherNameToString, getExpected } from '../__fixtures__/utils.js'
+import { getExpectMessage, getReceived, matcherNameToString, getExpected } from '../__fixtures__/utils.js'
 import * as Matchers from '../../src/matchers.js'
 
 vi.mock('@wdio/globals')
 
-const browserMatchers = ['toHaveUrl', 'toHaveTitle']
+const browserMatchers = ['toHaveUrl']
 
 const validText = ' Valid Text '
 const wrongText = ' Wrong Text '
@@ -106,7 +106,11 @@ describe('browser matchers', () => {
                 }
                 const result = await fn.call({ isNot: true }, browser, validText, { wait: 0 }) as ExpectWebdriverIO.AssertionResult
 
-                expect(result.pass).toBe(true)
+                expect(getExpectMessage(result.message())).toContain('not')
+                expect(getExpected(result.message())).toContain('Valid')
+                expect(getReceived(result.message())).toContain('Wrong')
+
+                expect(result.pass).toBe(false)
             })
 
             test('not - failure (with wait)', async () => {
@@ -127,7 +131,11 @@ describe('browser matchers', () => {
                 }
                 const result = await fn.call({ isNot: true }, browser, validText, { wait: 1 }) as ExpectWebdriverIO.AssertionResult
 
-                expect(result.pass).toBe(true)
+                expect(getExpectMessage(result.message())).toContain('not')
+                expect(getExpected(result.message())).toContain('Valid')
+                expect(getReceived(result.message())).toContain('Wrong')
+
+                expect(result.pass).toBe(false)
             })
 
             test('message', async () => {
@@ -137,4 +145,3 @@ describe('browser matchers', () => {
         })
     })
 })
-

--- a/test/matchers/browserMatchers.test.ts
+++ b/test/matchers/browserMatchers.test.ts
@@ -1,7 +1,7 @@
 import { vi, test, describe, expect } from 'vitest'
 import { browser } from '@wdio/globals'
 
-import { getExpectMessage, getReceived, matcherNameToString, getExpected } from '../__fixtures__/utils.js'
+import { getExpectMessage, matcherNameToString, getExpected } from '../__fixtures__/utils.js'
 import * as Matchers from '../../src/matchers.js'
 
 vi.mock('@wdio/globals')
@@ -106,11 +106,7 @@ describe('browser matchers', () => {
                 }
                 const result = await fn.call({ isNot: true }, browser, validText, { wait: 0 }) as ExpectWebdriverIO.AssertionResult
 
-                expect(getExpectMessage(result.message())).toContain('not')
-                expect(getExpected(result.message())).toContain('Valid')
-                expect(getReceived(result.message())).toContain('Wrong')
-
-                expect(result.pass).toBe(false)
+                expect(result.pass).toBe(true)
             })
 
             test('not - failure (with wait)', async () => {
@@ -131,11 +127,7 @@ describe('browser matchers', () => {
                 }
                 const result = await fn.call({ isNot: true }, browser, validText, { wait: 1 }) as ExpectWebdriverIO.AssertionResult
 
-                expect(getExpectMessage(result.message())).toContain('not')
-                expect(getExpected(result.message())).toContain('Valid')
-                expect(getReceived(result.message())).toContain('Wrong')
-
-                expect(result.pass).toBe(false)
+                expect(result.pass).toBe(true)
             })
 
             test('message', async () => {

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -176,7 +176,8 @@ describe('formatMessage', () => {
     })
     describe(formatFailureMessage, () => {
         const subject = 'window'
-        const expectation = 'have title'
+        const expectation = 'title'
+        const verb = 'have'
         const expectedValueArgument2 = 'myProp'
 
         const baseResult: CompareResult<string, string> = {
@@ -189,7 +190,7 @@ describe('formatMessage', () => {
         const baseContext: ExpectWebdriverIO.MatcherContext = {
             isNot: false,
             expectation,
-            verb: '',
+            verb,
             isMultiRemote: false
         }
 
@@ -200,9 +201,11 @@ describe('formatMessage', () => {
 
                 const message = formatFailureMessage(subject, results, context, '', {})
 
-                expect(message).toMatch('Expect window to have title')
-                const diffString = printDiffOrStringify('expected', 'actual', 'Expected', 'Received', true)
-                expect(message).toMatch(diffString)
+                expect(message).toEqual(`\
+Expect window to have title
+
+Expected: "expected"
+Received: "actual"`)
             })
         })
 
@@ -229,13 +232,16 @@ describe('formatMessage', () => {
 
                 const message = formatFailureMessage(subject, results, context, '', {})
 
-                expect(message).toContain('Expect window to have title for remote "browserA"')
-                const diffString1 = printDiffOrStringify('expected1', 'actual1', 'Expected', 'Received', true)
-                expect(message).toContain(diffString1)
+                expect(message).toEqual(`\
+Expect window to have title for remote "browserA"
 
-                expect(message).toContain('Expect window to have title for remote "browserB"')
-                const diffString2 = printDiffOrStringify('expected2', 'actual2', 'Expected', 'Received', true)
-                expect(message).toContain(diffString2)
+Expected: "expected1"
+Received: "actual1"
+
+Expect window to have title for remote "browserB"
+
+Expected: "expected2"
+Received: "actual2"`)
             })
         })
 
@@ -254,30 +260,51 @@ describe('formatMessage', () => {
 
                 const message = formatFailureMessage(subject, results, context, '', {})
 
-                expect(message).toMatch('Expect window not to have title')
-                const diffString = `Expected [not]: ${printExpected('actual')}\n` +
-                    `Received      : ${printReceived('actual')}`
-                expect(message).toMatch(diffString)
+                expect(message).toEqual(`\
+Expect window not to have title
+
+Expected [not]: "actual"
+Received      : "actual"`)
             })
 
             test('should handle message', () => {
                 const results = [baseResult]
-                const context = { ...baseContext, expectation: 'have property' }
+                const context = { ...baseContext, expectation: 'property' }
 
                 const message = formatFailureMessage('my-element', results, context, expectedValueArgument2, { message: 'Custom Message', containing: false })
 
-                expect(message).toMatch('Custom Message')
-                expect(message).toMatch('Expect my-element to have property myProp')
-                expect(message).not.toContain('containing')
+                expect(message).toEqual(`\
+Custom Message
+Expect my-element to have property myProp
+
+Expected: "expected"
+Received: "actual"`)
             })
 
             test('should handle containing', () => {
                 const results = [baseResult]
-                const context = { ...baseContext, expectation: 'have property' }
+                const context = { ...baseContext, expectation: 'property' }
 
                 const message = formatFailureMessage('my-element', results, context, expectedValueArgument2, { message: '', containing: true })
 
-                expect(message).toMatch('Expect my-element to have property myProp containing')
+                expect(message).toEqual(`\
+Expect my-element to have property myProp containing
+
+Expected: "expected"
+Received: "actual"`)
+            })
+
+            test('should handle no verb', () => {
+                const results = [baseResult]
+                const context = { ...baseContext, expectation: 'exist', verb: '' }
+
+                const message = formatFailureMessage('my-element', results, context)
+
+                expect(message).toEqual(`\
+Expect my-element to exist
+
+Expected: "expected"
+Received: "actual"`)
             })
         })
     })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -1,28 +1,29 @@
 import { test, describe, beforeEach, expect } from 'vitest'
 import { printDiffOrStringify, printExpected, printReceived } from 'jest-matcher-utils'
 
-import { enhanceError, numberError } from '../../src/util/formatMessage.js'
+import { enhanceError, formatFailureMessage, numberError } from '../../src/util/formatMessage.js'
+import type { CompareResult } from '../../src/utils.js'
 
 describe('formatMessage', () => {
-    describe('enhanceError', () => {
+    describe(enhanceError, () => {
         describe('default', () => {
             let actual: string
 
             beforeEach(() => {
                 actual = enhanceError(
-                    'Test Subject',
+                    'window',
                     'Test Expected',
                     'Test Actual',
                     { isNot: false },
-                    'Test Verb',
-                    'Test Expectation',
+                    'have title',
+                    '',
                     '',
                     { message: '', containing: false }
                 )
             })
 
             test('starting message', () => {
-                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation')
+                expect(actual).toMatch('Expect window to have title')
             })
 
             test('diff string', () => {
@@ -37,19 +38,19 @@ describe('formatMessage', () => {
             describe('different', () => {
                 beforeEach(() => {
                     actual = enhanceError(
-                        'Test Subject',
+                        'window',
                         'Test Expected',
                         'Test Actual',
                         { isNot: true },
-                        'Test Verb',
-                        'Test Expectation',
+                        'have title',
+                        '',
                         '',
                         { message: '', containing: false }
                     )
                 })
 
                 test('starting message', () => {
-                    expect(actual).toMatch('Expect Test Subject not to Test Verb Test Expectation')
+                    expect(actual).toMatch('Expect window not to have title')
                 })
 
                 test('diff string', () => {
@@ -61,19 +62,19 @@ describe('formatMessage', () => {
             describe('same', () => {
                 beforeEach(() => {
                     actual = enhanceError(
-                        'Test Subject',
+                        'window',
                         'Test Same',
                         'Test Same',
                         { isNot: true },
-                        'Test Verb',
-                        'Test Expectation',
+                        'have title',
+                        '',
                         '',
                         { message: '', containing: false }
                     )
                 })
 
                 test('starting message', () => {
-                    expect(actual).toMatch('Expect Test Subject not to Test Verb Test Expectation')
+                    expect(actual).toMatch('Expect window not to have title')
                 })
 
                 test('diff string', () => {
@@ -90,19 +91,19 @@ describe('formatMessage', () => {
 
             beforeEach(() => {
                 actual = enhanceError(
-                    'Test Subject',
+                    'window',
                     'Test Expected',
                     'Test Actual',
                     { isNot: false },
-                    'Test Verb',
-                    'Test Expectation',
+                    'have title',
+                    '',
                     '',
                     { message: '', containing: true }
                 )
             })
 
             test('starting message', () => {
-                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation containing')
+                expect(actual).toMatch('Expect window to have title  containing')
             })
 
             test('diff string', () => {
@@ -116,19 +117,19 @@ describe('formatMessage', () => {
 
             beforeEach(() => {
                 actual = enhanceError(
-                    'Test Subject',
+                    'window',
                     'Test Expected',
                     'Test Actual',
                     { isNot: false },
-                    'Test Verb',
-                    'Test Expectation',
+                    'have title',
+                    '',
                     '',
                     { message: 'Test Message', containing: false }
                 )
             })
 
             test('starting message', () => {
-                expect(actual).toMatch('Test Message\nExpect Test Subject to Test Verb Test Expectation')
+                expect(actual).toMatch('Test Message\nExpect window to have title')
             })
 
             test('diff string', () => {
@@ -142,19 +143,19 @@ describe('formatMessage', () => {
 
             beforeEach(() => {
                 actual = enhanceError(
-                    'Test Subject',
+                    'my-element',
                     'Test Expected',
                     'Test Actual',
                     { isNot: false },
-                    'Test Verb',
-                    'Test Expectation',
-                    'Test Arg2',
+                    'have property',
+                    '',
+                    'myProp',
                     { message: 'Test Message', containing: false }
                 )
             })
 
             test('starting message', () => {
-                expect(actual).toMatch('Expect Test Subject to Test Verb Test Expectation Test Arg2')
+                expect(actual).toMatch('Expect my-element to have property  myProp')
             })
 
             test('diff string', () => {
@@ -164,13 +165,120 @@ describe('formatMessage', () => {
         })
     })
 
-    describe('numberError', () => {
+    describe(numberError, () => {
         test('should return correct message', () => {
             expect(numberError()).toBe('no params')
             expect(numberError({ eq: 0 })).toBe(0)
             expect(numberError({ gte: 1 })).toBe('>= 1')
             expect(numberError({ lte: 1 })).toBe(' <= 1')
             expect(numberError({ gte: 2, lte: 1 })).toBe('>= 2 && <= 1')
+        })
+    })
+    describe(formatFailureMessage, () => {
+        const subject = 'window'
+        const expectation = 'have title'
+        const expectedValueArgument2 = 'myProp'
+
+        const baseResult: CompareResult<string, string> = {
+            result: false,
+            actual: 'actual',
+            expected: 'expected',
+            instance: 'browser',
+            value: 'actualValue'
+        }
+        const baseContext: ExpectWebdriverIO.MatcherContext = {
+            isNot: false,
+            expectation,
+            verb: '',
+            isMultiRemote: false
+        }
+
+        describe('Browser (not multi-remote) having single compareResults', () => {
+            test('should return correct message', () => {
+                const results = [baseResult]
+                const context = { ...baseContext }
+
+                const message = formatFailureMessage(subject, results, context, '', {})
+
+                expect(message).toMatch('Expect window to have title')
+                const diffString = printDiffOrStringify('expected', 'actual', 'Expected', 'Received', true)
+                expect(message).toMatch(diffString)
+            })
+        })
+
+        describe('Multi-remote having multiple results', () => {
+            test('should return correct message for multiple failures', () => {
+                const results = [
+                    {
+                        ...baseResult,
+                        actual: 'actual1',
+                        expected: 'expected1',
+                        instance: 'browserA'
+                    },
+                    {
+                        ...baseResult,
+                        actual: 'actual2',
+                        expected: 'expected2',
+                        instance: 'browserB'
+                    }
+                ]
+                const context = {
+                    ...baseContext,
+                    isMultiRemote: true
+                }
+
+                const message = formatFailureMessage(subject, results, context, '', {})
+
+                expect(message).toContain('Expect window to have title for remote "browserA"')
+                const diffString1 = printDiffOrStringify('expected1', 'actual1', 'Expected', 'Received', true)
+                expect(message).toContain(diffString1)
+
+                expect(message).toContain('Expect window to have title for remote "browserB"')
+                const diffString2 = printDiffOrStringify('expected2', 'actual2', 'Expected', 'Received', true)
+                expect(message).toContain(diffString2)
+            })
+        })
+
+        describe('Options', () => {
+            test('should handle isNot', () => {
+                const results = [{
+                    ...baseResult,
+                    result: true,
+                    actual: 'actual',
+                    expected: 'actual'
+                }]
+                const context = {
+                    ...baseContext,
+                    isNot: true
+                }
+
+                const message = formatFailureMessage(subject, results, context, '', {})
+
+                expect(message).toMatch('Expect window not to have title')
+                const diffString = `Expected [not]: ${printExpected('actual')}\n` +
+                    `Received      : ${printReceived('actual')}`
+                expect(message).toMatch(diffString)
+            })
+
+            test('should handle message', () => {
+                const results = [baseResult]
+                const context = { ...baseContext, expectation: 'have property' }
+
+                const message = formatFailureMessage('my-element', results, context, expectedValueArgument2, { message: 'Custom Message', containing: false })
+
+                expect(message).toMatch('Custom Message')
+                expect(message).toMatch('Expect my-element to have property myProp')
+                expect(message).not.toContain('containing')
+            })
+
+            test('should handle containing', () => {
+                const results = [baseResult]
+                const context = { ...baseContext, expectation: 'have property' }
+
+                const message = formatFailureMessage('my-element', results, context, expectedValueArgument2, { message: '', containing: true })
+
+                expect(message).toMatch('Expect my-element to have property myProp containing')
+            })
         })
     })
 })

--- a/test/util/multiRemoteUtil.test.ts
+++ b/test/util/multiRemoteUtil.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { toArray, isArray, isMultiRemote, getInstancesWithExpected } from '../../src/util/multiRemoteUtil.js'
+
+describe('multiRemoteUtil', () => {
+    describe(toArray, () => {
+        it('should return array if input is array', () => {
+            expect(toArray([1, 2])).toEqual([1, 2])
+        })
+
+        it('should return array with single item if input is not array', () => {
+            expect(toArray(1)).toEqual([1])
+        })
+
+        it('should handle edge cases', () => {
+            expect(toArray(undefined)).toEqual([undefined])
+            expect(toArray(null)).toEqual([null])
+            expect(toArray(false)).toEqual([false])
+            expect(toArray(0)).toEqual([0])
+            expect(toArray('')).toEqual([''])
+            expect(toArray({})).toEqual([{}])
+        })
+    })
+
+    describe(isArray, () => {
+        it('should return true if input is array', () => {
+            expect(isArray([1, 2])).toBe(true)
+        })
+
+        it('should return false if input is not array', () => {
+            expect(isArray(1)).toBe(false)
+        })
+    })
+
+    describe(isMultiRemote, () => {
+        it('should return true if browser is multi-remote', () => {
+            const browser = { isMultiremote: true } satisfies Partial<WebdriverIO.MultiRemoteBrowser> as WebdriverIO.MultiRemoteBrowser
+            expect(isMultiRemote(browser)).toBe(true)
+        })
+
+        it('should return false if browser is not multi-remote', () => {
+            const browser = { isMultiremote: false } satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser
+            expect(isMultiRemote(browser)).toBe(false)
+        })
+
+        it('should return false if isMultiremote property is missing', () => {
+            const browser = {} satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser
+            expect(isMultiRemote(browser)).toBe(false)
+        })
+    })
+
+    describe(getInstancesWithExpected, () => {
+        it('should return default instance for single browser', () => {
+            const browser = { isMultiremote: false } satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser
+            const expected = 'expected'
+            const result = getInstancesWithExpected(browser, expected)
+            expect(result).toEqual({
+                default: {
+                    browser,
+                    expectedValue: expected
+                }
+            })
+        })
+
+        describe('Multi-remote', () => {
+            let browser: WebdriverIO.MultiRemoteBrowser
+            let getInstance: ( name: string ) => WebdriverIO.Browser
+
+            beforeEach(() => {
+                getInstance = vi.fn((name) => ({
+                    capabilities: { browserName: name }
+                } satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser))
+                browser = {
+                    isMultiremote: true,
+                    instances: ['browserA', 'browserB'],
+                    getInstance
+                } satisfies Partial<WebdriverIO.MultiRemoteBrowser> as WebdriverIO.MultiRemoteBrowser
+            })
+
+            it('should return instances for multi-remote browser with single expected value', () => {
+                const expected = 'expected'
+                const result = getInstancesWithExpected(browser, expected)
+
+                expect(result).toEqual({
+                    browserA: {
+                        browser: { capabilities: { browserName: 'browserA' } },
+                        expectedValue: expected
+                    },
+                    browserB: {
+                        browser: { capabilities: { browserName: 'browserB' } },
+                        expectedValue: expected
+                    }
+                })
+                expect(getInstance).toHaveBeenCalledWith('browserA')
+                expect(getInstance).toHaveBeenCalledWith('browserB')
+            })
+
+            it('should return instances for multi-remote browser with array of expected values', () => {
+                const expected = ['expectedA', 'expectedB']
+                const result = getInstancesWithExpected(browser, expected)
+
+                expect(result).toEqual({
+                    browserA: {
+                        browser: { capabilities: { browserName: 'browserA' } },
+                        expectedValue: 'expectedA'
+                    },
+                    browserB: {
+                        browser: { capabilities: { browserName: 'browserB' } },
+                        expectedValue: 'expectedB'
+                    }
+                })
+            })
+
+            it('should throw error if expected values length does not match instances length', () => {
+                const expected = ['expectedA']
+                expect(() => getInstancesWithExpected(browser, expected)).toThrow('Expected values length (1) does not match number of browser instances (2) in multi-remote setup.')
+            })
+        })
+    })
+})

--- a/test/util/multiRemoteUtil.test.ts
+++ b/test/util/multiRemoteUtil.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { toArray, isArray, isMultiRemote, getInstancesWithExpected } from '../../src/util/multiRemoteUtil.js'
+import { toArray, isMultiRemote, mapExpectedValueWithInstances } from '../../src/util/multiRemoteUtil.js'
 
 describe('multiRemoteUtil', () => {
     describe(toArray, () => {
@@ -21,16 +21,6 @@ describe('multiRemoteUtil', () => {
         })
     })
 
-    describe(isArray, () => {
-        it('should return true if input is array', () => {
-            expect(isArray([1, 2])).toBe(true)
-        })
-
-        it('should return false if input is not array', () => {
-            expect(isArray(1)).toBe(false)
-        })
-    })
-
     describe(isMultiRemote, () => {
         it('should return true if browser is multi-remote', () => {
             const browser = { isMultiremote: true } satisfies Partial<WebdriverIO.MultiRemoteBrowser> as WebdriverIO.MultiRemoteBrowser
@@ -48,11 +38,11 @@ describe('multiRemoteUtil', () => {
         })
     })
 
-    describe(getInstancesWithExpected, () => {
+    describe(mapExpectedValueWithInstances, () => {
         it('should return default instance for single browser', () => {
             const browser = { isMultiremote: false } satisfies Partial<WebdriverIO.Browser> as WebdriverIO.Browser
             const expected = 'expected'
-            const result = getInstancesWithExpected(browser, expected)
+            const result = mapExpectedValueWithInstances(browser, expected)
             expect(result).toEqual({
                 default: {
                     browser,
@@ -78,7 +68,7 @@ describe('multiRemoteUtil', () => {
 
             it('should return instances for multi-remote browser with single expected value', () => {
                 const expected = 'expected'
-                const result = getInstancesWithExpected(browser, expected)
+                const result = mapExpectedValueWithInstances(browser, expected)
 
                 expect(result).toEqual({
                     browserA: {
@@ -96,7 +86,7 @@ describe('multiRemoteUtil', () => {
 
             it('should return instances for multi-remote browser with array of expected values', () => {
                 const expected = ['expectedA', 'expectedB']
-                const result = getInstancesWithExpected(browser, expected)
+                const result = mapExpectedValueWithInstances(browser, expected)
 
                 expect(result).toEqual({
                     browserA: {
@@ -112,7 +102,7 @@ describe('multiRemoteUtil', () => {
 
             it('should throw error if expected values length does not match instances length', () => {
                 const expected = ['expectedA']
-                expect(() => getInstancesWithExpected(browser, expected)).toThrow('Expected values length (1) does not match number of browser instances (2) in multi-remote setup.')
+                expect(() => mapExpectedValueWithInstances(browser, expected)).toThrow('Expected values length (1) does not match number of browser instances (2) in multi-remote setup.')
             })
         })
     })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -286,145 +286,474 @@ describe('utils', () => {
             throw new Error('Test error')
         }
 
-        describe('given isNot is false', () => {
-            const isNot = false
+        describe('given Browser is not multi-remote and return a single value', () => {
+            describe('given isNot is false', () => {
+                const isNot = false
 
-            test('should return true when condition is met immediately', async () => {
-                const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+                test('should return true when condition is met immediately', async () => {
+                    const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
 
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...trueCompareResult, pass : true }],
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }],
+                    })
                 })
-            })
 
-            test('should return false when condition is not met and wait is 0', async () => {
-                const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+                test('should return false when condition is not met and wait is 0', async () => {
+                    const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
 
-                expect(result).toEqual({
-                    pass: false,
-                    results: [{ ...falseCompareResult, pass: false }],
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }],
+                    })
                 })
-            })
 
-            test('should return true when condition is met within wait time', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    return attempts >= 3 ? trueCompareResult : falseCompareResult
-                }
-
-                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
-
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...trueCompareResult, pass : true }],
-                })
-                expect(attempts).toBeGreaterThanOrEqual(3)
-            })
-
-            test('should return false when condition is not met within wait time', async () => {
-                const result = await waitUntilResult(falseCondition, isNot, { wait: 200, interval: 50 })
-
-                expect(result).toEqual({
-                    pass: false,
-                    results: [{ ...falseCompareResult, pass: false }],
-                })
-            })
-
-            test('should throw error if condition throws and never recovers', async () => {
-                await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
-            })
-
-            test('should recover from errors if condition eventually succeeds', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    if (attempts < 3) {
-                        throw new Error('Not ready yet')
+                test('should return true when condition is met within wait time', async () => {
+                    let attempts = 0
+                    const condition = async () => {
+                        attempts++
+                        return attempts >= 3 ? trueCompareResult : falseCompareResult
                     }
-                    return trueCompareResult
-                }
 
-                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
 
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...trueCompareResult, pass : true }],
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts).toBeGreaterThanOrEqual(3)
                 })
-                expect(attempts).toBe(3)
+
+                test('should return false when condition is not met within wait time', async () => {
+                    const result = await waitUntilResult(falseCondition, isNot, { wait: 200, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should recover from errors if condition eventually succeeds', async () => {
+                    let attempts = 0
+                    const condition = async () => {
+                        attempts++
+                        if (attempts < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCompareResult
+                    }
+
+                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts).toBe(3)
+                })
+
+                test('should use default options when not provided', async () => {
+                    const result = await waitUntilResult(trueCondition)
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }],
+                    })
+                })
             })
 
-            test('should use default options when not provided', async () => {
-                const result = await waitUntilResult(trueCondition)
+            describe('given isNot is true', () => {
+                const isNot = true
 
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...trueCompareResult, pass : true }],
+                test('should handle isNot flag correctly when condition is true', async () => {
+                    const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }],
+                    })
                 })
+
+                test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
+                    const result = await waitUntilResult(trueCondition, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false', async () => {
+                    const result = await waitUntilResult(falseCondition, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
+                    const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should do all the attempts to succeed even with isNot true', async () => {
+                    let attempts = 0
+                    const condition = async () => {
+                        attempts++
+                        if (attempts < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCompareResult
+                    }
+                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }],
+                    })
+                    expect(attempts).toBe(3)
+                })
+
             })
         })
 
-        describe('given isNot is true', () => {
-            const isNot = true
+        describe('given Browser is multi-remote and return an array of value', () => {
+            const trueConditions = async () => {
+                return [{ ...trueCompareResult }, { ...trueCompareResult }]
+            }
+            const falseConditions = async () => {
+                return [{ ...falseCompareResult }, { ...falseCompareResult }]
+            }
+            describe('given isNot is false', () => {
+                const isNot = false
 
-            test('should handle isNot flag correctly when condition is true', async () => {
-                const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+                test('should return true when condition is met immediately', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
 
-                expect(result).toEqual({
-                    pass: false,
-                    results: [{ ...trueCompareResult, pass : false }],
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
                 })
-            })
 
-            test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
-                const result = await waitUntilResult(trueCondition, isNot, { wait: 0 })
+                test('should return false when condition is not met and wait is 0', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
 
-                expect(result).toEqual({
-                    pass: false,
-                    results: [{ ...trueCompareResult, pass : false }],
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }, { ...falseCompareResult, pass: false }],
+                    })
                 })
-            })
 
-            test('should handle isNot flag correctly when condition is false', async () => {
-                const result = await waitUntilResult(falseCondition, isNot, { wait: 1000, interval: 100 })
-
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...falseCompareResult, pass : true }],
-                })
-            })
-
-            test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
-                const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
-
-                expect(result).toEqual({
-                    pass: true,
-                    results: [{ ...falseCompareResult, pass : true }],
-                })
-            })
-
-            test('should throw error if condition throws and never recovers', async () => {
-                await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
-            })
-
-            test('should do all the attempts to succeed even with isNot true', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    if (attempts < 3) {
-                        throw new Error('Not ready yet')
+                test('should return true when condition is met within wait time', async () => {
+                    let attempts = 0
+                    const conditions = async () => {
+                        attempts++
+                        return attempts >= 3 ? trueConditions() : falseConditions()
                     }
-                    return trueCompareResult
-                }
-                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
-                expect(result).toEqual({
-                    pass: false,
-                    results: [{ ...trueCompareResult, pass : false }],
+
+                    const result = await waitUntilResult(conditions, isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts).toBeGreaterThanOrEqual(3)
                 })
-                expect(attempts).toBe(3)
+
+                test('should return false when condition is not met within wait time', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 200, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }, { ...falseCompareResult, pass: false }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should recover from errors if condition eventually succeeds', async () => {
+                    let attempts = 0
+                    const condition = async () => {
+                        attempts++
+                        if (attempts < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueConditions()
+                    }
+
+                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts).toBe(3)
+                })
+
+                test('should use default options when not provided', async () => {
+                    const result = await waitUntilResult(trueConditions)
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                })
             })
 
+            describe('given isNot is true', () => {
+                const isNot = true
+
+                test('should handle isNot flag correctly when condition is true', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }, { ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }, { ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should do all the attempts to succeed even with isNot true', async () => {
+                    let attempts = 0
+                    const conditions = async () => {
+                        attempts++
+                        if (attempts < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueConditions()
+                    }
+                    const result = await waitUntilResult(conditions, isNot, { wait: 1000, interval: 50 })
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                    expect(attempts).toBe(3)
+                })
+
+            })
+        })
+
+        describe('given Browser is multi-remote and we use the list of remotes to fetch each remote value', () => {
+            const trueConditions: (() => Promise<CompareResult>)[] = [
+                trueCondition,
+                trueCondition,
+            ]
+            const falseConditions: (() => Promise<CompareResult>)[] = [
+                falseCondition,
+                falseCondition
+            ]
+            describe('given isNot is false', () => {
+                const isNot = false
+
+                test('should return true when condition is met immediately', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                })
+
+                test('should return false when condition is not met and wait is 0', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }, { ...falseCompareResult, pass: false }],
+                    })
+                })
+
+                test('should return true when condition is met within wait time', async () => {
+                    let attempts1 = 0
+                    const condition1 = async () => {
+                        attempts1++
+                        return attempts1 >= 3 ? trueCondition() : falseCondition()
+                    }
+                    let attempts2 = 0
+                    const condition2 = async () => {
+                        attempts2++
+                        return attempts2 >= 3 ? trueCondition() : falseCondition()
+                    }
+
+                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts1).toBeGreaterThanOrEqual(3)
+                    expect(attempts2).toBeGreaterThanOrEqual(3)
+                })
+
+                test('should return false when condition is not met within wait time', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 200, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...falseCompareResult, pass: false }, { ...falseCompareResult, pass: false }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should recover from errors if condition eventually succeeds', async () => {
+                    let attempts1 = 0
+                    const condition1 = async () => {
+                        attempts1++
+                        if (attempts1 < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCondition()
+                    }
+
+                    let attempts2 = 0
+                    const condition2 = async () => {
+                        attempts2++
+                        if (attempts2 < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCondition()
+                    }
+
+                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                    expect(attempts1).toBe(3)
+                    expect(attempts2).toBe(3)
+                })
+
+                test('should use default options when not provided', async () => {
+                    const result = await waitUntilResult(trueConditions)
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...trueCompareResult, pass : true }, { ...trueCompareResult, pass : true }],
+                    })
+                })
+            })
+
+            describe('given isNot is true', () => {
+                const isNot = true
+
+                test('should handle isNot flag correctly when condition is true', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
+                    const result = await waitUntilResult(trueConditions, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 1000, interval: 100 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }, { ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
+                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+
+                    expect(result).toEqual({
+                        pass: true,
+                        results: [{ ...falseCompareResult, pass : true }, { ...falseCompareResult, pass : true }],
+                    })
+                })
+
+                test('should throw error if condition throws and never recovers', async () => {
+                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                })
+
+                test('should do all the attempts to succeed even with isNot true', async () => {
+                    let attempts1 = 0
+                    const condition1 = async () => {
+                        attempts1++
+                        if (attempts1 < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCondition()
+                    }
+                    let attempts2 = 0
+                    const condition2 = async () => {
+                        attempts2++
+                        if (attempts2 < 3) {
+                            throw new Error('Not ready yet')
+                        }
+                        return trueCondition()
+                    }
+
+                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+
+                    expect(result).toEqual({
+                        pass: false,
+                        results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
+                    })
+                    expect(attempts1).toBe(3)
+                    expect(attempts2).toBe(3)
+                })
+
+            })
         })
     })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import type { CompareResult } from '../src/utils'
-import { compareNumbers, compareObject, compareText, compareTextWithArray, waitUntil, waitUntilResult } from '../src/utils'
+import { compareNumbers, compareObject, compareText, compareTextWithArray, waitUntilResult } from '../src/utils'
 
 describe('utils', () => {
     describe('compareText', () => {
@@ -157,117 +157,6 @@ describe('utils', () => {
         test('should fail if the actual value is a number or array', () => {
             expect(compareObject(10, { 'foo': 'bar' }).result).toBe(false)
             expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).result).toBe(false)
-        })
-    })
-    describe('waitUntil', () => {
-        describe('given isNot is false', () => {
-            const isNot = false
-
-            test('should return true when condition is met immediately', async () => {
-                const condition = async () => true
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
-                expect(result).toBe(true)
-            })
-
-            test('should return false when condition is not met and wait is 0', async () => {
-                const condition = async () => false
-                const result = await waitUntil(condition, isNot, { wait: 0 })
-                expect(result).toBe(false)
-            })
-
-            test('should return true when condition is met within wait time', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    return attempts >= 3
-                }
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
-                expect(result).toBe(true)
-                expect(attempts).toBeGreaterThanOrEqual(3)
-            })
-
-            test('should return false when condition is not met within wait time', async () => {
-                const condition = async () => false
-                const result = await waitUntil(condition, isNot, { wait: 200, interval: 50 })
-                expect(result).toBe(false)
-            })
-
-            test('should throw error if condition throws and never recovers', async () => {
-                const condition = async () => {
-                    throw new Error('Test error')
-                }
-                await expect(waitUntil(condition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
-            })
-
-            test('should recover from errors if condition eventually succeeds', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    if (attempts < 3) {
-                        throw new Error('Not ready yet')
-                    }
-                    return true
-                }
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
-                expect(result).toBe(true)
-                expect(attempts).toBe(3)
-            })
-
-            test('should use default options when not provided', async () => {
-                const condition = async () => true
-                const result = await waitUntil(condition)
-                expect(result).toBe(true)
-            })
-        })
-
-        describe('given isNot is true', () => {
-            const isNot = true
-
-            test('should handle isNot flag correctly when condition is true', async () => {
-                const condition = async () => true
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
-                expect(result).toBe(false)
-            })
-
-            test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
-                const condition = async () => true
-                const result = await waitUntil(condition, isNot, { wait: 0 })
-                expect(result).toBe(false)
-            })
-
-            test('should handle isNot flag correctly when condition is false', async () => {
-                const condition = async () => false
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
-                expect(result).toBe(true)
-            })
-
-            test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
-                const condition = async () => false
-                const result = await waitUntil(condition, isNot, { wait: 0 })
-                expect(result).toBe(true)
-            })
-
-            test('should throw error if condition throws and never recovers', async () => {
-                const condition = async () => {
-                    throw new Error('Test error')
-                }
-                await expect(waitUntil(condition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
-            })
-
-            test('should do all the attempts to succeed even with isNot true', async () => {
-                let attempts = 0
-                const condition = async () => {
-                    attempts++
-                    if (attempts < 3) {
-                        throw new Error('Not ready yet')
-                    }
-                    return true
-                }
-                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
-                expect(result).toBe(false)
-                expect(attempts).toBe(3)
-            })
-
         })
     })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest'
-import { compareNumbers, compareObject, compareText, compareTextWithArray } from '../src/utils.js'
+import type { CompareResult } from '../src/utils'
+import { compareNumbers, compareObject, compareText, compareTextWithArray, waitUntil, waitUntilResult } from '../src/utils'
 
 describe('utils', () => {
     describe('compareText', () => {
@@ -156,6 +157,274 @@ describe('utils', () => {
         test('should fail if the actual value is a number or array', () => {
             expect(compareObject(10, { 'foo': 'bar' }).result).toBe(false)
             expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).result).toBe(false)
+        })
+    })
+    describe('waitUntil', () => {
+        describe('given isNot is false', () => {
+            const isNot = false
+
+            test('should return true when condition is met immediately', async () => {
+                const condition = async () => true
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
+                expect(result).toBe(true)
+            })
+
+            test('should return false when condition is not met and wait is 0', async () => {
+                const condition = async () => false
+                const result = await waitUntil(condition, isNot, { wait: 0 })
+                expect(result).toBe(false)
+            })
+
+            test('should return true when condition is met within wait time', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    return attempts >= 3
+                }
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
+                expect(result).toBe(true)
+                expect(attempts).toBeGreaterThanOrEqual(3)
+            })
+
+            test('should return false when condition is not met within wait time', async () => {
+                const condition = async () => false
+                const result = await waitUntil(condition, isNot, { wait: 200, interval: 50 })
+                expect(result).toBe(false)
+            })
+
+            test('should throw error if condition throws and never recovers', async () => {
+                const condition = async () => {
+                    throw new Error('Test error')
+                }
+                await expect(waitUntil(condition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+            })
+
+            test('should recover from errors if condition eventually succeeds', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    if (attempts < 3) {
+                        throw new Error('Not ready yet')
+                    }
+                    return true
+                }
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
+                expect(result).toBe(true)
+                expect(attempts).toBe(3)
+            })
+
+            test('should use default options when not provided', async () => {
+                const condition = async () => true
+                const result = await waitUntil(condition)
+                expect(result).toBe(true)
+            })
+        })
+
+        describe('given isNot is true', () => {
+            const isNot = true
+
+            test('should handle isNot flag correctly when condition is true', async () => {
+                const condition = async () => true
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
+                expect(result).toBe(false)
+            })
+
+            test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
+                const condition = async () => true
+                const result = await waitUntil(condition, isNot, { wait: 0 })
+                expect(result).toBe(false)
+            })
+
+            test('should handle isNot flag correctly when condition is false', async () => {
+                const condition = async () => false
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
+                expect(result).toBe(true)
+            })
+
+            test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
+                const condition = async () => false
+                const result = await waitUntil(condition, isNot, { wait: 0 })
+                expect(result).toBe(true)
+            })
+
+            test('should throw error if condition throws and never recovers', async () => {
+                const condition = async () => {
+                    throw new Error('Test error')
+                }
+                await expect(waitUntil(condition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+            })
+
+            test('should do all the attempts to succeed even with isNot true', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    if (attempts < 3) {
+                        throw new Error('Not ready yet')
+                    }
+                    return true
+                }
+                const result = await waitUntil(condition, isNot, { wait: 1000, interval: 50 })
+                expect(result).toBe(false)
+                expect(attempts).toBe(3)
+            })
+
+        })
+    })
+
+    describe('waitUntilResult', () => {
+        const trueCompareResult = { value: 'myValue', actual: 'myValue', expected: 'myValue', result: true } satisfies CompareResult<string, string>
+        const falseCompareResult = { value: 'myWrongValue', actual: 'myWrongValue', expected: 'myValue', result: false } satisfies CompareResult<string, string>
+
+        const trueCondition = async () => {
+            return { ...trueCompareResult }
+        }
+        const falseCondition = async () => {
+            return { ...falseCompareResult }
+        }
+
+        const errorCondition = async () => {
+            throw new Error('Test error')
+        }
+
+        describe('given isNot is false', () => {
+            const isNot = false
+
+            test('should return true when condition is met immediately', async () => {
+                const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...trueCompareResult, pass : true }],
+                })
+            })
+
+            test('should return false when condition is not met and wait is 0', async () => {
+                const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+
+                expect(result).toEqual({
+                    pass: false,
+                    results: [{ ...falseCompareResult, pass: false }],
+                })
+            })
+
+            test('should return true when condition is met within wait time', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    return attempts >= 3 ? trueCompareResult : falseCompareResult
+                }
+
+                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...trueCompareResult, pass : true }],
+                })
+                expect(attempts).toBeGreaterThanOrEqual(3)
+            })
+
+            test('should return false when condition is not met within wait time', async () => {
+                const result = await waitUntilResult(falseCondition, isNot, { wait: 200, interval: 50 })
+
+                expect(result).toEqual({
+                    pass: false,
+                    results: [{ ...falseCompareResult, pass: false }],
+                })
+            })
+
+            test('should throw error if condition throws and never recovers', async () => {
+                await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+            })
+
+            test('should recover from errors if condition eventually succeeds', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    if (attempts < 3) {
+                        throw new Error('Not ready yet')
+                    }
+                    return trueCompareResult
+                }
+
+                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...trueCompareResult, pass : true }],
+                })
+                expect(attempts).toBe(3)
+            })
+
+            test('should use default options when not provided', async () => {
+                const result = await waitUntilResult(trueCondition)
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...trueCompareResult, pass : true }],
+                })
+            })
+        })
+
+        describe('given isNot is true', () => {
+            const isNot = true
+
+            test('should handle isNot flag correctly when condition is true', async () => {
+                const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+
+                expect(result).toEqual({
+                    pass: false,
+                    results: [{ ...trueCompareResult, pass : false }],
+                })
+            })
+
+            test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
+                const result = await waitUntilResult(trueCondition, isNot, { wait: 0 })
+
+                expect(result).toEqual({
+                    pass: false,
+                    results: [{ ...trueCompareResult, pass : false }],
+                })
+            })
+
+            test('should handle isNot flag correctly when condition is false', async () => {
+                const result = await waitUntilResult(falseCondition, isNot, { wait: 1000, interval: 100 })
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...falseCompareResult, pass : true }],
+                })
+            })
+
+            test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
+                const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+
+                expect(result).toEqual({
+                    pass: true,
+                    results: [{ ...falseCompareResult, pass : true }],
+                })
+            })
+
+            test('should throw error if condition throws and never recovers', async () => {
+                await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+            })
+
+            test('should do all the attempts to succeed even with isNot true', async () => {
+                let attempts = 0
+                const condition = async () => {
+                    attempts++
+                    if (attempts < 3) {
+                        throw new Error('Not ready yet')
+                    }
+                    return trueCompareResult
+                }
+                const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                expect(result).toEqual({
+                    pass: false,
+                    results: [{ ...trueCompareResult, pass : false }],
+                })
+                expect(attempts).toBe(3)
+            })
+
         })
     })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import type { CompareResult } from '../src/utils'
-import { compareNumbers, compareObject, compareText, compareTextWithArray, waitUntilResult } from '../src/utils'
+import { compareNumbers, compareObject, compareText, compareTextWithArray, waitUntilResultSucceed } from '../src/utils'
 
 describe('utils', () => {
     describe('compareText', () => {
@@ -180,7 +180,7 @@ describe('utils', () => {
                 const isNot = false
 
                 test('should return true when condition is met immediately', async () => {
-                    const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueCondition, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -189,7 +189,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met and wait is 0', async () => {
-                    const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseCondition, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -204,7 +204,7 @@ describe('utils', () => {
                         return attempts >= 3 ? trueCompareResult : falseCompareResult
                     }
 
-                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(condition, isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -214,7 +214,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met within wait time', async () => {
-                    const result = await waitUntilResult(falseCondition, isNot, { wait: 200, interval: 50 })
+                    const result = await waitUntilResultSucceed(falseCondition, isNot, { wait: 200, interval: 50 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -223,7 +223,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should recover from errors if condition eventually succeeds', async () => {
@@ -236,7 +236,7 @@ describe('utils', () => {
                         return trueCompareResult
                     }
 
-                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(condition, isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -246,7 +246,7 @@ describe('utils', () => {
                 })
 
                 test('should use default options when not provided', async () => {
-                    const result = await waitUntilResult(trueCondition)
+                    const result = await waitUntilResultSucceed(trueCondition)
 
                     expect(result).toEqual({
                         pass: true,
@@ -259,7 +259,7 @@ describe('utils', () => {
                 const isNot = true
 
                 test('should handle isNot flag correctly when condition is true', async () => {
-                    const result = await waitUntilResult(trueCondition, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueCondition, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -268,7 +268,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
-                    const result = await waitUntilResult(trueCondition, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(trueCondition, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -277,7 +277,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false', async () => {
-                    const result = await waitUntilResult(falseCondition, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(falseCondition, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -286,7 +286,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
-                    const result = await waitUntilResult(falseCondition, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseCondition, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -295,7 +295,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should do all the attempts to succeed even with isNot true', async () => {
@@ -307,7 +307,7 @@ describe('utils', () => {
                         }
                         return trueCompareResult
                     }
-                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(condition, isNot, { wait: 1000, interval: 50 })
                     expect(result).toEqual({
                         pass: false,
                         results: [{ ...trueCompareResult, pass : false }],
@@ -329,7 +329,7 @@ describe('utils', () => {
                 const isNot = false
 
                 test('should return true when condition is met immediately', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -338,7 +338,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met and wait is 0', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -353,7 +353,7 @@ describe('utils', () => {
                         return attempts >= 3 ? trueConditions() : falseConditions()
                     }
 
-                    const result = await waitUntilResult(conditions, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(conditions, isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -363,7 +363,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met within wait time', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 200, interval: 50 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 200, interval: 50 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -372,7 +372,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should recover from errors if condition eventually succeeds', async () => {
@@ -385,7 +385,7 @@ describe('utils', () => {
                         return trueConditions()
                     }
 
-                    const result = await waitUntilResult(condition, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(condition, isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -395,7 +395,7 @@ describe('utils', () => {
                 })
 
                 test('should use default options when not provided', async () => {
-                    const result = await waitUntilResult(trueConditions)
+                    const result = await waitUntilResultSucceed(trueConditions)
 
                     expect(result).toEqual({
                         pass: true,
@@ -408,7 +408,7 @@ describe('utils', () => {
                 const isNot = true
 
                 test('should handle isNot flag correctly when condition is true', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -417,7 +417,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -426,7 +426,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -435,7 +435,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -444,7 +444,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should do all the attempts to succeed even with isNot true', async () => {
@@ -456,7 +456,7 @@ describe('utils', () => {
                         }
                         return trueConditions()
                     }
-                    const result = await waitUntilResult(conditions, isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed(conditions, isNot, { wait: 1000, interval: 50 })
                     expect(result).toEqual({
                         pass: false,
                         results: [{ ...trueCompareResult, pass : false }, { ...trueCompareResult, pass : false }],
@@ -480,7 +480,7 @@ describe('utils', () => {
                 const isNot = false
 
                 test('should return true when condition is met immediately', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -489,7 +489,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met and wait is 0', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -509,7 +509,7 @@ describe('utils', () => {
                         return attempts2 >= 3 ? trueCondition() : falseCondition()
                     }
 
-                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed([condition1, condition2], isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -520,7 +520,7 @@ describe('utils', () => {
                 })
 
                 test('should return false when condition is not met within wait time', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 200, interval: 50 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 200, interval: 50 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -529,7 +529,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should recover from errors if condition eventually succeeds', async () => {
@@ -551,7 +551,7 @@ describe('utils', () => {
                         return trueCondition()
                     }
 
-                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed([condition1, condition2], isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -562,7 +562,7 @@ describe('utils', () => {
                 })
 
                 test('should use default options when not provided', async () => {
-                    const result = await waitUntilResult(trueConditions)
+                    const result = await waitUntilResultSucceed(trueConditions)
 
                     expect(result).toEqual({
                         pass: true,
@@ -575,7 +575,7 @@ describe('utils', () => {
                 const isNot = true
 
                 test('should handle isNot flag correctly when condition is true', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -584,7 +584,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is true and wait is 0', async () => {
-                    const result = await waitUntilResult(trueConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(trueConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: false,
@@ -593,7 +593,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 1000, interval: 100 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 1000, interval: 100 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -602,7 +602,7 @@ describe('utils', () => {
                 })
 
                 test('should handle isNot flag correctly when condition is false and wait is 0', async () => {
-                    const result = await waitUntilResult(falseConditions, isNot, { wait: 0 })
+                    const result = await waitUntilResultSucceed(falseConditions, isNot, { wait: 0 })
 
                     expect(result).toEqual({
                         pass: true,
@@ -611,7 +611,7 @@ describe('utils', () => {
                 })
 
                 test('should throw error if condition throws and never recovers', async () => {
-                    await expect(waitUntilResult(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
+                    await expect(waitUntilResultSucceed(errorCondition, isNot, { wait: 200, interval: 50 })).rejects.toThrow('Test error')
                 })
 
                 test('should do all the attempts to succeed even with isNot true', async () => {
@@ -632,7 +632,7 @@ describe('utils', () => {
                         return trueCondition()
                     }
 
-                    const result = await waitUntilResult([condition1, condition2], isNot, { wait: 1000, interval: 50 })
+                    const result = await waitUntilResultSucceed([condition1, condition2], isNot, { wait: 1000, interval: 50 })
 
                     expect(result).toEqual({
                         pass: false,

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -662,11 +662,6 @@ declare namespace ExpectWebdriverIO {
 
     interface Matchers<R extends void | Promise<void>, T> extends WdioMatchers<R, T> {}
 
-    // interface MatcherContext extends ExpectLibMatcherContext {
-    //     verb?: string
-    //     expectation?: string
-    // }
-
     interface AsymmetricMatchers extends WdioAsymmetricMatchers {}
 
     interface InverseAsymmetricMatchers extends Omit<

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -621,6 +621,7 @@ declare namespace ExpectWebdriverIO {
         verb?: string
         expectation?: string
         isNot?: boolean
+        isMultiRemote?: boolean
     }
 
     /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -99,26 +99,18 @@ interface WdioBrowserMatchers<_R, ActualT> {
             options?: ExpectWebdriverIO.StringOptions,
         ) => Promise<void>
     >
-    // /**
-    //  * `WebdriverIO.Browser` -> `getTitle`
-    //  */
-    // toHaveTitle: FnWhenBrowser<
-    //     ActualT,
-    //     (
-    //         title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-    //         options?: ExpectWebdriverIO.StringOptions,
-    //     ) => Promise<void>
-    // >
 
     /**
      * `WebdriverIO.Browser`, `WebdriverIO.MultiRemoteBrowser` -> `getTitle`
      */
     toHaveTitle: FnWhenBrowserOrMultiRemote<
         ActualT,
+        // Browser
         (
             title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
             options?: ExpectWebdriverIO.StringOptions,
         ) => Promise<void>,
+        // MultiRemoteBrowser
         (
             url: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions,

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -39,23 +39,12 @@ type ElementArrayPromise = Promise<WebdriverIO.ElementArray>
 /**
  * Only Wdio real promise
  */
-type WdioOnlyPromiseLike =
-    | ElementPromise
-    | ElementArrayPromise
-    | ChainablePromiseElement
-    | ChainablePromiseArray
+type WdioOnlyPromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray
 
 /**
  * Only wdio real promise or potential promise usage on element or element array or browser
  */
-type WdioOnlyMaybePromiseLike =
-    | ElementPromise
-    | ElementArrayPromise
-    | ChainablePromiseElement
-    | ChainablePromiseArray
-    | WebdriverIO.Browser
-    | WebdriverIO.Element
-    | WebdriverIO.ElementArray
+type WdioOnlyMaybePromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray | WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.ElementArray
 
 /**
  * Note we are defining Matchers outside of the namespace as done in jest library until we can make every typing work correctly.
@@ -88,17 +77,11 @@ type FnWhenMock<ActualT, Fn> = ActualT extends MockPromise | WebdriverIO.Mock ? 
  * When asserting on a browser's properties requiring to be awaited, the return type is a Promise.
  * When actual is not a browser, the return type is never, so the function cannot be used.
  */
-interface WdioBrowserMatchers<_R, ActualT> {
+interface WdioBrowserMatchers<_R, ActualT>{
     /**
      * `WebdriverIO.Browser` -> `getUrl`
      */
-    toHaveUrl: FnWhenBrowser<
-        ActualT,
-        (
-            url: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveUrl: FnWhenBrowser<ActualT, (url: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Browser`, `WebdriverIO.MultiRemoteBrowser` -> `getTitle`
@@ -120,13 +103,7 @@ interface WdioBrowserMatchers<_R, ActualT> {
     /**
      * `WebdriverIO.Browser` -> `execute`
      */
-    toHaveClipboardText: FnWhenBrowser<
-        ActualT,
-        (
-            clipboardText: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveClipboardText: FnWhenBrowser<ActualT, (clipboardText: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
 }
 
 /**
@@ -142,24 +119,12 @@ interface WdioNetworkMatchers<_R, ActualT> {
     /**
      * Check that `WebdriverIO.Mock` was called N times
      */
-    toBeRequestedTimes: FnWhenMock<
-        ActualT,
-        (
-            times: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions,
-        ) => Promise<void>
-    >
+    toBeRequestedTimes: FnWhenMock<ActualT, (times: number | ExpectWebdriverIO.NumberOptions, options?: ExpectWebdriverIO.NumberOptions) => Promise<void>>
 
     /**
      * Check that `WebdriverIO.Mock` was called with the specific parameters
      */
-    toBeRequestedWith: FnWhenMock<
-        ActualT,
-        (
-            requestedWith: ExpectWebdriverIO.RequestedWith,
-            options?: ExpectWebdriverIO.CommandOptions,
-        ) => Promise<void>
-    >
+    toBeRequestedWith: FnWhenMock<ActualT, (requestedWith: ExpectWebdriverIO.RequestedWith, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 }
 
 /**
@@ -182,54 +147,37 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     /**
      * `WebdriverIO.Element` -> `isExisting`
      */
-    toBePresent: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBePresent: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isExisting`
      */
-    toBeExisting: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeExisting: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute`
      */
-    toHaveAttribute: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            attribute: string,
-            value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveAttribute: FnWhenElementOrArrayLike<ActualT, (
+        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions)
+    => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute`
      */
-    toHaveAttr: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            attribute: string,
-            value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveAttr: FnWhenElementOrArrayLike<ActualT, (
+        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` class
      * @deprecated since v1.3.1 - use `toHaveElementClass` instead.
      */
-    toHaveClass: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            className: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveClass: FnWhenElementOrArrayLike<ActualT, (
+        className: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` class
@@ -247,145 +195,103 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(element).toHaveElementClass(['btn', 'btn-large']);
      * ```
      */
-    toHaveElementClass: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            className: string | RegExp | Array<string | RegExp> | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveElementClass: FnWhenElementOrArrayLike<ActualT, (
+        className: string | RegExp | Array<string | RegExp> | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getProperty`
      */
-    toHaveElementProperty: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            property: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            value?: unknown,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, (
+        property: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        value?: unknown,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getProperty` value
      */
-    toHaveValue: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveValue: FnWhenElementOrArrayLike<ActualT, (
+        value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isClickable`
      */
-    toBeClickable: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeClickable: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `!isEnabled`
      */
-    toBeDisabled: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeDisabled: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isDisplayedInViewport`
      */
-    toBeDisplayedInViewport: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeDisplayedInViewport: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isEnabled`
      */
-    toBeEnabled: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeEnabled: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isFocused`
      */
-    toBeFocused: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeFocused: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isSelected`
      */
-    toBeSelected: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeSelected: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `isSelected`
      */
-    toBeChecked: FnWhenElementOrArrayLike<
-        ActualT,
-        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toBeChecked: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `$$('./*').length`
      * supports less / greater then or equals to be passed in options
      */
-    toHaveChildren: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            size?: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions,
-        ) => Promise<void>
-    >
+    toHaveChildren: FnWhenElementOrArrayLike<ActualT, (
+        size?: number | ExpectWebdriverIO.NumberOptions,
+        options?: ExpectWebdriverIO.NumberOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` href
      */
-    toHaveHref: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveHref: FnWhenElementOrArrayLike<ActualT, (
+        href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` href
      */
-    toHaveLink: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveLink: FnWhenElementOrArrayLike<ActualT, (
+        href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getProperty` value
      */
-    toHaveId: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            id: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveId: FnWhenElementOrArrayLike<ActualT, (
+        id: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getSize` value
      */
-    toHaveSize: FnWhenElementOrArrayLike<
-        ActualT,
-        (size: { height: number; width: number }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>
-    >
+    toHaveSize: FnWhenElementOrArrayLike<ActualT, (
+        size: { height: number; width: number },
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getText`
@@ -406,66 +312,43 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(elem).toHaveText(['Coffee', 'Tea', 'Milk'])
      * ```
      */
-    toHaveText: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            text:
-                | string
-                | RegExp
-                | ExpectWebdriverIO.PartialMatcher<string>
-                | Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveText: FnWhenElementOrArrayLike<ActualT, (
+        text: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getHTML`
      * Element's html equals the html provided
      */
-    toHaveHTML: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            html: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveHTML: FnWhenElementOrArrayLike<ActualT, (
+        html: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getComputedLabel`
      * Element's computed label equals the computed label provided
      */
-    toHaveComputedLabel: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            computedLabel:
-                | string
-                | RegExp
-                | ExpectWebdriverIO.PartialMatcher<string>
-                | Array<string | RegExp>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveComputedLabel: FnWhenElementOrArrayLike<ActualT, (
+        computedLabel: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getComputedRole`
      * Element's computed role equals the computed role provided
      */
-    toHaveComputedRole: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            computedRole: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+    toHaveComputedRole: FnWhenElementOrArrayLike<ActualT, (
+        computedRole: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getSize('width')`
      * Element's width equals the width provided
      */
-    toHaveWidth: FnWhenElementOrArrayLike<
-        ActualT,
-        (width: number, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
-    >
+    toHaveWidth: FnWhenElementOrArrayLike<ActualT, (width: number, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getSize('height')` or `getSize()`
@@ -480,21 +363,15 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(element).toHaveHeight({ height: 42, width: 42 })
      * ```
      */
-    toHaveHeight: FnWhenElementOrArrayLike<
-        ActualT,
-        (
-            heightOrSize: number | { height: number; width: number },
-            options?: ExpectWebdriverIO.CommandOptions,
-        ) => Promise<void>
-    >
+    toHaveHeight: FnWhenElementOrArrayLike<ActualT, (
+        heightOrSize: number | { height: number; width: number },
+        options?: ExpectWebdriverIO.CommandOptions
+    ) => Promise<void>>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute("style")`
      */
-    toHaveStyle: FnWhenElementOrArrayLike<
-        ActualT,
-        (style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>
-    >
+    toHaveStyle: FnWhenElementOrArrayLike<ActualT, (style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
 }
 
 /**
@@ -508,13 +385,10 @@ interface WdioElementArrayOnlyMatchers<_R, ActualT = unknown> {
      * `WebdriverIO.ElementArray` -> `$$('...').length`
      * supports less / greater then or equals to be passed in options
      */
-    toBeElementsArrayOfSize: FnWhenElementArrayLike<
-        ActualT,
-        (
-            size: number | ExpectWebdriverIO.NumberOptions,
-            options?: ExpectWebdriverIO.NumberOptions,
-        ) => Promise<void> & Promise<WebdriverIO.ElementArray>
-    >
+    toBeElementsArrayOfSize: FnWhenElementArrayLike<ActualT, (
+        size: number | ExpectWebdriverIO.NumberOptions,
+        options?: ExpectWebdriverIO.NumberOptions
+    ) => Promise<void> & Promise<WebdriverIO.ElementArray>>
 }
 
 /**
@@ -530,32 +404,24 @@ interface WdioJestOverloadedMatchers<_R, ActualT> {
      * snapshot matcher
      * @param label optional snapshot label
      */
-    toMatchSnapshot(label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void
+    toMatchSnapshot(label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void;
     /**
      * inline snapshot matcher
      * @param snapshot snapshot string (autogenerated if not specified)
      * @param label optional snapshot label
      */
-    toMatchInlineSnapshot(
-        snapshot?: string,
-        label?: string,
-    ): ActualT extends WdioPromiseLike ? Promise<void> : void
+    toMatchInlineSnapshot(snapshot?: string, label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void;
 }
 
 /**
  * All the specific WebDriverIO only matchers, excluding the generic matchers from the expect library.
  */
-type WdioCustomMatchers<R, ActualT> = WdioJestOverloadedMatchers<R, ActualT> &
-    WdioBrowserMatchers<R, ActualT> &
-    WdioElementOrArrayMatchers<R, ActualT> &
-    WdioElementArrayOnlyMatchers<R, ActualT> &
-    WdioNetworkMatchers<R, ActualT>
+type WdioCustomMatchers<R, ActualT> = WdioJestOverloadedMatchers<R, ActualT> & WdioBrowserMatchers<R, ActualT> & WdioElementOrArrayMatchers<R, ActualT> & WdioElementArrayOnlyMatchers<R, ActualT> & WdioNetworkMatchers<R, ActualT>
 
 /**
  * All the matchers that WebdriverIO Library supports including the generic matchers from the expect library.
  */
-type WdioMatchers<R extends void | Promise<void>, ActualT> = WdioCustomMatchers<R, ActualT> &
-    ExpectLibMatchers<R, ActualT>
+type WdioMatchers<R extends void | Promise<void>, ActualT> = WdioCustomMatchers<R, ActualT> & ExpectLibMatchers<R, ActualT>
 
 /**
  * Expects specific to WebdriverIO, excluding the generic expect matchers.
@@ -567,11 +433,7 @@ interface WdioCustomExpect {
      * All failures are collected and reported at the end of the test
      * Note: Until fixed, soft only support wdio custom matchers, and not the `expect` library matchers. Moreover, it always returns a Promise.
      */
-    soft<T = unknown>(
-        actual: T,
-    ): T extends PromiseLike<unknown>
-        ? ExpectWebdriverIO.MatchersAndInverse<Promise<void>, T> & ExpectWebdriverIO.PromiseMatchers<T>
-        : ExpectWebdriverIO.MatchersAndInverse<void, T>
+    soft<T = unknown>(actual: T): T extends PromiseLike<unknown> ? ExpectWebdriverIO.MatchersAndInverse<Promise<void>, T> & ExpectWebdriverIO.PromiseMatchers<T> : ExpectWebdriverIO.MatchersAndInverse<void, T>;
 
     /**
      * Get all current soft assertion failures
@@ -645,11 +507,7 @@ declare namespace ExpectWebdriverIO {
      * `AsymmetricMatchers` and `Inverse<AsymmetricMatchers>` needs to be defined and be before the `expect` library Expect (aka `WdioExpect`).
      * The above allows to have custom asymmetric matchers under the `ExpectWebdriverIO` namespace.
      */
-    interface Expect
-        extends
-        ExpectWebdriverIO.AsymmetricMatchers,
-        ExpectLibInverse<ExpectWebdriverIO.InverseAsymmetricMatchers>,
-        WdioExpect {
+    interface Expect extends ExpectWebdriverIO.AsymmetricMatchers, ExpectLibInverse<ExpectWebdriverIO.InverseAsymmetricMatchers>, WdioExpect {
         /**
          * The `expect` function is used every time you want to test a value.
          * You will rarely call `expect` by itself.
@@ -662,31 +520,20 @@ declare namespace ExpectWebdriverIO {
          *
          * @param actual The value to apply matchers against.
          */
-        <T = unknown>(
-            actual: T,
-        ): T extends PromiseLike<unknown>
-            ? ExpectWebdriverIO.MatchersAndInverse<void, T> & ExpectWebdriverIO.PromiseMatchers<T>
-            : ExpectWebdriverIO.MatchersAndInverse<void, T>
+        <T = unknown>(actual: T): T extends PromiseLike<unknown> ? ExpectWebdriverIO.MatchersAndInverse<void, T> & ExpectWebdriverIO.PromiseMatchers<T> : ExpectWebdriverIO.MatchersAndInverse<void, T>;
     }
 
     interface Matchers<R extends void | Promise<void>, T> extends WdioMatchers<R, T> {}
 
     interface AsymmetricMatchers extends WdioAsymmetricMatchers {}
 
-    interface InverseAsymmetricMatchers extends Omit<
-        ExpectWebdriverIO.AsymmetricMatchers,
-        'anything' | 'any'
-    > {}
+    interface InverseAsymmetricMatchers extends Omit<ExpectWebdriverIO.AsymmetricMatchers, 'anything' | 'any'> {}
 
     /**
      * End of block overloading types from the expect library.
      */
 
-    type MatchersAndInverse<R extends void | Promise<void>, ActualT> = ExpectWebdriverIO.Matchers<
-        R,
-        ActualT
-    > &
-        ExpectLibInverse<ExpectWebdriverIO.Matchers<R, ActualT>>
+    type MatchersAndInverse<R extends void | Promise<void>, ActualT> = ExpectWebdriverIO.Matchers<R, ActualT> & ExpectLibInverse<ExpectWebdriverIO.Matchers<R, ActualT>>
 
     /**
      * Take from expect library
@@ -742,7 +589,7 @@ declare namespace ExpectWebdriverIO {
         beforeStep(step: PickleStep, scenario: Scenario): void
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         afterTest(test: Test, context: any, result: TestResult): void
-        afterStep(step: PickleStep, scenario: Scenario, result: { passed: boolean; error?: Error }): void
+        afterStep(step: PickleStep, scenario: Scenario, result: { passed: boolean, error?: Error }): void
     }
 
     interface AssertionResult extends ExpectLibSyncExpectationResult {}
@@ -759,7 +606,7 @@ declare namespace ExpectWebdriverIO {
         /**
          * name of the matcher, e.g. `toHaveText` or `toBeClickable`
          */
-        matcherName: keyof Matchers<void, unknown>
+        matcherName: keyof Matchers<void, unknown>,
         /**
          * Value that the user has passed in
          *
@@ -771,7 +618,7 @@ declare namespace ExpectWebdriverIO {
          * ```
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expectedValue?: any
+        expectedValue?: any,
         /**
          * Options that the user has passed in, e.g. `expect(el).toHaveText('foo', { ignoreCase: true })` -> `{ ignoreCase: true }`
          */

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -21,6 +21,8 @@ type ExpectLibAsyncExpectationResult = import('expect').AsyncExpectationResult
 type ExpectLibExpectationResult = import('expect').ExpectationResult
 type ExpectLibMatcherContext = import('expect').MatcherContext
 
+type MaybeArray<T> = T | T[]
+
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,6 +74,7 @@ type MockPromise = Promise<WebdriverIO.Mock>
  * Type helpers allowing to use the function when the expect(actual: T) is of the expected type T.
  */
 type FnWhenBrowser<ActualT, Fn> = ActualT extends WebdriverIO.Browser ? Fn : never
+type FnWhenBrowserOrMultiRemote<ActualT, FnBrowser, FnMultiRemote> = ActualT extends WebdriverIO.Browser ? FnBrowser : ActualT extends WebdriverIO.MultiRemoteBrowser ? FnMultiRemote : never
 type FnWhenElementOrArrayLike<ActualT, Fn> = ActualT extends ElementOrArrayLike ? Fn : never
 type FnWhenElementArrayLike<ActualT, Fn> = ActualT extends ElementArrayLike ? Fn : never
 
@@ -81,7 +84,7 @@ type FnWhenElementArrayLike<ActualT, Fn> = ActualT extends ElementArrayLike ? Fn
 type FnWhenMock<ActualT, Fn> = ActualT extends MockPromise | WebdriverIO.Mock ? Fn : never
 
 /**
- * Matchers dedicated to Wdio Browser.
+ * Matchers dedicated to Wdio Browser or MultiRemoteBrowser.
  * When asserting on a browser's properties requiring to be awaited, the return type is a Promise.
  * When actual is not a browser, the return type is never, so the function cannot be used.
  */
@@ -96,16 +99,30 @@ interface WdioBrowserMatchers<_R, ActualT> {
             options?: ExpectWebdriverIO.StringOptions,
         ) => Promise<void>
     >
+    // /**
+    //  * `WebdriverIO.Browser` -> `getTitle`
+    //  */
+    // toHaveTitle: FnWhenBrowser<
+    //     ActualT,
+    //     (
+    //         title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+    //         options?: ExpectWebdriverIO.StringOptions,
+    //     ) => Promise<void>
+    // >
 
     /**
-     * `WebdriverIO.Browser` -> `getTitle`
+     * `WebdriverIO.Browser`, `WebdriverIO.MultiRemoteBrowser` -> `getTitle`
      */
-    toHaveTitle: FnWhenBrowser<
+    toHaveTitle: FnWhenBrowserOrMultiRemote<
         ActualT,
         (
             title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
             options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
+        ) => Promise<void>,
+        (
+            url: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>,
     >
 
     /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -122,7 +122,7 @@ interface WdioBrowserMatchers<_R, ActualT> {
         (
             url: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>,
+        ) => Promise<void>
     >
 
     /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports*/
-type ServiceInstance =  import('@wdio/types').Services.ServiceInstance
+type ServiceInstance = import('@wdio/types').Services.ServiceInstance
 type Test = import('@wdio/types').Frameworks.Test
 type TestResult = import('@wdio/types').Frameworks.TestResult
 type PickleStep = import('@wdio/types').Frameworks.PickleStep
@@ -24,7 +24,7 @@ type ExpectLibMatcherContext = import('expect').MatcherContext
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (this: Context, actual: any, ...expected: Array<any>): ExpectLibExpectationResult;
+    (this: Context, actual: any, ...expected: Array<any>): ExpectLibExpectationResult
 }
 
 /**
@@ -37,12 +37,23 @@ type ElementArrayPromise = Promise<WebdriverIO.ElementArray>
 /**
  * Only Wdio real promise
  */
-type WdioOnlyPromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray
+type WdioOnlyPromiseLike =
+    | ElementPromise
+    | ElementArrayPromise
+    | ChainablePromiseElement
+    | ChainablePromiseArray
 
 /**
  * Only wdio real promise or potential promise usage on element or element array or browser
  */
-type WdioOnlyMaybePromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray | WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.ElementArray
+type WdioOnlyMaybePromiseLike =
+    | ElementPromise
+    | ElementArrayPromise
+    | ChainablePromiseElement
+    | ChainablePromiseArray
+    | WebdriverIO.Browser
+    | WebdriverIO.Element
+    | WebdriverIO.ElementArray
 
 /**
  * Note we are defining Matchers outside of the namespace as done in jest library until we can make every typing work correctly.
@@ -74,21 +85,39 @@ type FnWhenMock<ActualT, Fn> = ActualT extends MockPromise | WebdriverIO.Mock ? 
  * When asserting on a browser's properties requiring to be awaited, the return type is a Promise.
  * When actual is not a browser, the return type is never, so the function cannot be used.
  */
-interface WdioBrowserMatchers<_R, ActualT>{
+interface WdioBrowserMatchers<_R, ActualT> {
     /**
      * `WebdriverIO.Browser` -> `getUrl`
      */
-    toHaveUrl: FnWhenBrowser<ActualT, (url: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
+    toHaveUrl: FnWhenBrowser<
+        ActualT,
+        (
+            url: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Browser` -> `getTitle`
      */
-    toHaveTitle: FnWhenBrowser<ActualT, (title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
+    toHaveTitle: FnWhenBrowser<
+        ActualT,
+        (
+            title: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Browser` -> `execute`
      */
-    toHaveClipboardText: FnWhenBrowser<ActualT, (clipboardText: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
+    toHaveClipboardText: FnWhenBrowser<
+        ActualT,
+        (
+            clipboardText: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 }
 
 /**
@@ -104,12 +133,24 @@ interface WdioNetworkMatchers<_R, ActualT> {
     /**
      * Check that `WebdriverIO.Mock` was called N times
      */
-    toBeRequestedTimes: FnWhenMock<ActualT, (times: number | ExpectWebdriverIO.NumberOptions, options?: ExpectWebdriverIO.NumberOptions) => Promise<void>>
+    toBeRequestedTimes: FnWhenMock<
+        ActualT,
+        (
+            times: number | ExpectWebdriverIO.NumberOptions,
+            options?: ExpectWebdriverIO.NumberOptions,
+        ) => Promise<void>
+    >
 
     /**
      * Check that `WebdriverIO.Mock` was called with the specific parameters
      */
-    toBeRequestedWith: FnWhenMock<ActualT, (requestedWith: ExpectWebdriverIO.RequestedWith, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeRequestedWith: FnWhenMock<
+        ActualT,
+        (
+            requestedWith: ExpectWebdriverIO.RequestedWith,
+            options?: ExpectWebdriverIO.CommandOptions,
+        ) => Promise<void>
+    >
 }
 
 /**
@@ -132,37 +173,54 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     /**
      * `WebdriverIO.Element` -> `isExisting`
      */
-    toBePresent: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBePresent: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isExisting`
      */
-    toBeExisting: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeExisting: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute`
      */
-    toHaveAttribute: FnWhenElementOrArrayLike<ActualT, (
-        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions)
-    => Promise<void>>
+    toHaveAttribute: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            attribute: string,
+            value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute`
      */
-    toHaveAttr: FnWhenElementOrArrayLike<ActualT, (
-        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveAttr: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            attribute: string,
+            value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` class
      * @deprecated since v1.3.1 - use `toHaveElementClass` instead.
      */
-    toHaveClass: FnWhenElementOrArrayLike<ActualT, (
-        className: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveClass: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            className: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` class
@@ -180,103 +238,145 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(element).toHaveElementClass(['btn', 'btn-large']);
      * ```
      */
-    toHaveElementClass: FnWhenElementOrArrayLike<ActualT, (
-        className: string | RegExp | Array<string | RegExp> | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveElementClass: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            className: string | RegExp | Array<string | RegExp> | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getProperty`
      */
-    toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, (
-        property: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        value?: unknown,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveElementProperty: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            property: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            value?: unknown,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getProperty` value
      */
-    toHaveValue: FnWhenElementOrArrayLike<ActualT, (
-        value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveValue: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isClickable`
      */
-    toBeClickable: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeClickable: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `!isEnabled`
      */
-    toBeDisabled: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeDisabled: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isDisplayedInViewport`
      */
-    toBeDisplayedInViewport: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeDisplayedInViewport: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isEnabled`
      */
-    toBeEnabled: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeEnabled: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isFocused`
      */
-    toBeFocused: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeFocused: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isSelected`
      */
-    toBeSelected: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeSelected: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `isSelected`
      */
-    toBeChecked: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toBeChecked: FnWhenElementOrArrayLike<
+        ActualT,
+        (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `$$('./*').length`
      * supports less / greater then or equals to be passed in options
      */
-    toHaveChildren: FnWhenElementOrArrayLike<ActualT, (
-        size?: number | ExpectWebdriverIO.NumberOptions,
-        options?: ExpectWebdriverIO.NumberOptions
-    ) => Promise<void>>
+    toHaveChildren: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            size?: number | ExpectWebdriverIO.NumberOptions,
+            options?: ExpectWebdriverIO.NumberOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` href
      */
-    toHaveHref: FnWhenElementOrArrayLike<ActualT, (
-        href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveHref: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` href
      */
-    toHaveLink: FnWhenElementOrArrayLike<ActualT, (
-        href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveLink: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getProperty` value
      */
-    toHaveId: FnWhenElementOrArrayLike<ActualT, (
-        id: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveId: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            id: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getSize` value
      */
-    toHaveSize: FnWhenElementOrArrayLike<ActualT, (
-        size: { height: number; width: number },
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveSize: FnWhenElementOrArrayLike<
+        ActualT,
+        (size: { height: number; width: number }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getText`
@@ -297,43 +397,66 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(elem).toHaveText(['Coffee', 'Tea', 'Milk'])
      * ```
      */
-    toHaveText: FnWhenElementOrArrayLike<ActualT, (
-        text: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveText: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            text:
+                | string
+                | RegExp
+                | ExpectWebdriverIO.PartialMatcher<string>
+                | Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getHTML`
      * Element's html equals the html provided
      */
-    toHaveHTML: FnWhenElementOrArrayLike<ActualT, (
-        html: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveHTML: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            html: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getComputedLabel`
      * Element's computed label equals the computed label provided
      */
-    toHaveComputedLabel: FnWhenElementOrArrayLike<ActualT, (
-        computedLabel: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveComputedLabel: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            computedLabel:
+                | string
+                | RegExp
+                | ExpectWebdriverIO.PartialMatcher<string>
+                | Array<string | RegExp>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getComputedRole`
      * Element's computed role equals the computed role provided
      */
-    toHaveComputedRole: FnWhenElementOrArrayLike<ActualT, (
-        computedRole: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveComputedRole: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            computedRole: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
+            options?: ExpectWebdriverIO.StringOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getSize('width')`
      * Element's width equals the width provided
      */
-    toHaveWidth: FnWhenElementOrArrayLike<ActualT, (width: number, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toHaveWidth: FnWhenElementOrArrayLike<
+        ActualT,
+        (width: number, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getSize('height')` or `getSize()`
@@ -348,15 +471,21 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * await expect(element).toHaveHeight({ height: 42, width: 42 })
      * ```
      */
-    toHaveHeight: FnWhenElementOrArrayLike<ActualT, (
-        heightOrSize: number | { height: number; width: number },
-        options?: ExpectWebdriverIO.CommandOptions
-    ) => Promise<void>>
+    toHaveHeight: FnWhenElementOrArrayLike<
+        ActualT,
+        (
+            heightOrSize: number | { height: number; width: number },
+            options?: ExpectWebdriverIO.CommandOptions,
+        ) => Promise<void>
+    >
 
     /**
      * `WebdriverIO.Element` -> `getAttribute("style")`
      */
-    toHaveStyle: FnWhenElementOrArrayLike<ActualT, (style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
+    toHaveStyle: FnWhenElementOrArrayLike<
+        ActualT,
+        (style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>
+    >
 }
 
 /**
@@ -370,10 +499,13 @@ interface WdioElementArrayOnlyMatchers<_R, ActualT = unknown> {
      * `WebdriverIO.ElementArray` -> `$$('...').length`
      * supports less / greater then or equals to be passed in options
      */
-    toBeElementsArrayOfSize: FnWhenElementArrayLike<ActualT, (
-        size: number | ExpectWebdriverIO.NumberOptions,
-        options?: ExpectWebdriverIO.NumberOptions
-    ) => Promise<void> & Promise<WebdriverIO.ElementArray>>
+    toBeElementsArrayOfSize: FnWhenElementArrayLike<
+        ActualT,
+        (
+            size: number | ExpectWebdriverIO.NumberOptions,
+            options?: ExpectWebdriverIO.NumberOptions,
+        ) => Promise<void> & Promise<WebdriverIO.ElementArray>
+    >
 }
 
 /**
@@ -389,24 +521,32 @@ interface WdioJestOverloadedMatchers<_R, ActualT> {
      * snapshot matcher
      * @param label optional snapshot label
      */
-    toMatchSnapshot(label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void;
+    toMatchSnapshot(label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void
     /**
      * inline snapshot matcher
      * @param snapshot snapshot string (autogenerated if not specified)
      * @param label optional snapshot label
      */
-    toMatchInlineSnapshot(snapshot?: string, label?: string): ActualT extends WdioPromiseLike ? Promise<void> : void;
+    toMatchInlineSnapshot(
+        snapshot?: string,
+        label?: string,
+    ): ActualT extends WdioPromiseLike ? Promise<void> : void
 }
 
 /**
  * All the specific WebDriverIO only matchers, excluding the generic matchers from the expect library.
  */
-type WdioCustomMatchers<R, ActualT> = WdioJestOverloadedMatchers<R, ActualT> & WdioBrowserMatchers<R, ActualT> & WdioElementOrArrayMatchers<R, ActualT> & WdioElementArrayOnlyMatchers<R, ActualT> & WdioNetworkMatchers<R, ActualT>
+type WdioCustomMatchers<R, ActualT> = WdioJestOverloadedMatchers<R, ActualT> &
+    WdioBrowserMatchers<R, ActualT> &
+    WdioElementOrArrayMatchers<R, ActualT> &
+    WdioElementArrayOnlyMatchers<R, ActualT> &
+    WdioNetworkMatchers<R, ActualT>
 
 /**
  * All the matchers that WebdriverIO Library supports including the generic matchers from the expect library.
  */
-type WdioMatchers<R extends void | Promise<void>, ActualT> = WdioCustomMatchers<R, ActualT> & ExpectLibMatchers<R, ActualT>
+type WdioMatchers<R extends void | Promise<void>, ActualT> = WdioCustomMatchers<R, ActualT> &
+    ExpectLibMatchers<R, ActualT>
 
 /**
  * Expects specific to WebdriverIO, excluding the generic expect matchers.
@@ -418,7 +558,11 @@ interface WdioCustomExpect {
      * All failures are collected and reported at the end of the test
      * Note: Until fixed, soft only support wdio custom matchers, and not the `expect` library matchers. Moreover, it always returns a Promise.
      */
-    soft<T = unknown>(actual: T): T extends PromiseLike<unknown> ? ExpectWebdriverIO.MatchersAndInverse<Promise<void>, T> & ExpectWebdriverIO.PromiseMatchers<T> : ExpectWebdriverIO.MatchersAndInverse<void, T>;
+    soft<T = unknown>(
+        actual: T,
+    ): T extends PromiseLike<unknown>
+        ? ExpectWebdriverIO.MatchersAndInverse<Promise<void>, T> & ExpectWebdriverIO.PromiseMatchers<T>
+        : ExpectWebdriverIO.MatchersAndInverse<void, T>
 
     /**
      * Get all current soft assertion failures
@@ -453,7 +597,7 @@ type WdioAsymmetricMatchers = ExpectLibAsymmetricMatchers
  */
 type WdioAsymmetricMatcher<R> = ExpectWebdriverIO.PartialMatcher<R> & {
     // Overwrite protected properties of expect.AsymmetricMatcher to access them
-    sample: R;
+    sample: R
 }
 
 declare namespace ExpectWebdriverIO {
@@ -471,6 +615,15 @@ declare namespace ExpectWebdriverIO {
     function getConfig(): any
 
     /**
+     * The this context available inside each matcher function.
+     */
+    interface MatcherContext /* extends ExpectLibMatcherContext */ {
+        verb?: string
+        expectation?: string
+        isNot?: boolean
+    }
+
+    /**
      * The below block are overloaded types from the expect library.
      * They are required to show "everything" under the `ExpectWebdriverIO` namespace.
      * They are also required to be be able to declare custom asymmetric/normal matchers under the `ExpectWebdriverIO` namespace.
@@ -482,7 +635,11 @@ declare namespace ExpectWebdriverIO {
      * `AsymmetricMatchers` and `Inverse<AsymmetricMatchers>` needs to be defined and be before the `expect` library Expect (aka `WdioExpect`).
      * The above allows to have custom asymmetric matchers under the `ExpectWebdriverIO` namespace.
      */
-    interface Expect extends ExpectWebdriverIO.AsymmetricMatchers, ExpectLibInverse<ExpectWebdriverIO.InverseAsymmetricMatchers>, WdioExpect {
+    interface Expect
+        extends
+        ExpectWebdriverIO.AsymmetricMatchers,
+        ExpectLibInverse<ExpectWebdriverIO.InverseAsymmetricMatchers>,
+        WdioExpect {
         /**
          * The `expect` function is used every time you want to test a value.
          * You will rarely call `expect` by itself.
@@ -495,20 +652,36 @@ declare namespace ExpectWebdriverIO {
          *
          * @param actual The value to apply matchers against.
          */
-        <T = unknown>(actual: T): T extends PromiseLike<unknown> ? ExpectWebdriverIO.MatchersAndInverse<void, T> & ExpectWebdriverIO.PromiseMatchers<T> : ExpectWebdriverIO.MatchersAndInverse<void, T>;
+        <T = unknown>(
+            actual: T,
+        ): T extends PromiseLike<unknown>
+            ? ExpectWebdriverIO.MatchersAndInverse<void, T> & ExpectWebdriverIO.PromiseMatchers<T>
+            : ExpectWebdriverIO.MatchersAndInverse<void, T>
     }
 
     interface Matchers<R extends void | Promise<void>, T> extends WdioMatchers<R, T> {}
 
+    // interface MatcherContext extends ExpectLibMatcherContext {
+    //     verb?: string
+    //     expectation?: string
+    // }
+
     interface AsymmetricMatchers extends WdioAsymmetricMatchers {}
 
-    interface InverseAsymmetricMatchers extends Omit<ExpectWebdriverIO.AsymmetricMatchers, 'anything' | 'any'> {}
+    interface InverseAsymmetricMatchers extends Omit<
+        ExpectWebdriverIO.AsymmetricMatchers,
+        'anything' | 'any'
+    > {}
 
     /**
      * End of block overloading types from the expect library.
      */
 
-    type MatchersAndInverse<R extends void | Promise<void>, ActualT> = ExpectWebdriverIO.Matchers<R, ActualT> & ExpectLibInverse<ExpectWebdriverIO.Matchers<R, ActualT>>
+    type MatchersAndInverse<R extends void | Promise<void>, ActualT> = ExpectWebdriverIO.Matchers<
+        R,
+        ActualT
+    > &
+        ExpectLibInverse<ExpectWebdriverIO.Matchers<R, ActualT>>
 
     /**
      * Take from expect library
@@ -518,12 +691,12 @@ declare namespace ExpectWebdriverIO {
          * Unwraps the reason of a rejected promise so any other matcher can be chained.
          * If the promise is fulfilled the assertion fails.
          */
-        rejects: MatchersAndInverse<Promise<void>, T>;
+        rejects: MatchersAndInverse<Promise<void>, T>
         /**
          * Unwraps the value of a fulfilled promise so any other matcher can be chained.
          * If the promise is rejected the assertion fails.
          */
-        resolves: MatchersAndInverse<Promise<void>, T>;
+        resolves: MatchersAndInverse<Promise<void>, T>
     }
     interface SnapshotServiceArgs {
         updateState?: SnapshotUpdateState
@@ -564,7 +737,7 @@ declare namespace ExpectWebdriverIO {
         beforeStep(step: PickleStep, scenario: Scenario): void
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         afterTest(test: Test, context: any, result: TestResult): void
-        afterStep(step: PickleStep, scenario: Scenario, result: { passed: boolean, error?: Error }): void
+        afterStep(step: PickleStep, scenario: Scenario, result: { passed: boolean; error?: Error }): void
     }
 
     interface AssertionResult extends ExpectLibSyncExpectationResult {}
@@ -581,7 +754,7 @@ declare namespace ExpectWebdriverIO {
         /**
          * name of the matcher, e.g. `toHaveText` or `toBeClickable`
          */
-        matcherName: keyof Matchers<void, unknown>,
+        matcherName: keyof Matchers<void, unknown>
         /**
          * Value that the user has passed in
          *
@@ -593,7 +766,7 @@ declare namespace ExpectWebdriverIO {
          * ```
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expectedValue?: any,
+        expectedValue?: any
         /**
          * Options that the user has passed in, e.g. `expect(el).toHaveText('foo', { ignoreCase: true })` -> `{ ignoreCase: true }`
          */
@@ -729,7 +902,7 @@ declare namespace ExpectWebdriverIO {
     }
 
     type RequestedWith = {
-        url?: string | ExpectWebdriverIO.PartialMatcher<string>| ((url: string) => boolean)
+        url?: string | ExpectWebdriverIO.PartialMatcher<string> | ((url: string) => boolean)
         method?: string | Array<string>
         statusCode?: number | Array<number>
         requestHeaders?:


### PR DESCRIPTION
Fixes partially https://github.com/webdriverio/expect-webdriverio/issues/106

PR serving as a starting point to support the multi-remote case.
- The goal is to have a strong groundwork and not to implement all matchers in a single PR.
- The first iteration is to implement the `toHaveTitle` browser matchers
- Element matchers will come next
- `waitUntil` was reviewed to support multiple instances better so that we can retry only those that failed, optimizing the fetching process.
   - Also, it now returns a `CompareResult` to be more flexible and returns more information for the assertions.
- The mechanism to fetch actual data and to format the error message was streamlined using an array of instances (even for non-multi-remote cases) to have a single algorithm used, but all extensible.
- Until the work is proven enough, it is kept under the **UNSTABLE** umbrella, so it is to be used at your own risk.

Depnd on:
- For per-browser value, we need https://github.com/webdriverio/webdriverio/pull/15459#issuecomment-5160734487

Draft TODOs:
- [x] Code review
- [x] Add unit tests
- [ ] Remove array expected support?