### PR TITLE
chore: fix husky install deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ts:mocha": "cd test-types/mocha && vitest --typecheck --typecheck.tsconfig ./tsconfig.json --run",
     "checks:all": "npm run build && npm run compile && npm run tsc:root-types && npm run test && npm run ts",
     "watch": "npm run compile -- --watch",
-    "prepare": "husky install",
+    "prepare": "husky",
     "playgrounds:setup": "cd playgrounds && npm run setup",
     "playgrounds:checks:all": "cd playgrounds && npm run checks:all",
     "playgrounds:snapshots:update": "cd playgrounds && npm run snapshots:update"


### PR DESCRIPTION
## Summary
This PR updates the Husky `prepare` script in `package.json` to be compatible with Husky v9 by removing the deprecated `husky install` command.

## What changed
* Replaced `"prepare": "husky install"` with `"prepare": "husky"` in `package.json`.

## Why
* The `husky install` command was deprecated in Husky v9.
* This change prevents deprecation warnings from appearing during `npm install`.
* It ensures the Git hooks setup continues to work correctly with the current version of Husky.

## References
* [Husky v9.0.1 Release Notes](https://github.com/typicode/husky/releases/tag/v9.0.1)

## Notes
* There are no functional changes to the behavior of the Git hooks.
* This is purely a maintenance fix for dependency and tooling compatibility.