### PR TITLE
feat: Support basic non-promises matchers with Soft assertion

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,10 @@ it('product page smoke', async () => {
   // These won't throw immediately if they fail
   await expect.soft(await $('h1').getText()).toEqual('Basketball Shoes');
   await expect.soft(await $('#price').getText()).toMatch(/€\d+/);
+  
+  // Also work with basic matcher
+  const h1Text = await $('h1').getText()
+  expect.soft(h1Text).toEqual('Basketball Shoes');
 
   // Regular assertions still throw immediately
   await expect(await $('.add-to-cart').isClickable()).toBe(true);
@@ -75,7 +79,7 @@ export const config = {
   // ...
   services: [
     // ...other services
-    [SoftAssertionService,  {}]
+    [SoftAssertionService, {}]
   ],
   // ...
 }

--- a/src/softExpect.ts
+++ b/src/softExpect.ts
@@ -30,6 +30,8 @@ const createSoftExpect = <T = unknown>(actual: T): ExpectWebdriverIO.Matchers<Pr
                 // Support basic & wdio (and more) matchers that start with "to"
                 return createSoftMatcher(actual, propName, softService)
             }
+
+            // For any other properties, return undefined
             return undefined
         }
     })
@@ -68,7 +70,7 @@ const createSoftMatcher = <T>(
     softService: SoftAssertService,
     prefix?: string
 ) => {
-    return (...args: unknown[]) => {
+    return (...args: unknown[]): ExpectWebdriverIO.AsyncAssertionResult | SyncExpectationResult  => {
         try {
             // Build the expectation chain
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,7 +108,7 @@ function handlingMatcherFailure(prefix: string | undefined, matcherName: string,
     return {
         pass: true,
         message: () => `Soft assertion failed: ${fullMatcherName}`
-    }
+    } satisfies SyncExpectationResult
 }
 
 export default createSoftExpect

--- a/test/softAssertions.test.ts
+++ b/test/softAssertions.test.ts
@@ -55,40 +55,27 @@ describe('Soft Assertions', () => {
             await Promise.all([elementSoftToHaveText, elementsSoftToHaveText, elementsSoftNotToHaveText])
         })
 
-        it('should handle non-promises properly', () => {
+        it('should handle non-promises matchers properly by not using promises', () => {
             const softService = SoftAssertService.getInstance()
             softService.setCurrentTest('non-promise-1', 'test name', 'test file')
 
+            // Base line on Jest 'expect' library
             expect(expectLib(true).toBe(true)).toBeUndefined()
             expect(expectLib(true).toBe).toBeInstanceOf(Function)
             expect(expectLib(true).toBe(true)).not.toBeInstanceOf(Promise)
             expect(expectLib(true).not.toBe(false)).not.toBeInstanceOf(Promise)
 
+            // wdio expect
             expect(expectWdio(true).toBe(true)).toBeUndefined()
             expect(expectWdio(true).toBe).toBeInstanceOf(Function)
             expect(expectWdio(true).toBe(true)).not.toBeInstanceOf(Promise)
             expect(expectWdio(true).not.toBe(false)).not.toBeInstanceOf(Promise)
 
+            // wdio expect.soft
             expect(expectWdio.soft(true).toBe(true)).toBeUndefined()
             expect(expectWdio.soft(true).toBe).toBeInstanceOf(Function)
             expect(expectWdio.soft(true).toBe).not.toBeInstanceOf(Promise)
             expect(expectWdio.soft(true).not.toBe(false)).not.toBeInstanceOf(Promise)
-        })
-
-        it.for([
-            '',
-            2,
-            [],
-        ])('should handle non-promises and return a non-promise target to have the correct runtime type', (actualPromise) => {
-            const softService = SoftAssertService.getInstance()
-            softService.setCurrentTest('non-promise-2', 'test name', 'test file')
-
-            const wdioExpect = expectWdio(actualPromise)
-            expect(wdioExpect).not.toBeInstanceOf(Promise)
-
-            const softExpect = expectWdio.soft(actualPromise)
-            expect(softExpect).toBeInstanceOf(Object)
-            expect(softExpect).not.toBeInstanceOf(Promise)
         })
 
         it('should not throw immediately on failure', async () => {
@@ -213,7 +200,7 @@ describe('Soft Assertions', () => {
                 expect(failures[0].matcherName).toBe('not.toEqual')
             })
 
-            it.skip('not - should support basic matcher success', async () => {
+            it('not - should support basic matcher success', async () => {
                 const softService = SoftAssertService.getInstance()
                 softService.setCurrentTest('test-10', 'test name', 'test file')
 

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -6,54 +6,57 @@ import { expect as expectWdio } from '../src/index.js'
 
 describe('Type test', () => {
 
-    test('Jest "expect" lib type tests as baseline', () => {
+    describe('Expects + Promise matchers & basic matchers', () => {
+
+        test('Jest "expect" lib type tests as baseline', () => {
+            // Basic matchers
+            expectTypeOf(expectLib(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+            expectTypeOf(expectLib(true).toBe(true)).toBeVoid()
+            expectTypeOf(expectLib(true).toBe(true)).not.toExtend<Promise<void>>()
+            expectTypeOf(expectLib(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectLib(Promise.resolve(true)).resolves.toBe(expect.any)).resolves.toBeVoid()
+
+            // element matchers are not available in 'expect' lib
+            expectTypeOf(expectLib($('element')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectLib($('element'))).not.toHaveProperty('toHaveText')
+            expectTypeOf(expectLib($$('elements')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectLib($$('elements'))).not.toHaveProperty('toHaveText')
+        })
+
+        test('Wdio expect & matchers type tests', () => {
         // Basic matchers
-        expectTypeOf(expectLib(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
-        expectTypeOf(expectLib(true).toBe(true)).toBeVoid()
-        expectTypeOf(expectLib(true).toBe(true)).not.toExtend<Promise<void>>()
-        expectTypeOf(expectLib(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectLib(Promise.resolve(true)).resolves.toBe(expect.any)).resolves.toBeVoid()
+            expectTypeOf(expectWdio(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+            expectTypeOf(expectWdio(true).toBe(true)).toBeVoid()
+            expectTypeOf(expectWdio(true).toBe(true)).not.toExtend<Promise<void>>()
+            expectTypeOf(expectWdio(Promise.resolve(true)).toBe(true))
+            expectTypeOf(expectWdio(Promise.resolve(true)).resolves.toBe(true)).resolves.toBeVoid()
 
-        // element matchers are not available in 'expect' lib
-        expectTypeOf(expectLib($('element')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectLib($('element'))).not.toHaveProperty('toHaveText')
-        expectTypeOf(expectLib($$('elements')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectLib($$('elements'))).not.toHaveProperty('toHaveText')
-    })
+            // element matchers
+            expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
+            expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
+            expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
+            expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
 
-    test('Wdio expect & matchers type tests', () => {
+        })
+
+        test('Wdio soft expect & matchers type tests', () => {
         // Basic matchers
-        expectTypeOf(expectWdio(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
-        expectTypeOf(expectWdio(true).toBe(true)).toBeVoid()
-        expectTypeOf(expectWdio(true).toBe(true)).not.toExtend<Promise<void>>()
-        expectTypeOf(expectWdio(Promise.resolve(true)).toBe(true))
-        expectTypeOf(expectWdio(Promise.resolve(true)).resolves.toBe(true)).resolves.toBeVoid()
+            expectTypeOf(expectWdio.soft(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+            expectTypeOf(expectWdio.soft(true).toBe(true)).toExtend<void>()
+            expectTypeOf(expectWdio.soft(true).toBe(true)).not.toExtend<Promise<void>>()
+            // TODO to fix one day? When non elements matchers + promise, we should stick to void and not have Promise<void>
+            //expectTypeOf(expectWdio.soft(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectWdio.soft(Promise.resolve(true)).resolves.toBe(expect.any)).toExtend<Promise<void>>()
 
-        // element matchers
-        expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
-        expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
-        expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
-        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
-
-    })
-
-    test('Wdio soft expect & matchers type tests', () => {
-        // Basic matchers
-        expectTypeOf(expectWdio.soft(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
-        expectTypeOf(expectWdio.soft(true).toBe(true)).toExtend<void>()
-        expectTypeOf(expectWdio.soft(true).toBe(true)).not.toExtend<Promise<void>>()
-        // to fix?
-        //expectTypeOf(expectWdio.soft(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectWdio.soft(Promise.resolve(true)).resolves.toBe(expect.any)).toExtend<Promise<void>>()
-
-        // element matchers
-        expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
-        expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
-        expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
-        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
-        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
+            // element matchers
+            expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
+            expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
+            expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
+            expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
+            expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
+        })
     })
 })

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,59 @@
+import { describe, expect, expectTypeOf, test } from 'vitest'
+import { $, $$ } from '@wdio/globals'
+import type { Matchers, Inverse } from 'expect'
+import expectLib from 'expect'
+import { expect as expectWdio } from '../src/index.js'
+
+describe('Type test', () => {
+
+    test('Jest "expect" lib type tests as baseline', () => {
+        // Basic matchers
+        expectTypeOf(expectLib(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+        expectTypeOf(expectLib(true).toBe(true)).toBeVoid()
+        expectTypeOf(expectLib(true).toBe(true)).not.toExtend<Promise<void>>()
+        expectTypeOf(expectLib(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectLib(Promise.resolve(true)).resolves.toBe(expect.any)).resolves.toBeVoid()
+
+        // element matchers are not available in 'expect' lib
+        expectTypeOf(expectLib($('element')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectLib($('element'))).not.toHaveProperty('toHaveText')
+        expectTypeOf(expectLib($$('elements')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectLib($$('elements'))).not.toHaveProperty('toHaveText')
+    })
+
+    test('Wdio expect & matchers type tests', () => {
+        // Basic matchers
+        expectTypeOf(expectWdio(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+        expectTypeOf(expectWdio(true).toBe(true)).toBeVoid()
+        expectTypeOf(expectWdio(true).toBe(true)).not.toExtend<Promise<void>>()
+        expectTypeOf(expectWdio(Promise.resolve(true)).toBe(true))
+        expectTypeOf(expectWdio(Promise.resolve(true)).resolves.toBe(true)).resolves.toBeVoid()
+
+        // element matchers
+        expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
+        expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
+        expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
+        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
+
+    })
+
+    test('Wdio soft expect & matchers type tests', () => {
+        // Basic matchers
+        expectTypeOf(expectWdio.soft(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
+        expectTypeOf(expectWdio.soft(true).toBe(true)).toExtend<void>()
+        expectTypeOf(expectWdio.soft(true).toBe(true)).not.toExtend<Promise<void>>()
+        // to fix?
+        //expectTypeOf(expectWdio.soft(Promise.resolve(true)).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectWdio.soft(Promise.resolve(true)).resolves.toBe(expect.any)).toExtend<Promise<void>>()
+
+        // element matchers
+        expectTypeOf(expectWdio($('element')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectWdio($('element')).toHaveText('test')).not.toBeVoid()
+        expectTypeOf(expectWdio($('element')).toHaveText('test')).toExtend<Promise<void>>()
+        expectTypeOf(expectWdio($$('elements')).toBe(expect.any)).toBeVoid()
+        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).toExtend<Promise<void>>()
+        expectTypeOf(expectWdio($$('elements')).toHaveText('test')).not.toBeVoid()
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/webdriverio/expect-webdriverio/issues/1887

- Support any matchers which name start with `to`
- Ensure we process synchronously non-promise matchers