### PR TITLE
fix: Typing on toHaveHTML should allow HTMLOptions

### DIFF
--- a/test-types/mocha/types-mocha.test.ts
+++ b/test-types/mocha/types-mocha.test.ts
@@ -83,6 +83,12 @@ describe('type assertions', () => {
         })
     })
 
+    describe('toHaveHTML', () => {
+        it('should allow using HTMLOptions', async () => {
+            expectPromiseVoid = expect(element).toHaveHTML('html', { includeSelectorTag: true })
+        })
+    })
+
     describe('element', () => {
 
         describe('toBeDisabled', () => {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -320,7 +320,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      */
     toHaveHTML: FnWhenElementOrArrayLike<ActualT, (
         html: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | Array<string | RegExp>,
-        options?: ExpectWebdriverIO.StringOptions
+        options?: ExpectWebdriverIO.HTMLOptions
     ) => Promise<void>>
 
     /**


### PR DESCRIPTION
Fixes #2089 
`toHaveHTML` should be using `HTMLOptions` and not only StringOptions to allow passing `includeSelectorTag`