### PR TITLE
fix: Use `ReturnType` for more robust Chainable type

### DIFF
--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -8,8 +8,8 @@ type Scenario = import('@wdio/types').Frameworks.Scenario
 type SnapshotResult = import('@vitest/snapshot').SnapshotResult
 type SnapshotUpdateState = import('@vitest/snapshot').SnapshotUpdateState
 
-type ChainablePromiseElement = import('webdriverio').ChainablePromiseElement
-type ChainablePromiseArray = import('webdriverio').ChainablePromiseArray
+type ChainablePromiseElement = ReturnType<WebdriverIO.Browser['$']>
+type ChainablePromiseArray = ReturnType<WebdriverIO.Browser['$$']>
 
 type ExpectLibAsymmetricMatchers = import('expect').AsymmetricMatchers
 type ExpectLibAsymmetricMatcher<T> = import('expect').AsymmetricMatcher<T>


### PR DESCRIPTION
In jest playgrounds, `ChainablePromiseElement` & `ChainablePromiseArray` had difficulty resolving properly due to a conflicting `webdriverio` version. Using `ReturnType<WebdriverIO.Browser['$']>` make it more reliable.

Why ReturnType<WebdriverIO.Browser['$']> fixed it:
- It anchors the type to the consumer’s currently active WebdriverIO namespace instead of a separately imported webdriverio module.
- So both sides of your matcher condition use the same type universe, and the extends checks succeed.
