### PR TITLE
fix: Better support of existence for `toHaveAttribute` & `toHaveElementProperty`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -384,7 +384,7 @@ await expect(myInput).toHaveElementClass(expect.stringContaining('form'), { mess
 
 ### toHaveElementProperty
 
-Checks if an element has a certain property.
+Checks if an element has a certain property and value
 
 ##### Usage
 
@@ -392,6 +392,17 @@ Checks if an element has a certain property.
 const elem = await $('#elem')
 await expect(elem).toHaveElementProperty('height', 23)
 await expect(elem).not.toHaveElementProperty('height', 0)
+```
+
+Checks if an element has a certain property with any value
+
+##### Usage
+
+```js
+const elem = await $('#elem')
+await expect(elem).toHaveElementProperty('height')
+// Does not have height property
+await expect(elem).not.toHaveElementProperty('height')
 ```
 
 ### toHaveValue

--- a/docs/API.md
+++ b/docs/API.md
@@ -349,7 +349,7 @@ await expect(myInput).toHaveAttribute('class', 'form-control')
 await expect(myInput).toHaveAttribute('class', expect.stringContaining('control'))
 ```
 
-Checks if an element has a specific attribute with a value.
+Checks if an element has a specific attribute.
 
 ##### Usage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -349,6 +349,26 @@ await expect(myInput).toHaveAttribute('class', 'form-control')
 await expect(myInput).toHaveAttribute('class', expect.stringContaining('control'))
 ```
 
+Checks if an element has a specific attribute with a value.
+
+##### Usage
+
+```js
+const myInput = await $('input')
+await expect(myInput).toHaveAttribute('class')
+await expect(myInput).toHaveAttribute('class', { wait: 1000 })
+```
+
+Checks if an element does not have the specified attribute.
+
+##### Usage
+
+```js
+const myInput = await $('input')
+await expect(myInput).not.toHaveAttribute('class')
+await expect(myInput).not.toHaveAttribute('class', { wait: 1000 })
+```
+
 ### toHaveElementClass
 
 Checks if an element has a single class name. Can also be called with an array as a parameter when the element can have multiple class names.

--- a/docs/API.md
+++ b/docs/API.md
@@ -349,18 +349,6 @@ await expect(myInput).toHaveAttribute('class', 'form-control')
 await expect(myInput).toHaveAttribute('class', expect.stringContaining('control'))
 ```
 
-### toHaveAttr
-
-Same as `toHaveAttribute`.
-
-##### Usage
-
-```js
-const myInput = await $('input')
-await expect(myInput).toHaveAttr('class', 'form-control')
-await expect(myInput).toHaveAttr('class', expect.stringContaining('control'))
-```
-
 ### toHaveElementClass
 
 Checks if an element has a single class name. Can also be called with an array as a parameter when the element can have multiple class names.

--- a/docs/API.md
+++ b/docs/API.md
@@ -394,7 +394,7 @@ await expect(elem).toHaveElementProperty('height', 23)
 await expect(elem).not.toHaveElementProperty('height', 0)
 ```
 
-Checks if an element has a certain property with any value
+Checks if an element has a certain property.
 
 ##### Usage
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -35,7 +35,7 @@ describe('suite', () => {
         const myInput = await $('input')
 
         await expect(myInput).toHaveElementClass('form-control', { message: 'Not a form control!', })
-        await expect(myInput).toHaveAttribute('class', 'form-control') // alias toHaveAttr
+        await expect(myInput).toHaveAttribute('class', 'form-control')
 
         await expect(myInput).toHaveValue('value', 'user', { containing: true, ignoreCase: true })
 

--- a/playgrounds/jasmine/eslint.config.mjs
+++ b/playgrounds/jasmine/eslint.config.mjs
@@ -27,5 +27,6 @@ export default {
     ...tsEslintPlugin.configs['recommended'].rules,
     '@typescript-eslint/no-floating-promises': 'error',
     'jasmine/no-focused-tests': 'error',
+    'jasmine/no-spec-dupes': 'error',
   },
 };

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/basic-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/basic-matchers.test.ts
@@ -163,7 +163,7 @@ describe('Basic Expect Matchers available when pulling expect from expect-webdri
             expect({ num: 1.1 }).toEqual({ num: expect.closeTo(1.101, 2) })
         })
 
-        it('should have toBe not work with stringContaining', async () => {
+        it('should have toBe not work with stringContaining with wdio asymmetric matcher', async () => {
             expect(() => {
                 expect('title').toBe(expect.stringContaining('title'))
             }).toThrow()

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -95,6 +95,11 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(docsLink).toHaveAttribute('href', expect.stringContaining('docs'))
         })
 
+        it('should verify attribute contains value', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).toHaveAttribute('href', jasmine.stringContaining('docs'))
+        })
+
         it('should verify element has class', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementClass('DocSearch-Button')

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -90,12 +90,12 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(docsLink).toHaveAttribute('href', '/docs/gettingstarted')
         })
 
-        it('should verify attribute contains value', async () => {
+        it('should verify attribute contains value with wdio asymmetric matcher', async () => {
             const docsLink = await $('a[href="/docs/gettingstarted"]')
             await expect(docsLink).toHaveAttribute('href', expect.stringContaining('docs'))
         })
 
-        it('should verify attribute contains value', async () => {
+        it('should verify attribute contains value with jasmine matcher', async () => {
             const docsLink = await $('a[href="/docs/gettingstarted"]')
             await expect(docsLink).toHaveAttribute('href', jasmine.stringContaining('docs'))
         })

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -85,9 +85,29 @@ describe('WebdriverIO Custom Matchers', () => {
     })
 
     describe('Element attribute matchers', () => {
+        it('should verify element exists', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).toHaveAttribute('href')
+        })
+
+        it('should verify element exists immediately', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).toHaveAttribute('href', { wait: 0 })
+        })
+
         it('should verify element has attribute', async () => {
             const docsLink = await $('a[href="/docs/gettingstarted"]')
             await expect(docsLink).toHaveAttribute('href', '/docs/gettingstarted')
+        })
+
+        it('should verify element does not exist', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).not.toHaveAttribute('non-existent-attribute')
+        })
+
+        it('should verify element does not exist immediately', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).not.toHaveAttribute('non-existent-attribute', { wait: 0 })
         })
 
         it('should verify attribute contains value', async () => {

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -1,5 +1,4 @@
 import { browser, $, $$ } from '@wdio/globals'
-import { expect } from 'expect-webdriverio'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {
@@ -85,29 +84,9 @@ describe('WebdriverIO Custom Matchers', () => {
     })
 
     describe('Element attribute matchers', () => {
-        it('should verify element exists', async () => {
-            const docsLink = await $('a[href="/docs/gettingstarted"]')
-            await expect(docsLink).toHaveAttribute('href')
-        })
-
-        it('should verify element exists immediately', async () => {
-            const docsLink = await $('a[href="/docs/gettingstarted"]')
-            await expect(docsLink).toHaveAttribute('href', { wait: 0 })
-        })
-
         it('should verify element has attribute', async () => {
             const docsLink = await $('a[href="/docs/gettingstarted"]')
             await expect(docsLink).toHaveAttribute('href', '/docs/gettingstarted')
-        })
-
-        it('should verify element does not exist', async () => {
-            const docsLink = await $('a[href="/docs/gettingstarted"]')
-            await expect(docsLink).not.toHaveAttribute('non-existent-attribute')
-        })
-
-        it('should verify element does not exist immediately', async () => {
-            const docsLink = await $('a[href="/docs/gettingstarted"]')
-            await expect(docsLink).not.toHaveAttribute('non-existent-attribute', { wait: 0 })
         })
 
         it('should verify attribute contains value', async () => {
@@ -169,7 +148,6 @@ describe('WebdriverIO Custom Matchers', () => {
             await searchButton.click()
 
             // The search modal input should be focused after clicking
-
             await browser.pause(500) // Wait for modal to open
             const searchInput = await $('.DocSearch-Input')
             if (await searchInput.isExisting()) {

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -1,4 +1,5 @@
 import { browser, $, $$ } from '@wdio/globals'
+import { expect } from 'expect-webdriverio'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {

--- a/playgrounds/jasmine/test/specs/globalImport/basic-matchers-jasmine.test.ts
+++ b/playgrounds/jasmine/test/specs/globalImport/basic-matchers-jasmine.test.ts
@@ -85,7 +85,7 @@ describe('Basic Matchers', () => {
     // Simply showing not available matchers in Jasmine
     xdescribe('Excluded tests showing unavailable matchers in Jasmine', () => {
         describe('Object matchers', () => {
-            it('should match object properties', async () => {
+            it('should match object properties with unavailable matchers', async () => {
                 const capabilities = await browser.capabilities
 
                 // @ts-expect-error -- toMatchObject is not available in Jasmine even at runtime

--- a/playgrounds/jest/eslint.config.mjs
+++ b/playgrounds/jest/eslint.config.mjs
@@ -27,5 +27,6 @@ export default {
     ...tsEslintPlugin.configs['recommended'].rules,
     '@typescript-eslint/no-floating-promises': 'error',
     'jest/no-focused-tests': 'error',
+    'jest/no-identical-title': 'error',
   },
 };

--- a/playgrounds/mocha/eslint.config.mjs
+++ b/playgrounds/mocha/eslint.config.mjs
@@ -28,5 +28,6 @@ export default {
     ...tsEslintPlugin.configs['recommended'].rules,
     '@typescript-eslint/no-floating-promises': 'error',
     'mocha/no-exclusive-tests': 'error',
+    'mocha/no-identical-title': 'error',
   },
 };

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -106,9 +106,19 @@ describe('WebdriverIO Custom Matchers', () => {
     })
 
     describe('Element property matchers', () => {
-        it('should verify element property', async () => {
+        it('should verify element property value', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementProperty('type', 'button')
+        })
+
+        it('should verify that element property exists', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).toHaveElementProperty('type')
+        })
+
+        it('should verify that element property does not exist', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('doesNNotExist')
         })
     })
 

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -131,7 +131,7 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(searchButton).toHaveElementProperty('type', 'button')
         })
 
-        it('should verify element property value', async () => {
+        it('should verify element property value with asymmetric matcher', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementProperty('type', expect.stringContaining('button'))
         })

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -136,9 +136,19 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(searchButton).toHaveElementProperty('type')
         })
 
+        it('should verify that element property exists immediately', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).toHaveElementProperty('type', { wait: 0 })
+        })
+
         it('should verify that element property does not exist', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).not.toHaveElementProperty('doesNNotExist')
+        })
+
+        it('should verify that element property does not exist immediately', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('doesNNotExist', { wait: 0 })
         })
     })
 

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -131,6 +131,11 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(searchButton).toHaveElementProperty('type', 'button')
         })
 
+        it('should verify element property value', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).toHaveElementProperty('type', expect.stringContaining('button'))
+        })
+
         it('should verify that element property exists', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementProperty('type')

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -84,9 +84,29 @@ describe('WebdriverIO Custom Matchers', () => {
     })
 
     describe('Element attribute matchers', () => {
+        it('should verify element exists', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).toHaveAttribute('href')
+        })
+
+        it('should verify element exists immediately', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).toHaveAttribute('href', { wait: 0 })
+        })
+
         it('should verify element has attribute', async () => {
             const docsLink = await $('a[href="/docs/gettingstarted"]')
             await expect(docsLink).toHaveAttribute('href', '/docs/gettingstarted')
+        })
+
+        it('should verify element does not exist', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).not.toHaveAttribute('non-existent-attribute')
+        })
+
+        it('should verify element does not exist immediately', async () => {
+            const docsLink = await $('a[href="/docs/gettingstarted"]')
+            await expect(docsLink).not.toHaveAttribute('non-existent-attribute', { wait: 0 })
         })
 
         it('should verify attribute contains value', async () => {

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,3 +1,4 @@
+import type { AsyncAssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
 import {
@@ -7,62 +8,69 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
+import { isStringOptions } from '../../util/commandOptionsUtils'
 
-async function conditionAttr(el: WebdriverIO.Element, attribute: string) {
-    const attr = await el.getAttribute(attribute)
-    if (typeof attr !== 'string') {
-        return { result: false, value: attr }
+async function conditionAttributeIsPresent(el: WebdriverIO.Element, attribute: string) {
+    const attributeValue = await el.getAttribute(attribute)
+    if (typeof attributeValue !== 'string') {
+        return { result: false, value: attributeValue }
     }
-    return { result: true, value: attr }
+    return { result: true, value: attributeValue }
 
 }
 
-async function conditionAttrAndValue(el: WebdriverIO.Element, attribute: string, value: string | RegExp | AsymmetricMatcher<string>, options: ExpectWebdriverIO.StringOptions) {
-    const attr = await el.getAttribute(attribute)
-    if (typeof attr !== 'string') {
-        return { result: false, value: attr }
+async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: string | RegExp | AsymmetricMatcher<string>, options: ExpectWebdriverIO.StringOptions) {
+    const attributeValue = await el.getAttribute(attribute)
+    if (typeof attributeValue !== 'string') {
+        return { result: false, value: attributeValue }
     }
 
-    return compareText(attr, value, options)
+    return compareText(attributeValue, expectedValue, options)
 }
 
-export async function toHaveAttributeAndValue(received: WdioElementMaybePromise, attribute: string, value: string | RegExp | AsymmetricMatcher<string>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
-    const isNot = this.isNot
-    const { expectation = 'attribute', verb = 'have' } = this
+export async function toHaveAttributeAndValue(received: WdioElementMaybePromise, attribute: string, expectedValue: string | RegExp | AsymmetricMatcher<string>, options: ExpectWebdriverIO.StringOptions) {
+    const { expectation = 'attribute', verb = 'have', isNot } = this
 
     let el = await received?.getElement()
     let attr
-    const pass = await waitUntil(async () => {
-        const result = await executeCommand.call(this, el, conditionAttrAndValue, options, [attribute, value, options])
-        el = result.el as WebdriverIO.Element
-        attr = result.values
+    const pass = await waitUntil(
+        async () => {
+            const result = await executeCommand.call(this, el, conditionAttributeValueMatchWithExpected, options, [attribute, expectedValue, options])
+            el = result.el as WebdriverIO.Element
+            attr = result.values
 
-        return result.success
-    }, isNot, options)
+            return result.success
+        },
+        isNot,
+        { wait: options.wait, interval: options.interval }
+    )
 
-    const expected = wrapExpectedWithArray(el, attr, value)
+    const expected = wrapExpectedWithArray(el, attr, expectedValue)
     const message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
 
     return {
         pass,
         message: (): string => message
-    } as ExpectWebdriverIO.AssertionResult
+    }
 }
 
-async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: string) {
-    const isNot = this.isNot
-    const { expectation = 'attribute', verb = 'have' } = this
+async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: string, options: ExpectWebdriverIO.CommandOptions) {
+    const { expectation = 'attribute', verb = 'have', isNot } = this
 
     let el = await received?.getElement()
 
-    const pass = await waitUntil(async () => {
-        const result = await executeCommand.call(this, el, conditionAttr, {}, [attribute])
-        el = result.el as WebdriverIO.Element
+    const pass = await waitUntil(
+        async () => {
+            const result = await executeCommand.call(this, el, conditionAttributeIsPresent, options, [attribute])
+            el = result.el as WebdriverIO.Element
 
-        return result.success
-    }, isNot, {})
+            return result.success
+        },
+        isNot,
+        { wait: options.wait, interval: options.interval }
+    )
 
-    const message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, {})
+    const message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, options)
 
     return {
         pass,
@@ -70,14 +78,53 @@ async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: s
     }
 }
 
+/**
+ * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
+ */
 export async function toHaveAttribute(
     received: WdioElementMaybePromise,
     attribute: string,
-    value?: string | RegExp | AsymmetricMatcher<string>,
+    value: undefined,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
+
+/**
+ * When called with only the attribute name (and optional configuration options).
+ */
+export async function toHaveAttribute(
+    received: WdioElementMaybePromise,
+    attribute: string,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
+
+/**
+ * When called with an expected attribute name and value.
+ */
+export async function toHaveAttribute(
+    received: WdioElementMaybePromise,
+    attribute: string,
+    value: string | RegExp | AsymmetricMatcher<string>,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
+
+export async function toHaveAttribute(
+    received: WdioElementMaybePromise,
+    attribute: string,
+    valueOrOptions?: string | RegExp | AsymmetricMatcher<string> | ExpectWebdriverIO.StringOptions,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
+): Promise<AsyncAssertionResult> {
+    const matcherName = 'toHaveAttribute'
+
+    let value: string | RegExp | AsymmetricMatcher<string> | undefined
+    if (isStringOptions(valueOrOptions)) {
+        options = valueOrOptions
+        value = undefined
+    } else {
+        value = valueOrOptions as string | RegExp | AsymmetricMatcher<string>
+    }
+
     await options.beforeAssertion?.({
-        matcherName: 'toHaveAttribute',
+        matcherName,
         expectedValue: [attribute, value],
         options,
     })
@@ -86,10 +133,10 @@ export async function toHaveAttribute(
         // Name and value is passed in e.g. el.toHaveAttribute('attr', 'value', (opts))
         ? await toHaveAttributeAndValue.call(this, received, attribute, value, options)
         // Only name is passed in e.g. el.toHaveAttribute('attr')
-        : await toHaveAttributeFn.call(this, received, attribute)
+        : await toHaveAttributeFn.call(this, received, attribute, options)
 
     await options.afterAssertion?.({
-        matcherName: 'toHaveAttribute',
+        matcherName,
         expectedValue: [attribute, value],
         options,
         result
@@ -98,4 +145,7 @@ export async function toHaveAttribute(
     return result
 }
 
+/**
+ * @deprecated Use `toHaveAttribute` with or without value instead and not with undefined.
+ */
 export const toHaveAttr = toHaveAttribute

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -8,7 +8,7 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
-import { isStringOptions } from '../../util/commandOptionsUtils'
+import { isStringOptions } from '../../util/commandOptionsUtils.js'
 
 async function conditionAttributeIsPresent(el: WebdriverIO.Element, attribute: string) {
     const attributeValue = await el.getAttribute(attribute)

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -146,6 +146,6 @@ export async function toHaveAttribute(
 }
 
 /**
- * @deprecated Use `toHaveAttribute` with or without value instead and not with undefined.
+ * @deprecated since 5.7.0 Use `toHaveAttribute`
  */
 export const toHaveAttr = toHaveAttribute

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -79,7 +79,7 @@ async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: s
 }
 
 /**
- * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
+ * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
  */
 export async function toHaveAttribute(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -18,7 +18,7 @@ async function condition(
 ) {
     const { asString = false } = options
 
-    let propertyValue = await el.getProperty(property)
+    const propertyValue = await el.getProperty(property)
 
     // As specified in the w3c spec, cases where property does not exist
     if (propertyValue === null || propertyValue === undefined) {
@@ -34,8 +34,7 @@ async function condition(
         return { result: propertyValue === expectedValue, value: propertyValue }
     }
 
-    propertyValue = propertyValue.toString()
-    return compareText(propertyValue as string, expectedValue as string | RegExp | AsymmetricMatcher<string>, options)
+    return compareText(propertyValue.toString(), expectedValue as string | RegExp | AsymmetricMatcher<string>, options)
 }
 
 /**

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -103,7 +103,7 @@ export async function toHaveElementProperty(
             return result.success
         },
         isNot,
-        options
+        { wait: options.wait, interval: options.interval }
     )
 
     let message: string

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,5 +1,7 @@
+import type { AsyncAssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
+import { isStringOptions } from '../../util/commandOptionsUtils.js'
 import {
     compareText,
     enhanceError,
@@ -11,42 +13,82 @@ import {
 async function condition(
     el: WebdriverIO.Element,
     property: string,
-    value: unknown,
+    expectedValue: unknown,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ) {
     const { asString = false } = options
 
-    let prop = await el.getProperty(property)
+    let propertyValue = await el.getProperty(property)
 
     // As specified in the w3c spec, cases where property does not exist
-    if (prop === null || prop === undefined) {
-        return { result: false, value: prop }
+    if (propertyValue === null || propertyValue === undefined) {
+        return { result: false, value: propertyValue }
     }
 
     // As specified in the w3c spec, cases where property simply exists, missing undefined here?
-    if (value === null) {
-        return { result: true, value: prop }
+    if (expectedValue === null || expectedValue === undefined) {
+        return { result: true, value: propertyValue }
     }
 
-    if (!(value instanceof RegExp) && typeof prop !== 'string' && !asString) {
-        return { result: prop === value, value: prop }
+    if (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString) {
+        return { result: propertyValue === expectedValue, value: propertyValue }
     }
 
-    prop = prop.toString()
-    return compareText(prop as string, value as string | RegExp | AsymmetricMatcher<string>, options)
+    propertyValue = propertyValue.toString()
+    return compareText(propertyValue as string, expectedValue as string | RegExp | AsymmetricMatcher<string>, options)
 }
+
+/**
+ * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
+ */
+export async function toHaveElementProperty(
+    received: WdioElementMaybePromise,
+    property: string,
+    value: undefined,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
+
+/**
+ * When called with only the property name (and optional configuration options).
+ */
+export async function toHaveElementProperty(
+    received: WdioElementMaybePromise,
+    property: string,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
+
+/**
+ * When called with an expected property name and value.
+ */
+export async function toHaveElementProperty(
+    received: WdioElementMaybePromise,
+    property: string,
+    value: string | number | RegExp | AsymmetricMatcher<string> | null,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<AsyncAssertionResult>
 
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value?: string | RegExp | AsymmetricMatcher<string> | null,
+    valueOrOptions?: string | number | RegExp | AsymmetricMatcher<string> | null | ExpectWebdriverIO.StringOptions,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
+): Promise<AsyncAssertionResult> {
+    let value: string | number | RegExp | AsymmetricMatcher<string> | null | undefined
+
+    // Determine if the third argument is actually options or the expected value
+    if (isStringOptions(valueOrOptions)) {
+        options = valueOrOptions
+        value = undefined
+    } else {
+        value = valueOrOptions as string | number | RegExp | AsymmetricMatcher<string> | null
+    }
+
+    const matcherName = 'toHaveElementProperty'
     const isNot = this.isNot
     const { expectation = 'property', verb = 'have' } = this
 
     await options.beforeAssertion?.({
-        matcherName: 'toHaveElementProperty',
+        matcherName,
         expectedValue: [property, value],
         options,
     })
@@ -79,7 +121,7 @@ export async function toHaveElementProperty(
     }
 
     await options.afterAssertion?.({
-        matcherName: 'toHaveElementProperty',
+        matcherName,
         expectedValue: [property, value],
         options,
         result

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -43,7 +43,7 @@ async function condition(
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value: undefined,
+    value: undefined | null,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AsyncAssertionResult>
 
@@ -62,7 +62,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value: string | number | RegExp | AsymmetricMatcher<string> | null,
+    value: string | number | RegExp | AsymmetricMatcher<string>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AsyncAssertionResult>
 

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -39,7 +39,7 @@ async function condition(
 }
 
 /**
- * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
+ * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
  */
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -25,7 +25,7 @@ async function condition(
         return { result: false, value: propertyValue }
     }
 
-    // As specified in the w3c spec, cases where property simply exists, missing undefined here?
+    // As specified in the w3c spec, cases where property simply exists
     if (expectedValue === null || expectedValue === undefined) {
         return { result: true, value: propertyValue }
     }

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -10,7 +10,6 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
         return false
     }
 
-    // 3. Extract object keys
     const objKeys = Object.keys(obj)
 
     // Condition A: It is a completely empty object -> {}
@@ -38,6 +37,5 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
         'afterAssertion'
     ])
 
-    // Condition B: At least one key in the object exists in our whitelist
     return objKeys.every(key => allowedKeys.has(key))
 }

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -4,7 +4,8 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
         typeof obj !== 'object' ||
         obj instanceof RegExp ||
         Array.isArray(obj) ||
-        'asymmetricMatch' in obj
+        'asymmetricMatch' in obj ||
+        Object.prototype.toString.call(obj) !== '[object Object]' // This instantly filters out null, primitives, Arrays, Dates, RegExps, Maps, Sets, etc.
     ) {
         return false
     }

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -1,0 +1,42 @@
+export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOptions {
+    if (obj === null ||
+        obj === undefined ||
+        typeof obj !== 'object' ||
+        obj instanceof RegExp ||
+        Array.isArray(obj) ||
+        'asymmetricMatch' in obj
+    ) {
+        return false
+    }
+
+    // 3. Extract object keys
+    const objKeys = Object.keys(obj)
+
+    // Condition A: It is a completely empty object -> {}
+    if (objKeys.length === 0) {
+        return true
+    }
+
+    // 4. Combined whitelist of all optional properties from the interfaces
+    const allowedKeys = new Set([
+        // StringOptions
+        'ignoreCase',
+        'trim',
+        'containing',
+        'atStart',
+        'atEnd',
+        'atIndex',
+        'replace',
+        'asString',
+        // CommandOptions
+        'message',
+        // DefaultOptions
+        'wait',
+        'interval',
+        'beforeAssertion',
+        'afterAssertion'
+    ])
+
+    // Condition B: At least one key in the object exists in our whitelist
+    return objKeys.some(key => allowedKeys.has(key))
+}

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -39,5 +39,5 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
     ])
 
     // Condition B: At least one key in the object exists in our whitelist
-    return objKeys.some(key => allowedKeys.has(key))
+    return objKeys.every(key => allowedKeys.has(key))
 }

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -1,3 +1,22 @@
+const STRING_OPTIONS_ALLOWED_KEY_LIST = new Set([
+    // StringOptions
+    'ignoreCase',
+    'trim',
+    'containing',
+    'atStart',
+    'atEnd',
+    'atIndex',
+    'replace',
+    'asString',
+    // CommandOptions
+    'message',
+    // DefaultOptions
+    'wait',
+    'interval',
+    'beforeAssertion',
+    'afterAssertion'
+])
+
 export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOptions {
     if (obj === null ||
         obj === undefined ||
@@ -17,25 +36,5 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
         return true
     }
 
-    // 4. Combined whitelist of all optional properties from the interfaces
-    const allowedKeys = new Set([
-        // StringOptions
-        'ignoreCase',
-        'trim',
-        'containing',
-        'atStart',
-        'atEnd',
-        'atIndex',
-        'replace',
-        'asString',
-        // CommandOptions
-        'message',
-        // DefaultOptions
-        'wait',
-        'interval',
-        'beforeAssertion',
-        'afterAssertion'
-    ])
-
-    return objKeys.every(key => allowedKeys.has(key))
+    return objKeys.every(key => STRING_OPTIONS_ALLOWED_KEY_LIST.has(key))
 }

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -481,6 +481,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveElementProperty('prop', 'val')).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(element).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+
+                // Deprecated matchers
+                expectTypeOf(expect(element).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
             })
         })
 

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -451,6 +451,11 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveAttribute('class', 'val')).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveAttribute('class', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
 
+                // Deprecated matchers with undefined value
+                expectTypeOf(expect(element).toHaveAttribute('class', undefined)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveAttribute('class', undefined,  { wait: 1 })).toEqualTypeOf<Promise<void>>()
+
+                // Deprecated matchers
                 expectTypeOf(expect(element).toHaveAttr('class')).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveAttr('class', 'val')).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveAttr('class', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -58,12 +58,6 @@ describe(toHaveAttribute, () => {
                 expect(result.pass).toBe(true)
             })
 
-            test('not - failure when present for %s - pass should be true', async () => {
-                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
-
-                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-            })
-
             describe('message shows correctly', () => {
                 test('expect message', async () => {
                     vi.mocked(el.getAttribute).mockResolvedValue(null as unknown as string)
@@ -117,17 +111,6 @@ Received: false`
                 expect(result.pass).toBe(false)
             })
 
-            test.for([
-                undefined,
-                null
-            ])('not - failure when present for %s - pass should be false', async ( attributeValue) => {
-                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
-
-                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
-
-                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-            })
-
             describe('message shows correctly', () => {
                 test('expect message', async () => {
                     vi.mocked(el.getAttribute).mockResolvedValue('Wrong')
@@ -161,14 +144,31 @@ Received: "Wrong"`
             })
         })
 
-        describe('attribute does not exist or does not have a value', () => {
+        describe('given attribute existence', () => {
             test.for([
                 undefined,
                 null
-            ])('failure when not present for %s', async ( attributeValue) => {
+            ])('failure when not present (not expected value) for %s', async ( attributeValue) => {
                 vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
 
                 const result = await thisContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have attribute attribute_name
+
+Expected: true
+Received: false`
+                )
+            })
+
+            test.for([
+                undefined,
+                null
+            ])('failure when not present (not expected value but with options) for %s', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
+
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', { wait: 1, interval: 1 })
 
                 expect(result.pass).toBe(false)
             })
@@ -176,7 +176,7 @@ Received: "Wrong"`
             test.for([
                 undefined,
                 null
-            ])('failure when not present for %s', async ( attributeValue) => {
+            ])('failure when not present with undefined expected value for %s - deprecated', async ( attributeValue) => {
                 vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
 
                 const result = await thisContext.toHaveAttribute(el, 'attribute_name', undefined)
@@ -198,12 +198,25 @@ Received: "Wrong"`
             test.for([
                 undefined,
                 null
-            ])('not - success when not present for %s - pass should be false', async ( attributeValue) => {
+            ])('not - success when not present with undefined expected value for %s - pass should be false -- deprecated', async ( attributeValue) => {
                 vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
 
                 const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name', undefined)
 
                 expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+            })
+
+            test('not - failure when present for %s - pass should be true', async () => {
+                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                // TODO: The error message is misleading to fix one day?
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) not to have attribute attribute_name
+
+Expected [not]: false
+Received      : true`
+                )
             })
         })
     })

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -58,7 +58,7 @@ describe(toHaveAttribute, () => {
                 expect(result.pass).toBe(true)
             })
 
-            test('success when present by passing undefined value with options - deprecated', async () => {
+            test('success when checking with asymmetric matcher', async () => {
                 // Casting since we use vitest asymmetrics matcher instead of wdio one and TypeScript show a deprecation
                 const result = await thisContext.toHaveAttribute(el, 'attribute_name', expect.stringContaining('Correct') as AsymmetricMatcher<string>)
 

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -58,6 +58,13 @@ describe(toHaveAttribute, () => {
                 expect(result.pass).toBe(true)
             })
 
+            test('success when present by passing undefined value with options - deprecated', async () => {
+                // Casting since we use vitest asymmetrics matcher instead of wdio one and TypeScript show a deprecation
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', expect.stringContaining('Correct') as AsymmetricMatcher<string>)
+
+                expect(result.pass).toBe(true)
+            })
+
             describe('message shows correctly', () => {
                 test('expect message', async () => {
                     vi.mocked(el.getAttribute).mockResolvedValue(null as unknown as string)

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -1,140 +1,209 @@
 import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
 
-import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils.js'
-import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute.js'
-import type { AssertionResult } from 'expect-webdriverio'
+import { toHaveAttribute } from '../../../src/matchers/element/toHaveAttribute'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveAttribute', () => {
-    let el: ChainablePromiseElement
+describe(toHaveAttribute, () => {
+    let thisContext: { toHaveAttribute: typeof toHaveAttribute }
+    let thisIsNotContext: { isNot: boolean, toHaveAttribute: typeof toHaveAttribute }
 
-    beforeEach(async () => {
-        el = await $('sel')
+    beforeEach(() => {
+        thisContext = { toHaveAttribute }
+        thisIsNotContext = { isNot: true, toHaveAttribute }
     })
 
-    describe('attribute exists', () => {
-        test('success when present', async () => {
-            const beforeAssertion = vi.fn()
-            const afterAssertion = vi.fn()
-            el.getAttribute = vi.fn().mockResolvedValue('Correct Value')
+    describe('given single element', () => {
+        let el: ChainablePromiseElement
 
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', undefined, { beforeAssertion, afterAssertion })
+        beforeEach(async () => {
+            el = await $('sel')
+            vi.mocked(el.getAttribute).mockResolvedValue('Correct Value')
+        })
 
-            expect(result.pass).toBe(true)
-            expect(beforeAssertion).toBeCalledWith({
-                matcherName: 'toHaveAttribute',
-                expectedValue: ['attribute_name', undefined],
-                options: { beforeAssertion, afterAssertion }
+        describe('attribute exists', () => {
+            test('success when present', async () => {
+                const beforeAssertion = vi.fn()
+                const afterAssertion = vi.fn()
+
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', { beforeAssertion, afterAssertion, wait: 3, interval: 3 })
+
+                // TODO: to bring back later with a subsequent PR
+                //expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 3, interval: 3 })
+                expect(result.pass).toBe(true)
+                expect(beforeAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveAttribute',
+                    expectedValue: ['attribute_name', undefined],
+                    options: { beforeAssertion, afterAssertion, wait: 3, interval: 3 }
+                })
+                expect(afterAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveAttribute',
+                    expectedValue: ['attribute_name', undefined],
+                    options: { beforeAssertion, afterAssertion, wait: 3, interval: 3 },
+                    result
+                })
             })
-            expect(afterAssertion).toBeCalledWith({
-                matcherName: 'toHaveAttribute',
-                expectedValue: ['attribute_name', undefined],
-                options: { beforeAssertion, afterAssertion },
-                result
+
+            test('success when present by passing undefined value - deprecated', async () => {
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', undefined)
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('success when present by passing undefined value with options - deprecated', async () => {
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', undefined,  { wait: 1, interval: 1 })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('not - failure when present for %s - pass should be true', async () => {
+                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            })
+
+            describe('message shows correctly', () => {
+                test('expect message', async () => {
+                    vi.mocked(el.getAttribute).mockResolvedValue(null as unknown as string)
+
+                    const result = await thisContext.toHaveAttribute(el, 'attribute_name')
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have attribute attribute_name
+
+Expected: true
+Received: false`
+                    )
+                })
             })
         })
 
-        test('failure when not present', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue(null)
+        describe('attribute has value', () => {
+            test('success with correct value', async () => {
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', 'Correct Value', { ignoreCase: true, wait: 1 })
 
-            const result = await toHaveAttribute.call({}, el, 'attribute_name')
-
-            expect(result.pass).toBe(false)
-        })
-
-        describe('message shows correctly', () => {
-            let result: AssertionResult
-
-            beforeEach(async () => {
-                el.getAttribute = vi.fn().mockResolvedValue(null)
-
-                result = await toHaveAttribute.call({}, el, 'attribute_name')
+                expect(result.pass).toBe(true)
             })
-            test('expect message', () => {
-                expect(getExpectMessage(result.message())).toContain('to have attribute')
+
+            test('success with RegExp and correct value', async () => {
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', /cOrReCt VaLuE/i)
+
+                expect(result.pass).toBe(true)
             })
-            test('expected message', () => {
-                expect(getExpected(result.message())).toContain('true')
+
+            test('failure with wrong value', async () => {
+                vi.mocked(el.getAttribute).mockResolvedValue('Wrong Value')
+
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', 'Correct Value', { ignoreCase: true, wait: 1 })
+
+                expect(result.pass).toBe(false)
             })
-            test('received message', () => {
-                expect(getReceived(result.message())).toContain('false')
+
+            test('failure with non-string attribute value as actual', async () => {
+                vi.mocked(el.getAttribute).mockResolvedValue(123 as unknown as string)
+
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', 'Correct Value', { ignoreCase: true, wait: 1 })
+
+                expect(result.pass).toBe(false)
             })
-        })
-    })
 
-    describe('attribute has value', () => {
-        test('success with correct value', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue('Correct Value')
+            test('failure with non-string attribute value as expected', async () => {
+                // @ts-expect-error invalid type
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', 123, { ignoreCase: true, wait: 1 })
 
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', 'Correct Value', { ignoreCase: true })
-
-            expect(result.pass).toBe(true)
-        })
-        test('success with RegExp and correct value', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue('Correct Value')
-
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', /cOrReCt VaLuE/i)
-
-            expect(result.pass).toBe(true)
-        })
-        test('failure with wrong value', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue('Wrong Value')
-
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', 'Correct Value', { ignoreCase: true })
-
-            expect(result.pass).toBe(false)
-        })
-        test('failure with non-string attribute value as actual', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue(123)
-
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', 'Correct Value', { ignoreCase: true })
-
-            expect(result.pass).toBe(false)
-        })
-        test('failure with non-string attribute value as expected', async () => {
-            el.getAttribute = vi.fn().mockResolvedValue('Correct Value')
-
-            // @ts-expect-error invalid type
-            const result = await toHaveAttribute.call({}, el, 'attribute_name', 123, { ignoreCase: true })
-
-            expect(result.pass).toBe(false)
-        })
-        describe('message shows correctly', () => {
-            let result: AssertionResult
-
-            beforeEach(async () => {
-                el.getAttribute = vi.fn().mockResolvedValue('Wrong')
-
-                result = await toHaveAttribute.call({}, el, 'attribute_name', 'Correct')
+                expect(result.pass).toBe(false)
             })
-            test('expect message', () => {
-                expect(getExpectMessage(result.message())).toContain('to have attribute')
+
+            test.for([
+                undefined,
+                null
+            ])('not - failure when present for %s - pass should be false', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
+
+                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })
-            test('expected message', () => {
-                expect(getExpected(result.message())).toContain('Correct')
+
+            describe('message shows correctly', () => {
+                test('expect message', async () => {
+                    vi.mocked(el.getAttribute).mockResolvedValue('Wrong')
+
+                    const result = await thisContext.toHaveAttribute(el, 'attribute_name', 'Correct')
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have attribute attribute_name
+
+Expected: "Correct"
+Received: "Wrong"`
+                    )
+                })
             })
-            test('received message', () => {
-                expect(getReceived(result.message())).toContain('Wrong')
+
+            describe('failure with RegExp, message shows correctly', () => {
+                test('expect message', async () => {
+                    vi.mocked(el.getAttribute).mockResolvedValue('Wrong')
+
+                    const result = await thisContext.toHaveAttribute(el, 'attribute_name', /WDIO/)
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have attribute attribute_name
+
+Expected: /WDIO/
+Received: "Wrong"`
+                    )
+                })
             })
         })
-        describe('failure with RegExp, message shows correctly', () => {
-            let result: AssertionResult
 
-            beforeEach(async () => {
-                el.getAttribute = vi.fn().mockResolvedValue('Wrong')
+        describe('attribute does not exist or does not have a value', () => {
+            test.for([
+                undefined,
+                null
+            ])('failure when not present for %s', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
 
-                result = await toHaveAttribute.call({}, el, 'attribute_name', /WDIO/)
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(false)
             })
-            test('expect message', () => {
-                expect(getExpectMessage(result.message())).toContain('to have attribute')
+
+            test.for([
+                undefined,
+                null
+            ])('failure when not present for %s', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
+
+                const result = await thisContext.toHaveAttribute(el, 'attribute_name', undefined)
+
+                expect(result.pass).toBe(false)
             })
-            test('expected message', () => {
-                expect(getExpected(result.message())).toContain('/WDIO/')
+
+            test.for([
+                undefined,
+                null
+            ])('not - success when not present for %s - pass should be false', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
+
+                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })
-            test('received message', () => {
-                expect(getReceived(result.message())).toContain('Wrong')
+
+            test.for([
+                undefined,
+                null
+            ])('not - success when not present for %s - pass should be false', async ( attributeValue) => {
+                vi.mocked(el.getAttribute).mockResolvedValue(attributeValue as unknown as string)
+
+                const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name', undefined)
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })
         })
     })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -1,227 +1,147 @@
 import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
 
-import { getExpectMessage, getExpected, getReceived } from '../../__fixtures__/utils.js'
 import { toHaveElementProperty } from '../../../src/matchers/element/toHaveElementProperty.js'
-import type { AssertionResult } from 'expect-webdriverio'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveElementProperty', () => {
+describe(toHaveElementProperty, () => {
+    const thisContext = { toHaveElementProperty }
+    const thisIsNotContext = { isNot: true, toHaveElementProperty }
 
-    test('ignore case of stringified value', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
-        const beforeAssertion = vi.fn()
-        const afterAssertion = vi.fn()
+    describe('given a single element', () => {
+        let el: ChainablePromiseElement
 
-        const result = await toHaveElementProperty.call({}, el, 'property', 'iPhone', { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion })
-
-        expect(result.pass).toBe(true)
-        expect(el.getProperty).toHaveBeenCalledTimes(1)
-        expect(beforeAssertion).toBeCalledWith({
-            matcherName: 'toHaveElementProperty',
-            expectedValue: ['property', 'iPhone'],
-            options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion }
+        beforeEach(() => {
+            el = $('sel')
+            vi.mocked(el.getProperty).mockResolvedValue('iphone')
         })
-        expect(afterAssertion).toBeCalledWith({
-            matcherName: 'toHaveElementProperty',
-            expectedValue: ['property', 'iPhone'],
-            options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion },
-            result
+
+        test('ignore case of stringified value', async () => {
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
+
+            const result = await thisContext.toHaveElementProperty(el, 'property', 'iPhone', { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion })
+
+            expect(result.pass).toBe(true)
+            expect(el.getProperty).toHaveBeenCalledTimes(1)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveElementProperty',
+                expectedValue: ['property', 'iPhone'],
+                options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion }
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveElementProperty',
+                expectedValue: ['property', 'iPhone'],
+                options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion },
+                result
+            })
         })
-    })
 
-    test('assymeric match', async () => {
-        const el = await $('sel')
+        test('success with when property value is number', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
 
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
+            const result = await thisContext.toHaveElementProperty(el, 'property', 5)
 
-        const result = await toHaveElementProperty.call({}, el, 'property', expect.stringContaining('phone'))
-        expect(result.pass).toBe(true)
-    })
+            expect(result.pass).toBe(true)
+        })
 
-    test('should return false if values dont match', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
+        // TODO Need deep equality to support array and object properly
+        test('success with when property value an object, bug?', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue( { foo: 'bar' } )
 
-        const result = await toHaveElementProperty.bind({})(el, 'property', 'foobar', { wait: 1 })
+            // @ts-expect-error -- object not working for now, to support later
+            const result = await thisContext.toHaveElementProperty(el, 'property', { foo: 'bar' } )
 
-        expect(result.pass).toBe(false)
-    })
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property property
 
-    test('should return success (false) if values dont match when isNot is true', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
+Expected: {"foo": "bar"}
+Received: {"foo": "bar"}`
+            )
+        })
 
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'foobar', { wait: 1 })
+        test('assymeric match', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'property', expect.stringContaining('phone'))
+            expect(result.pass).toBe(true)
+        })
 
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
+        test('not - success - should return pass=false if values dont match', async () => {
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'foobar')
 
-    test('should return true if values match', async () => {
-        const el = await $('sel')
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        })
 
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
-        const result = await toHaveElementProperty.bind({})(el, 'property', 'iphone', { wait: 1 })
-        expect(result.pass).toBe(true)
-    })
+        test('not - failure - should return true if values match', async () => {
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'iphone')
 
-    test('should return failure (true) if values match when isNot is true', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'iphone', { wait: 1 })
-
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have property property
 
 Expected [not]: "iphone"
-Received      : "iphone"`
-        )
-    })
-
-    test('with RegExp should return true if values match', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('iphone')
-
-        const result = await toHaveElementProperty.call({}, el, 'property', /iPhOnE/i)
-
-        expect(result.pass).toBe(true)
-    })
-
-    test.for([
-        { propertyActualValue: null },
-        { propertyActualValue: undefined }]
-    )('return false for not defined actual if expected is defined since property does not exist', async ( { propertyActualValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(propertyActualValue)
-
-        const result = await toHaveElementProperty.bind({})(el, 'property', 'iphone', { wait: 1 })
-        expect(result.pass).toBe(false)
-    })
-
-    test.for([
-        { propertyActualValue: null },
-        { propertyActualValue: undefined }]
-    )('return success (false) for not defined actual and defined expected when isNot is true since property does not exist', async ({ propertyActualValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(propertyActualValue)
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'iphone', { wait: 1 })
-
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
-
-    test.for([
-        { expectedValue: null },
-        // { expectedValue: undefined } // fails a bug?
-    ]
-    )('should return true when property does exist by passing an not defined expected value', async ( { expectedValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('Test Value')
-
-        const result = await toHaveElementProperty.bind({})(el, 'property', expectedValue)
-
-        expect(result.pass).toBe(true)
-    })
-
-    test.for([
-        { expectedValue: null },
-        //{ expectedValue: undefined } // fails a bug?
-    ]
-    )('should return failure (true) if property exists by passing not defined expected value when isNot is true', async ( { expectedValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('Test Value')
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', expectedValue)
-
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-    })
-
-    // Bug? When requesting to have element property and it does exist should we return true here?
-    test.skip('return true if property is present', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('Test Value')
-
-        const result = await toHaveElementProperty.bind({})(el, 'property')
-        expect(result.pass).toBe(true)
-    })
-
-    // Bug? When requesting to not have element property and it does exist should we have a failure (pass=true?
-    test.skip('return failure (true) if property is present when isNot is true', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue('Test Value')
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property')
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-    })
-
-    test.for([
-        { expectedValue: null },
-        { expectedValue: undefined }
-    ]
-    )('return false if property is not present', async ({ expectedValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(expectedValue)
-
-        const result = await toHaveElementProperty.bind({})(el, 'property')
-        expect(result.pass).toBe(false)
-    })
-    test.for([
-        { expectedValue: null },
-        { expectedValue: undefined }
-    ]
-    )('return success (false) if value is not present when isNot is true', async ({ expectedValue }) => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(expectedValue)
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property')
-
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
-
-    test('should return false if value is non-string', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(5)
-
-        const result = await toHaveElementProperty.bind({})(el, 'property', 'Test Value')
-        expect(result.pass).toBe(false)
-    })
-
-    test('should return success (false) if value is non-string when isNot is true', async () => {
-        const el = await $('sel')
-        el.getProperty = vi.fn().mockResolvedValue(5)
-
-        const result = await toHaveElementProperty.bind({ isNot: true })(el, 'property', 'Test Value')
-
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
-
-    describe('failure with RegExp when value does not match', () => {
-        let result: AssertionResult
-
-        beforeEach(async () => {
-            const el = await $('sel')
-            el.getProperty = vi.fn().mockResolvedValue('iphone')
-
-            result = await toHaveElementProperty.call({}, el, 'property', /WDIO/, { wait: 1 })
+Received      : "iphone"`)
         })
 
-        test('failure', () => {
+        test('with RegExp should return true if values match', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'property', /iPhOnE/i)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test('should return false for undefined input', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(undefined)
+
+            const result = await thisContext.toHaveElementProperty(el, 'property', 'iphone')
+
             expect(result.pass).toBe(false)
         })
 
-        describe('message shows correctly', () => {
-            test('expect message', () => {
-                expect(getExpectMessage(result.message())).toContain('to have property')
-            })
-            test('expected message', () => {
-                expect(getExpected(result.message())).toContain('/WDIO/')
-            })
-            test('received message', () => {
-                expect(getReceived(result.message())).toContain('iphone')
+        test('should return false for null input', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(null)
+
+            const result = await thisContext.toHaveElementProperty(el, 'property', 'iphone')
+
+            expect(result.pass).toBe(false)
+        })
+
+        //TODO: False when expecting null and value is null, sounds like a bug?
+        test('should return true? if value is null', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(null)
+
+            const result = await thisContext.toHaveElementProperty(el, 'property', null)
+
+            expect(result.pass).toBe(false)
+        })
+
+        test('should return false if value is non-string', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisContext.toHaveElementProperty(el, 'property', 'Test Value')
+
+            expect(result.pass).toBe(false)
+        })
+
+        test('not - success - should return pass=false if value is non-string', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'Test Value')
+
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        })
+
+        describe('failure with RegExp when value does not match', () => {
+            test('failure', async () => {
+                const result = await thisContext.toHaveElementProperty(el, 'property', /WDIO/)
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property property
+
+Expected: /WDIO/
+Received: "iphone"`)
             })
         })
     })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -3,6 +3,8 @@ import { $ } from '@wdio/globals'
 
 import { toHaveElementProperty } from '../../../src/matchers/element/toHaveElementProperty.js'
 import stripAnsi from 'strip-ansi'
+import { jasmine } from '../../__mocks__/jasmine.js'
+// import { expect as wdioExpect } from '@wdio/globals'
 
 vi.mock('@wdio/globals')
 
@@ -22,18 +24,18 @@ describe(toHaveElementProperty, () => {
             const beforeAssertion = vi.fn()
             const afterAssertion = vi.fn()
 
-            const result = await thisContext.toHaveElementProperty(el, 'property', 'iPhone', { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion })
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 'iPhone', { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion })
 
             expect(result.pass).toBe(true)
             expect(el.getProperty).toHaveBeenCalledTimes(1)
             expect(beforeAssertion).toHaveBeenCalledWith({
                 matcherName: 'toHaveElementProperty',
-                expectedValue: ['property', 'iPhone'],
+                expectedValue: ['myPropertyName', 'iPhone'],
                 options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion }
             })
             expect(afterAssertion).toHaveBeenCalledWith({
                 matcherName: 'toHaveElementProperty',
-                expectedValue: ['property', 'iPhone'],
+                expectedValue: ['myPropertyName', 'iPhone'],
                 options: { wait: 0, ignoreCase: true, beforeAssertion, afterAssertion },
                 result
             })
@@ -42,7 +44,7 @@ describe(toHaveElementProperty, () => {
         test('success with when property value is number', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
-            const result = await thisContext.toHaveElementProperty(el, 'property', 5)
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 5)
 
             expect(result.pass).toBe(true)
         })
@@ -52,49 +54,136 @@ describe(toHaveElementProperty, () => {
             vi.mocked(el.getProperty).mockResolvedValue( { foo: 'bar' } )
 
             // @ts-expect-error -- object not working for now, to support later
-            const result = await thisContext.toHaveElementProperty(el, 'property', { foo: 'bar' } )
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', { foo: 'bar' } )
 
             expect(result.pass).toBe(false)
             expect(stripAnsi(result.message())).toEqual(`\
-Expect $(\`sel\`) to have property property
+Expect $(\`sel\`) to have property myPropertyName
 
 Expected: {"foo": "bar"}
 Received: {"foo": "bar"}`
             )
         })
 
-        test('assymeric match', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'property', expect.stringContaining('phone'))
+        test('assymeric match with vitest asymmetrics matcher', async () => {
+            // Casting since we use vitest asymmetrics matcher instead of wdio one and TypeScript show a deprecation
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', expect.stringContaining('phone') as AsymmetricMatcher<string>)
             expect(result.pass).toBe(true)
         })
 
+        test('assymeric match with jasmine matcher', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', jasmine.stringContaining('phone'))
+            expect(result.pass).toBe(true)
+        })
+
+        // TODO dprevost to debug
+        // test('assymeric match with wdio matcher', async () => {
+        //     const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.stringContaining('phone'))
+        //     expect(result.pass).toBe(true)
+        // })
+
         test('not - success - should return pass=false if values dont match', async () => {
-            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'foobar')
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName', 'foobar')
 
             expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
         })
 
         test('not - failure - should return true if values match', async () => {
-            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'iphone')
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName', 'iphone')
 
             expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
             expect(stripAnsi(result.message())).toEqual(`\
-Expect $(\`sel\`) not to have property property
+Expect $(\`sel\`) not to have property myPropertyName
 
 Expected [not]: "iphone"
 Received      : "iphone"`)
         })
 
         test('with RegExp should return true if values match', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'property', /iPhOnE/i)
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', /iPhOnE/i)
 
             expect(result.pass).toBe(true)
+        })
+
+        test.for([
+            { expectedValue: null },
+            { expectedValue: undefined }
+        ]
+        )('should return true when property does exist by passing an not defined expected value - deprecated', async ( { expectedValue }) => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', expectedValue)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test.for([
+            { expectedValue: null },
+            { expectedValue: undefined }
+        ]
+        )('not - should return failure (true) if property exists by passing not defined expected value when isNot is true - deprecated', async ( { expectedValue }) => {
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName', expectedValue)
+
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+        })
+
+        test('should return true when property does exist', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName')
+
+            expect(result.pass).toBe(true)
+        })
+
+        test.for([
+            { propertyValue: null },
+            { propertyValue: undefined }
+        ]
+        )('should return false when property does not exist', async ({ propertyValue }) => {
+            vi.mocked(el.getProperty).mockResolvedValue(propertyValue)
+
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName')
+
+            expect(result.pass).toBe(false)
+            // TODO error message is ambiguous, should be "Expected: true" instead of "Expected: false"
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
+
+Expected: true
+Received: false`
+            )
+        })
+
+        test('not - should return failure (true) if property exists', async () => {
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName')
+
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) not to have property myPropertyName
+
+Expected [not]: false
+Received      : true`)
+        })
+
+        test.for([
+            { propertyValue: null },
+            { propertyValue: undefined }
+        ]
+        )('not - should return success (false) when property does not exist', async ({ propertyValue }) => {
+            vi.mocked(el.getProperty).mockResolvedValue(propertyValue)
+
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName')
+
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+            // TODO error message is ambiguous, should be "Expected [not]: true" instead of "Expected [not]: false"
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) not to have property myPropertyName
+
+Expected [not]: false
+Received      : false`
+            )
         })
 
         test('should return false for undefined input', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(undefined)
 
-            const result = await thisContext.toHaveElementProperty(el, 'property', 'iphone')
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 'iphone')
 
             expect(result.pass).toBe(false)
         })
@@ -102,16 +191,7 @@ Received      : "iphone"`)
         test('should return false for null input', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(null)
 
-            const result = await thisContext.toHaveElementProperty(el, 'property', 'iphone')
-
-            expect(result.pass).toBe(false)
-        })
-
-        //TODO: False when expecting null and value is null, sounds like a bug?
-        test('should return true? if value is null', async () => {
-            vi.mocked(el.getProperty).mockResolvedValue(null)
-
-            const result = await thisContext.toHaveElementProperty(el, 'property', null)
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 'iphone')
 
             expect(result.pass).toBe(false)
         })
@@ -119,7 +199,7 @@ Received      : "iphone"`)
         test('should return false if value is non-string', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
-            const result = await thisContext.toHaveElementProperty(el, 'property', 'Test Value')
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 'Test Value')
 
             expect(result.pass).toBe(false)
         })
@@ -127,18 +207,18 @@ Received      : "iphone"`)
         test('not - success - should return pass=false if value is non-string', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
-            const result = await thisIsNotContext.toHaveElementProperty(el, 'property', 'Test Value')
+            const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName', 'Test Value')
 
             expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
         })
 
         describe('failure with RegExp when value does not match', () => {
             test('failure', async () => {
-                const result = await thisContext.toHaveElementProperty(el, 'property', /WDIO/)
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', /WDIO/)
 
                 expect(result.pass).toBe(false)
                 expect(stripAnsi(result.message())).toEqual(`\
-Expect $(\`sel\`) to have property property
+Expect $(\`sel\`) to have property myPropertyName
 
 Expected: /WDIO/
 Received: "iphone"`)

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -130,6 +130,12 @@ Received      : "iphone"`)
             expect(result.pass).toBe(true)
         })
 
+        test('should return true when property does exist by passing an not defined expected value with options', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', { wait: 0 })
+
+            expect(result.pass).toBe(true)
+        })
+
         test.for([
             { expectedValue: null },
             { expectedValue: undefined }

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -4,7 +4,6 @@ import { $ } from '@wdio/globals'
 import { toHaveElementProperty } from '../../../src/matchers/element/toHaveElementProperty.js'
 import stripAnsi from 'strip-ansi'
 import { jasmine } from '../../__mocks__/jasmine.js'
-// import { expect as wdioExpect } from '@wdio/globals'
 
 vi.mock('@wdio/globals')
 
@@ -75,12 +74,6 @@ Received: {"foo": "bar"}`
             const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', jasmine.stringContaining('phone'))
             expect(result.pass).toBe(true)
         })
-
-        // TODO dprevost to debug
-        // test('assymeric match with wdio matcher', async () => {
-        //     const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.stringContaining('phone'))
-        //     expect(result.pass).toBe(true)
-        // })
 
         test('not - success - should return pass=false if values dont match', async () => {
             const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName', 'foobar')

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -40,10 +40,32 @@ describe(toHaveElementProperty, () => {
             })
         })
 
-        test('success with when property value is number', async () => {
+        test('success with when property value is number and expected is the same number', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
             const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 5)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test('fail with when property value is number and expected is a string without asString option', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', '5')
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
+
+Expected: "5"
+Received: 5`
+            )
+        })
+
+        test('success with when property value is number and expected is a string with asString option', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', '5', { asString: true })
 
             expect(result.pass).toBe(true)
         })

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isStringOptions } from '../../src/util/commandOptionsUtils'
+
+describe('isStringOptions Type Guard', () => {
+
+    // 1. Testing Requirement: Empty Objects
+    describe('Empty Objects', () => {
+        it('should return true for a completely empty object literal', () => {
+            expect(isStringOptions({})).toBe(true)
+        })
+    })
+
+    // 2. Testing Requirement: StringOptions Properties
+    describe('StringOptions Properties', () => {
+        it('should return true for objects containing StringOptions properties', () => {
+            expect(isStringOptions({ ignoreCase: true })).toBe(true)
+            expect(isStringOptions({ trim: false })).toBe(true)
+            expect(isStringOptions({ containing: true })).toBe(true)
+            expect(isStringOptions({ atStart: true })).toBe(true)
+            expect(isStringOptions({ atEnd: false })).toBe(true)
+            expect(isStringOptions({ atIndex: 2 })).toBe(true)
+            expect(isStringOptions({ replace: ['foo', 'bar'] })).toBe(true)
+            expect(isStringOptions({ asString: true })).toBe(true)
+        })
+    })
+
+    // 3. Testing Requirement: Inherited CommandOptions & DefaultOptions Properties
+    describe('Parent Interface Properties (CommandOptions & DefaultOptions)', () => {
+        it('should return true for objects containing inherited properties', () => {
+            expect(isStringOptions({ message: 'Custom Error Message' })).toBe(true)
+            expect(isStringOptions({ wait: 5000 })).toBe(true)
+            expect(isStringOptions({ interval: 200 })).toBe(true)
+            expect(isStringOptions({ beforeAssertion: async () => {} })).toBe(true)
+            expect(isStringOptions({ afterAssertion: async () => {} })).toBe(true)
+        })
+
+        it('should return true for a mixed configuration object', () => {
+            const mixedOptions = {
+                trim: true,
+                wait: 1000,
+                message: 'Failed assertion'
+            }
+            expect(isStringOptions(mixedOptions)).toBe(true)
+        })
+    })
+
+    // 4. Testing Requirement: Non-Option Objects (Exclusions)
+    describe('Invalid Configurations & False Positives', () => {
+        it('should return false for primitive types and null', () => {
+            expect(isStringOptions('some-string-value')).toBe(false)
+            expect(isStringOptions(123)).toBe(false)
+            expect(isStringOptions(true)).toBe(false)
+            expect(isStringOptions(null)).toBe(false)
+            expect(isStringOptions(undefined)).toBe(false)
+        })
+
+        it('should return false for RegExp instances', () => {
+            expect(isStringOptions(/test-regex/i)).toBe(false)
+            expect(isStringOptions(new RegExp('test'))).toBe(false)
+        })
+
+        it('should return false for Asymmetric Matchers', () => {
+            // Mocking an asymmetric matcher object shape like expect.stringContaining()
+            const mockAsymmetricMatcher = {
+                asymmetricMatch: vi.fn(),
+                toString: vi.fn()
+            }
+            expect(isStringOptions(mockAsymmetricMatcher)).toBe(false)
+        })
+
+        it('should return false for plain objects with unrelated custom properties', () => {
+            expect(isStringOptions({ customKey: 'not-an-option' })).toBe(false)
+            expect(isStringOptions({ id: 'element-id', class: 'btn' })).toBe(false)
+        })
+    })
+})

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -44,7 +44,7 @@ describe('isStringOptions Type Guard', () => {
         })
     })
 
-    // 4. Testing Requirement: Non-Option Objects (Exclusions)
+    // 4. Testing Requirement: Invalid Configurations & False Positives
     describe('Invalid Configurations & False Positives', () => {
         it('should return false for primitive types and null', () => {
             expect(isStringOptions('some-string-value')).toBe(false)
@@ -60,7 +60,6 @@ describe('isStringOptions Type Guard', () => {
         })
 
         it('should return false for Asymmetric Matchers', () => {
-            // Mocking an asymmetric matcher object shape like expect.stringContaining()
             const mockAsymmetricMatcher = {
                 asymmetricMatch: vi.fn(),
                 toString: vi.fn()
@@ -68,9 +67,14 @@ describe('isStringOptions Type Guard', () => {
             expect(isStringOptions(mockAsymmetricMatcher)).toBe(false)
         })
 
-        it('should return false for plain objects with unrelated custom properties', () => {
+        it('should return false for plain objects with all unrelated custom properties', () => {
             expect(isStringOptions({ customKey: 'not-an-option' })).toBe(false)
             expect(isStringOptions({ id: 'element-id', class: 'btn' })).toBe(false)
+        })
+
+        it('should return false for arrays and other object-type built-ins', () => {
+            expect(isStringOptions(['trim', 'ignoreCase'])).toBe(false)
+            expect(isStringOptions(new Date())).toBe(false)
         })
     })
 })

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -83,4 +83,38 @@ describe('isStringOptions Type Guard', () => {
             expect(isStringOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
         })
     })
+
+    describe('Interface Exhaustiveness Guard', () => {
+        it('should compile successfully only if all interface keys are covered', () => {
+        // This object maps EVERY allowed key from your Set.
+        // We cast it strictly to require all optional keys from the combined types.
+            const typeCompletenessCheck: Required<
+            ExpectWebdriverIO.StringOptions &
+            ExpectWebdriverIO.CommandOptions &
+            ExpectWebdriverIO.DefaultOptions
+            > = {
+            // StringOptions
+                ignoreCase: true,
+                trim: true,
+                containing: true,
+                atStart: true,
+                atEnd: true,
+                atIndex: 1,
+                replace: ['searchPattern', 'replacementValue'],
+                asString: true,
+
+                // CommandOptions
+                message: '',
+
+                // DefaultOptions
+                wait: 0,
+                interval: 0,
+                beforeAssertion: async () => {},
+                afterAssertion: async () => {}
+            }
+
+            // Run the runtime check against the fully-populated type asset
+            expect(isStringOptions(typeCompletenessCheck)).toBe(true)
+        })
+    })
 })

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -12,7 +12,7 @@ describe('isStringOptions Type Guard', () => {
 
     // 2. Testing Requirement: StringOptions Properties
     describe('StringOptions Properties', () => {
-        it('should return true for objects containing StringOptions properties', () => {
+        it('should return true for objects containing valid StringOptions properties', () => {
             expect(isStringOptions({ ignoreCase: true })).toBe(true)
             expect(isStringOptions({ trim: false })).toBe(true)
             expect(isStringOptions({ containing: true })).toBe(true)
@@ -30,11 +30,11 @@ describe('isStringOptions Type Guard', () => {
             expect(isStringOptions({ message: 'Custom Error Message' })).toBe(true)
             expect(isStringOptions({ wait: 5000 })).toBe(true)
             expect(isStringOptions({ interval: 200 })).toBe(true)
-            expect(isStringOptions({ beforeAssertion: async () => {} })).toBe(true)
-            expect(isStringOptions({ afterAssertion: async () => {} })).toBe(true)
+            expect(isStringOptions({ beforeAssertion: async () => { } })).toBe(true)
+            expect(isStringOptions({ afterAssertion: async () => { } })).toBe(true)
         })
 
-        it('should return true for a mixed configuration object', () => {
+        it('should return true for a fully valid mixed configuration object', () => {
             const mixedOptions = {
                 trim: true,
                 wait: 1000,
@@ -75,6 +75,12 @@ describe('isStringOptions Type Guard', () => {
         it('should return false for arrays and other object-type built-ins', () => {
             expect(isStringOptions(['trim', 'ignoreCase'])).toBe(false)
             expect(isStringOptions(new Date())).toBe(false)
+        })
+
+        it('should return false for objects containing valid options mixed with invalid/unrecognized keys', () => {
+            expect(isStringOptions({ trim: true, invalidProperty: 'malicious-or-typo' })).toBe(false)
+            expect(isStringOptions({ wait: 2000, href: '/path/to/element' })).toBe(false)
+            expect(isStringOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
         })
     })
 })

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -233,7 +233,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null,
+            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -220,7 +220,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
          */
         (
             property: string,
-            value: undefined,
+            value: undefined | null,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
 
@@ -233,7 +233,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null,
+            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -152,7 +152,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
 
     toHaveAttribute: FnWhenElementOrArrayLike<ActualT, {
         /**
-         * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveAttribute(attribute, options)`.
+         * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveAttribute(attribute, options)`.
          */
         (
             attribute: string,
@@ -216,7 +216,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
 
     toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, {
         /**
-         * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
+         * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
          */
         (
             property: string,

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -175,7 +175,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }>
 
     /**
-     * @deprecated since v5.6.9 Use `toHaveAttribute` instead.
+     * @deprecated since v5.7.1 Use `toHaveAttribute` instead.
      * `WebdriverIO.Element` -> `getAttribute`
      */
     toHaveAttr: FnWhenElementOrArrayLike<ActualT, (

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -150,19 +150,37 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      */
     toBeExisting: FnWhenElementOrArrayLike<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
 
-    /**
-     * `WebdriverIO.Element` -> `getAttribute`
-     */
-    toHaveAttribute: FnWhenElementOrArrayLike<ActualT, (
-        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions)
-    => Promise<void>>
+    toHaveAttribute: FnWhenElementOrArrayLike<ActualT, {
+        /**
+         * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveAttribute(attribute, options)`.
+         */
+        (
+            attribute: string,
+            value: undefined,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+
+        /** Check ONLY for the presence of the attribute (and optional configuration options) */
+        (
+            attribute: string,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+
+        /** Assert both attribute name AND a specific expected value */
+        (
+            attribute: string,
+            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+    }>
 
     /**
+     * @deprecated since v5.6.9 Use `toHaveAttribute` instead.
      * `WebdriverIO.Element` -> `getAttribute`
      */
     toHaveAttr: FnWhenElementOrArrayLike<ActualT, (
-        attribute: string, value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+        attribute: string,
+        value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
         options?: ExpectWebdriverIO.StringOptions
     ) => Promise<void>>
 
@@ -196,17 +214,29 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         options?: ExpectWebdriverIO.StringOptions
     ) => Promise<void>>
 
-    /**
-     * `WebdriverIO.Element` -> `getProperty`
-     */
-    toHaveElementProperty: FnWhenElementOrArrayLike<
-        ActualT,
+    toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, {
+        /**
+         * @deprecated since 5.6.10 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
+         */
         (
             property: string,
-            value?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null,
-            options?: ExpectWebdriverIO.StringOptions,
-        ) => Promise<void>
-    >
+            value: undefined,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+
+        /** Check ONLY for the presence of the property (and optional configuration options) */
+        (
+            property: string,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+
+        /** Assert both property name AND a specific expected value */
+        (
+            property: string,
+            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>;
+    }>
 
     /**
      * `WebdriverIO.Element` -> `getProperty` value
@@ -634,7 +664,7 @@ declare namespace ExpectWebdriverIO {
     const wdioCustomMatchers: MatchersObject
 
     /**
-     * @deprecated use `wdioCustomMatchers` instead
+     * @deprecated since 5.6.9 use `wdioCustomMatchers` instead
      */
     const matchers: Map<string, RawMatcherFn>
 


### PR DESCRIPTION
Ease the signature when checking the existence of an attribute so that we can do
```ts
await expect(el).toHaveAttribute(el, 'attribute_name', { wait: 0 })
await expect(elem).toHaveElementProperty('height', { wait: 0 })
```
instead of
```ts
await expect(el).toHaveAttribute(el, 'attribute_name', undefined, { wait: 0 })
await expect(elem).toHaveElementProperty('height', undefined, { wait: 0 })
await expect(elem).toHaveElementProperty('height', null, { wait: 0 })
```
Other
- Fix missing command options when doing waitUntil on `toHaveAttribute` when passing no expect value
- Add a few refactorings prior to supporting $$

