### PR TITLE
feat: Replace NumberOptions by NumberMatcher + parser utility

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -663,6 +663,13 @@ Checks if element has a specific width.
 await browser.url('http://github.com')
 const logo = await $('.octicon-mark-github')
 await expect(logo).toHaveWidth(32)
+// Same as
+await expect(logo).toHaveWidth({ eq: 32 })
+
+// Greater/Less than equals or in between
+await expect(logo).toHaveWidth({ gte: 32 })
+await expect(logo).toHaveWidth({ lte: 34 })
+await expect(logo).toHaveWidth({ gte: 32, lte: 34 })
 ```
 
 ### toHaveHeight
@@ -675,11 +682,19 @@ Checks if element has a specific height.
 await browser.url('http://github.com')
 const logo = await $('.octicon-mark-github')
 await expect(logo).toHaveHeight(32)
+// Same as
+await expect(logo).toHaveHeight({ eq: 32 })
+
+// Greater/Less than equals or in between
+await expect(logo).toHaveHeight({ gte: 32 })
+await expect(logo).toHaveHeight({ lte: 34 })
+await expect(logo).toHaveHeight({ gte: 32, lte: 34 })
 ```
 
 ### toHaveSize
 
 Checks if element has a specific size.
+**Note:** gte and lte or not supported yet.
 
 ##### Usage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -716,9 +716,14 @@ Checks amount of fetched elements using [`$$`](https://webdriver.io/docs/api/ele
 const listItems = await $$('ul>li')
 await expect(listItems).toBeElementsArrayOfSize(5) // 5 items in the list
 
+// Greater/Less then
 await expect(listItems).toBeElementsArrayOfSize({ lte: 10 })
 // same as
 assert.ok(listItems.length <= 10)
+
+await expect(listItems).toBeElementsArrayOfSize({ gte: 5 })
+// In between
+await expect(listItems).toBeElementsArrayOfSize({ gte: 5, lte: 5 })
 ```
 
 ## Network Matchers
@@ -742,9 +747,12 @@ Checks that mock was called for the expected amount of times
 
 ```js
 const mock = browser.mock('**/api/todo*')
-await expect(mock).toBeRequestedTimes(2) // await expect(mock).toBeRequestedTimes({ eq: 2 })
+await expect(mock).toBeRequestedTimes(2)
+// same as
+await expect(mock).toBeRequestedTimes({ eq: 2 })
 
-await expect(mock).toBeRequestedTimes({ gte: 5, lte: 10 }) // request called at least 5 times but less than 11
+// request called at least 5 times but less than 11
+await expect(mock).toBeRequestedTimes({ gte: 5, lte: 10 }) 
 ```
 
 ### toBeRequestedWith

--- a/docs/API.md
+++ b/docs/API.md
@@ -694,7 +694,7 @@ await expect(logo).toHaveHeight({ gte: 32, lte: 34 })
 ### toHaveSize
 
 Checks if element has a specific size.
-**Note:** gte and lte or not supported yet.
+**Note:** gte and lte are not supported yet.
 
 ##### Usage
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,8 @@ export default wdioEslint.config([
         },
         rules: {
             '@typescript-eslint/no-require-imports': 'off',
-            '@typescript-eslint/no-explicit-any': 'off'
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/consistent-type-imports': 'off'
         }
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import wdioEslint from '@wdio/eslint'
+import vitest from '@vitest/eslint-plugin'
 
 export default wdioEslint.config([
     {
@@ -24,10 +25,14 @@ export default wdioEslint.config([
                 beforeEach: true
             }
         },
+        plugins: {
+            vitest
+        },
         rules: {
             '@typescript-eslint/no-require-imports': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/consistent-type-imports': 'off'
+            '@typescript-eslint/consistent-type-imports': 'off',
+            'vitest/no-identical-title': 'error',
         }
     },
     {
@@ -87,7 +92,7 @@ export default wdioEslint.config([
             }
         },
         rules: {
-            'local/enforce-options-list': 'error'
+            'local/enforce-options-list': 'error',
         }
     }
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,9 +2115,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2138,9 +2132,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2158,9 +2149,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2178,9 +2166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2198,9 +2183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.12.4",
         "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/eslint-plugin": "^1.6.21",
         "@wdio/eslint": "^0.1.3",
         "@wdio/types": "^9.27.2",
         "eslint": "^9.39.4",
@@ -622,9 +623,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2766,6 +2767,230 @@
         "@vitest/browser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.21.tgz",
+      "integrity": "sha512-5nu7QuW5Dg9v4I9t9ZiU1Hh91BoG0x3lOzOWYTsr1bqpIqcHYzFSQ052LvZwGtEm7Trh+Mr2heYEmZ4LkDjfaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8976,9 +9201,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.12.4",
     "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/eslint-plugin": "^1.6.21",
     "@wdio/eslint": "^0.1.3",
     "@wdio/types": "^9.27.2",
     "eslint": "^9.39.4",

--- a/playgrounds/mocha/test/specs/network-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/network-matchers.test.ts
@@ -77,12 +77,19 @@ describe('Network Matchers', () => {
         await expect(mock).toBeRequestedTimes({ gte: 1, lte: 2 })
     })
 
-
     it('should assert times called lte with options', async () => {
         await expect(mock).toBeRequestedTimes({ lte: 2 }, { wait: 0 })
     })
 
     it('should assert times called lte with options - deprecated', async () => {
         await expect(mock).toBeRequestedTimes({ lte: 2, wait: 0 })
+    })
+
+    it('should be requested', async () => {
+        await expect(mock).toBeRequested()
+    })
+
+    it('should throw an error when asserting not be requested', async () => {
+        await expect(expect(mock).not.toBeRequested()).rejects.toThrow()
     })
 })

--- a/playgrounds/mocha/test/specs/network-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/network-matchers.test.ts
@@ -61,4 +61,28 @@ describe('Network Matchers', () => {
             )
     })
 
+    it('should assert times called', async () => {
+        await expect(mock).toBeRequestedTimes(1)
+    })
+
+    it('should assert times called gte', async () => {
+        await expect(mock).toBeRequestedTimes({ gte: 1 })
+    })
+
+    it('should assert times called lte', async () => {
+        await expect(mock).toBeRequestedTimes({ lte: 2 })
+    })
+
+    it('should assert times called gte and lte', async () => {
+        await expect(mock).toBeRequestedTimes({ gte: 1, lte: 2 })
+    })
+
+
+    it('should assert times called lte with options', async () => {
+        await expect(mock).toBeRequestedTimes({ lte: 2 }, { wait: 0 })
+    })
+
+    it('should assert times called lte with options - deprecated', async () => {
+        await expect(mock).toBeRequestedTimes({ lte: 2, wait: 0 })
+    })
 })

--- a/playgrounds/mocha/wdio.conf.ts
+++ b/playgrounds/mocha/wdio.conf.ts
@@ -23,6 +23,7 @@ export const config: WebdriverIO.Config = {
         //'./test/specs/**/soft-expect.test.ts',
         //'./test/specs/**/snapshot.test.ts'
         //'./test/specs/**/wdio-matchers.test.ts'
+        //'./test/specs/**/network-matchers.test.ts'
     ],
 
     //

--- a/playgrounds/package-lock.json
+++ b/playgrounds/package-lock.json
@@ -41,6 +41,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.12.4",
         "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/eslint-plugin": "^1.6.21",
         "@wdio/eslint": "^0.1.3",
         "@wdio/types": "^9.27.2",
         "eslint": "^9.39.4",

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -79,7 +79,7 @@ async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: s
 }
 
 /**
- * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
+ * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
  */
 export async function toHaveAttribute(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -58,11 +58,13 @@ async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: s
     const { expectation = 'attribute', verb = 'have', isNot } = this
 
     let el = await received?.getElement()
+    let actualAttributeValue
 
     const pass = await waitUntil(
         async () => {
             const result = await executeCommand.call(this, el, conditionAttributeIsPresent, options, [attribute])
             el = result.el as WebdriverIO.Element
+            actualAttributeValue = result.values
 
             return result.success
         },
@@ -70,7 +72,9 @@ async function toHaveAttributeFn(received: WdioElementMaybePromise, attribute: s
         { wait: options.wait, interval: options.interval }
     )
 
-    const message = enhanceError(el, !isNot, pass, this, verb, expectation, attribute, options)
+    const expected = 'to have a defined value'
+    const actual = `value ${actualAttributeValue}`
+    const message = enhanceError(el, expected, actual, this, verb, expectation, attribute, options)
 
     return {
         pass,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -57,14 +57,17 @@ export async function toHaveChildren(
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
     expectedValueOrOptions?: number | ExpectWebdriverIO.NumberMatcher | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions,
-    options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
+    options?: ExpectWebdriverIO.CommandOptions
 ): Promise<ExpectWebdriverIO.AsyncAssertionResult> {
     const matcherName = 'toHaveChildren'
     const { expectation = 'children', verb = 'have', isNot } = this
 
-    // Properly support new case where the second argument is the commandOptions and not a number or NumberMatcher for a clear API.
-    if (isStrictlyCommandOptions(expectedValueOrOptions)) {
-        options = expectedValueOrOptions ?? DEFAULT_OPTIONS
+    const hasOnlyTwoArgs = options === undefined
+    options = options ?? DEFAULT_OPTIONS
+
+    // Properly support new case `toHaveChildren(commandOptions)` where the second argument is the commandOptions and not a number or NumberMatcher for a clearer API instead of `toHaveChildren(undefined, commandOptions)`.
+    if (hasOnlyTwoArgs && isStrictlyCommandOptions(expectedValueOrOptions)) {
+        options = expectedValueOrOptions
         expectedValueOrOptions = undefined
     }
 

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
-import { isDefinedObject, isStriclyCommandOptions } from '../../util/commandOptionsUtils.js'
+import { isDefinedObject, isStrictlyCommandOptions } from '../../util/commandOptionsUtils.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
 import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
@@ -62,12 +62,12 @@ export async function toHaveChildren(
     const matcherName = 'toHaveChildren'
     const { expectation = 'children', verb = 'have', isNot } = this
 
-    // Extract beforeAssertion and afterAssertion from either expectedValueOrOptions or options, done before isStriclyCommandOptions check to ensurewe stay backward compatible with deprecated NumberOptions usage. To remove in next major version.
+    // Extract beforeAssertion and afterAssertion from either expectedValueOrOptions or options, done before isStrictlyCommandOptions check to ensure we stay backward compatible with deprecated NumberOptions usage. To remove in next major version.
     const beforeAssertion = ( isDefinedObject(expectedValueOrOptions) && 'beforeAssertion' in expectedValueOrOptions ? expectedValueOrOptions.beforeAssertion ?? options.beforeAssertion : options.beforeAssertion)
     const afterAssertion = ( isDefinedObject(expectedValueOrOptions) && 'afterAssertion' in expectedValueOrOptions ? expectedValueOrOptions.afterAssertion ?? options.afterAssertion : options.afterAssertion )
 
     // New case where second argument is strictly the options object, and no expected value is provided.
-    if (isStriclyCommandOptions(expectedValueOrOptions)) {
+    if (isStrictlyCommandOptions(expectedValueOrOptions)) {
         options =  expectedValueOrOptions
         expectedValueOrOptions = undefined // Let's fake an omitted expected to undefined for now.
     }

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -78,13 +78,8 @@ export async function toHaveChildren(
         options,
     })
 
-    let expectedValue: NumberMatcher
-    let commandOptions: ExpectWebdriverIO.CommandOptions = options
-    if (isStriclyCommandOptions(expectedValueOrOptions)) {
-        ({ numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(undefined, expectedValueOrOptions, true))
-    } else {
-        ({ numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(expectedValueOrOptions, options, true))
-    }
+    // After the beforeAssertion hook, so backward compatibility is kept when expectedValueOrOptions is undefined instead of default value. To change on next major?
+    const { numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(expectedValueOrOptions, options, true)
 
     let el = await received?.getElement()
     let children

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -63,7 +63,7 @@ export async function toHaveChildren(
     const { expectation = 'children', verb = 'have', isNot } = this
 
     // Extract beforeAssertion and afterAssertion from either expectedValueOrOptions or options, done before isStriclyCommandOptions check to ensurewe stay backward compatible with deprecated NumberOptions usage. To remove in next major version.
-    const beforeAssertion = ( isDefinedObject(expectedValueOrOptions) && 'beforeAssertion' in expectedValueOrOptions ? expectedValueOrOptions.beforeAssertion ?? options.afterAssertion : options.beforeAssertion)
+    const beforeAssertion = ( isDefinedObject(expectedValueOrOptions) && 'beforeAssertion' in expectedValueOrOptions ? expectedValueOrOptions.beforeAssertion ?? options.beforeAssertion : options.beforeAssertion)
     const afterAssertion = ( isDefinedObject(expectedValueOrOptions) && 'afterAssertion' in expectedValueOrOptions ? expectedValueOrOptions.afterAssertion ?? options.afterAssertion : options.afterAssertion )
 
     // New case where second argument is strictly the options object, and no expected value is provided.

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
-import { isDefinedObject, isStrictlyCommandOptions } from '../../util/commandOptionsUtils.js'
+import { isStrictlyCommandOptions } from '../../util/commandOptionsUtils.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
 import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
@@ -56,35 +56,30 @@ export async function toHaveChildren(
 
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
-    expectedValueOrOptions: number | ExpectWebdriverIO.NumberMatcher | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions | undefined,
+    expectedValueOrOptions?: number | ExpectWebdriverIO.NumberMatcher | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ): Promise<ExpectWebdriverIO.AsyncAssertionResult> {
     const matcherName = 'toHaveChildren'
     const { expectation = 'children', verb = 'have', isNot } = this
 
-    // Extract beforeAssertion and afterAssertion from either expectedValueOrOptions or options, done before isStrictlyCommandOptions check to ensure we stay backward compatible with deprecated NumberOptions usage. To remove in next major version.
-    const beforeAssertion = ( isDefinedObject(expectedValueOrOptions) && 'beforeAssertion' in expectedValueOrOptions ? expectedValueOrOptions.beforeAssertion ?? options.beforeAssertion : options.beforeAssertion)
-    const afterAssertion = ( isDefinedObject(expectedValueOrOptions) && 'afterAssertion' in expectedValueOrOptions ? expectedValueOrOptions.afterAssertion ?? options.afterAssertion : options.afterAssertion )
-
-    // New case where second argument is strictly the options object, and no expected value is provided.
+    // Properly support new case where the second argument is the commandOptions and not a number or NumberMatcher for a clear API.
     if (isStrictlyCommandOptions(expectedValueOrOptions)) {
-        options =  expectedValueOrOptions
-        expectedValueOrOptions = undefined // Let's fake an omitted expected to undefined for now.
+        options = expectedValueOrOptions ?? DEFAULT_OPTIONS
+        expectedValueOrOptions = undefined
     }
 
-    await beforeAssertion?.({
+    const { numberMatcher: expectedNumber, commandOptions } = validateNumberAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
+
+    await commandOptions.beforeAssertion?.({
         matcherName,
-        expectedValue: expectedValueOrOptions,
+        expectedValue: expectedValueOrOptions, // Send unaltered value to the hook for backward compatibility
         options,
     })
-
-    // After the beforeAssertion hook, so backward compatibility is kept when expectedValueOrOptions is undefined instead of default value. To change on next major?
-    const { numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(expectedValueOrOptions, options, true)
 
     let el = await received?.getElement()
     let children
     const pass = await waitUntil(async () => {
-        const result = await executeCommand.call(this, el, condition, commandOptions, [expectedValue])
+        const result = await executeCommand.call(this, el, condition, commandOptions, [expectedNumber])
         el = result.el as WebdriverIO.Element
         children = result.values
 
@@ -93,14 +88,14 @@ export async function toHaveChildren(
     isNot,
     { wait: commandOptions.wait, interval: commandOptions.interval })
 
-    const expectedArray = wrapExpectedWithArray(el, children, expectedValue)
+    const expectedArray = wrapExpectedWithArray(el, children, expectedNumber)
     const message = enhanceError(el, expectedArray, children, this, verb, expectation, '', commandOptions)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message
     }
 
-    await afterAssertion?.({
+    await commandOptions.afterAssertion?.({
         matcherName,
         expectedValue: expectedValueOrOptions,
         options,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -37,7 +37,7 @@ export async function toHaveChildren(
 ): Promise<ExpectWebdriverIO.AsyncAssertionResult>
 
 /**
- * When called with an expected child count or number options.
+ * When called with an expected child count or number matcher.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -20,7 +20,7 @@ async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher) 
 }
 
 /**
- * @deprecated Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, options)`.
+ * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, options)`.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
@@ -46,7 +46,7 @@ export async function toHaveChildren(
 ): Promise<ExpectWebdriverIO.AsyncAssertionResult>
 
 /**
- * @deprecated since 5.7.1, NumberOptions is no longer supported. Use `toHaveChildren(el, numberMatcher, options)` instead.
+ * deprecated since 5.7.1, remove in v6.0.0. NumberOptions is no longer supported. Use `toHaveChildren(el, numberMatcher, options)` instead.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,74 +1,113 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
+import { isDefinedObject, isStriclyCommandOptions } from '../../util/commandOptionsUtils.js'
+import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
+import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
-    compareNumbers,
     enhanceError,
     executeCommand,
-    numberError,
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
 
-async function condition(el: WebdriverIO.Element, options: ExpectWebdriverIO.NumberOptions) {
+async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher) {
     const children = await el.$$('./*').getElements()
 
-    // If no options passed in + children exists
-    if (
-        typeof options.lte !== 'number' &&
-        typeof options.gte !== 'number' &&
-        typeof options.eq !== 'number'
-    ) {
-        return {
-            result: children.length > 0,
-            value: children?.length
-        }
-    }
-
     return {
-        result: compareNumbers(children?.length, options),
+        result: expectedValue.match(children?.length),
         value: children?.length
     }
 }
 
+/**
+ * @deprecated Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, options)`.
+ */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
-    expectedValue?: number | ExpectWebdriverIO.NumberOptions,
-    options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
-    const isNot = this.isNot
-    const { expectation = 'children', verb = 'have' } = this
+    expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AsyncAssertionResult>
 
-    await options.beforeAssertion?.({
-        matcherName: 'toHaveChildren',
-        expectedValue,
+/**
+ * When called with only configuration options (omitting the expected count) where default is gte 1.
+ */
+export async function toHaveChildren(
+    received: WdioElementMaybePromise,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AsyncAssertionResult>
+
+/**
+ * When called with an expected child count or number options.
+ */
+export async function toHaveChildren(
+    received: WdioElementMaybePromise,
+    expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AsyncAssertionResult>
+
+/**
+ * @deprecated since 5.7.1, NumberOptions is no longer supported. Use `toHaveChildren(el, numberMatcher, options)` instead.
+ */
+export async function toHaveChildren(
+    received: WdioElementMaybePromise,
+    expectedValue: ExpectWebdriverIO.NumberOptions,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AsyncAssertionResult>
+
+export async function toHaveChildren(
+    received: WdioElementMaybePromise,
+    expectedValueOrOptions: number | ExpectWebdriverIO.NumberMatcher | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions | undefined,
+    options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
+): Promise<ExpectWebdriverIO.AsyncAssertionResult> {
+    const matcherName = 'toHaveChildren'
+    const { expectation = 'children', verb = 'have', isNot } = this
+
+    // Extract beforeAssertion and afterAssertion from either expectedValueOrOptions or options, done before isStriclyCommandOptions check to ensurewe stay backward compatible with deprecated NumberOptions usage. To remove in next major version.
+    const beforeAssertion = ( isDefinedObject(expectedValueOrOptions) && 'beforeAssertion' in expectedValueOrOptions ? expectedValueOrOptions.beforeAssertion ?? options.afterAssertion : options.beforeAssertion)
+    const afterAssertion = ( isDefinedObject(expectedValueOrOptions) && 'afterAssertion' in expectedValueOrOptions ? expectedValueOrOptions.afterAssertion ?? options.afterAssertion : options.afterAssertion )
+
+    // New case where second argument is strictly the options object, and no expected value is provided.
+    if (isStriclyCommandOptions(expectedValueOrOptions)) {
+        options =  expectedValueOrOptions
+        expectedValueOrOptions = undefined // Let's fake an omitted expected to undefined for now.
+    }
+
+    await beforeAssertion?.({
+        matcherName,
+        expectedValue: expectedValueOrOptions,
         options,
     })
 
-    const numberOptions: ExpectWebdriverIO.NumberOptions = typeof expectedValue === 'number'
-        ? { eq: expectedValue } as ExpectWebdriverIO.NumberOptions
-        : expectedValue || {}
+    let expectedValue: NumberMatcher
+    let commandOptions: ExpectWebdriverIO.CommandOptions = options
+    if (isStriclyCommandOptions(expectedValueOrOptions)) {
+        ({ numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(undefined, expectedValueOrOptions, true))
+    } else {
+        ({ numberMatcher: expectedValue, commandOptions } = validateNumberAndExtractOptions(expectedValueOrOptions, options, true))
+    }
 
     let el = await received?.getElement()
     let children
     const pass = await waitUntil(async () => {
-        const result = await executeCommand.call(this, el, condition, numberOptions, [numberOptions])
+        const result = await executeCommand.call(this, el, condition, commandOptions, [expectedValue])
         el = result.el as WebdriverIO.Element
         children = result.values
 
         return result.success
-    }, isNot, { ...numberOptions, ...options })
+    },
+    isNot,
+    { wait: commandOptions.wait, interval: commandOptions.interval })
 
-    const error = numberError(numberOptions)
-    const expectedArray = wrapExpectedWithArray(el, children, error)
-    const message = enhanceError(el, expectedArray, children, this, verb, expectation, '', numberOptions)
+    const expectedArray = wrapExpectedWithArray(el, children, expectedValue)
+    const message = enhanceError(el, expectedArray, children, this, verb, expectation, '', commandOptions)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message
     }
 
-    await options.afterAssertion?.({
-        matcherName: 'toHaveChildren',
-        expectedValue,
+    await afterAssertion?.({
+        matcherName,
+        expectedValue: expectedValueOrOptions,
         options,
         result
     })

--- a/src/matchers/element/toHaveClass.ts
+++ b/src/matchers/element/toHaveClass.ts
@@ -31,7 +31,7 @@ async function condition(el: WebdriverIO.Element, attribute: string, value: stri
 }
 
 /**
- * @deprecated
+ * @deprecated to remove in v6.0.0
  */
 export function toHaveClass(...args: unknown[]) {
     return toHaveElementClass.call(this || {}, ...args)
@@ -81,7 +81,7 @@ export async function toHaveElementClass(
 }
 
 /**
- * @deprecated
+ * @deprecated to remove in v6.0.0
  */
 export function toHaveClassContaining(el: WebdriverIO.Element, className: string | RegExp | AsymmetricMatcher<string>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
     return toHaveAttributeAndValue.call(this, el, 'class', className, {

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -38,7 +38,7 @@ async function condition(
 }
 
 /**
- * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
+ * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
  */
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -93,12 +93,12 @@ export async function toHaveElementProperty(
     })
 
     let el = await received?.getElement()
-    let prop: unknown
+    let actualProppertyValue: unknown
     const pass = await waitUntil(
         async () => {
             const result = await executeCommand.call(this, el, condition, options, [property, value])
             el = result.el as WebdriverIO.Element
-            prop = result.values
+            actualProppertyValue = result.values
 
             return result.success
         },
@@ -108,10 +108,12 @@ export async function toHaveElementProperty(
 
     let message: string
     if (value === undefined) {
-        message = enhanceError(el, !isNot, pass, this, verb, expectation, property, options)
+        const expected = 'to have a defined value'
+        const actual = `value ${actualProppertyValue}`
+        message = enhanceError(el, expected, actual, this, verb, expectation, property, options)
     } else {
-        const expected = wrapExpectedWithArray(el, prop, value)
-        message = enhanceError(el, expected, prop, this, verb, expectation, property, options)
+        const expected = wrapExpectedWithArray(el, actualProppertyValue, value)
+        message = enhanceError(el, expected, actualProppertyValue, this, verb, expectation, property, options)
     }
 
     const result: ExpectWebdriverIO.AssertionResult = {

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -1,18 +1,18 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
+import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
+import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
-    compareNumbers,
     enhanceError,
     executeCommand,
-    numberError,
     waitUntil,
 } from '../../utils.js'
 
-async function condition(el: WebdriverIO.Element, height: number, options: ExpectWebdriverIO.NumberOptions) {
+async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher) {
     const actualHeight = await el.getSize('height')
 
     return {
-        result: compareNumbers(actualHeight, options),
+        result: expectedNumber.match(actualHeight),
         value: actualHeight
     }
 }
@@ -22,31 +22,23 @@ export async function toHaveHeight(
     expectedValue: number | ExpectWebdriverIO.NumberOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
-    const isNot = this.isNot
-    const { expectation = 'height', verb = 'have' } = this
+    const matcherName = 'toHaveHeight'
+    const { expectation = 'height', verb = 'have', isNot } = this
 
     await options.beforeAssertion?.({
-        matcherName: 'toHaveHeight',
+        matcherName,
         expectedValue,
         options,
     })
 
-    // type check
-    let numberOptions: ExpectWebdriverIO.NumberOptions
-    if (typeof expectedValue === 'number') {
-        numberOptions = { eq: expectedValue } as ExpectWebdriverIO.NumberOptions
-    } else if (!expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')) {
-        throw new Error('Invalid params passed to toHaveHeight.')
-    } else {
-        numberOptions = expectedValue
-    }
+    const { numberMatcher: expectedNumber, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let el = await received?.getElement()
     let actualHeight
 
     const pass = await waitUntil(
         async () => {
-            const result = await executeCommand.call(this, el, condition, numberOptions, [expectedValue, numberOptions])
+            const result = await executeCommand.call(this, el, condition, commandOptions, [expectedNumber])
 
             el = result.el as WebdriverIO.Element
             actualHeight = result.values
@@ -54,19 +46,18 @@ export async function toHaveHeight(
             return result.success
         },
         isNot,
-        { ...numberOptions, ...options }
+        { wait: commandOptions.wait, interval: commandOptions.interval }
     )
 
-    const error = numberError(numberOptions)
     const message = enhanceError(
         el,
-        error,
+        expectedNumber,
         actualHeight,
         this,
         verb,
         expectation,
         '',
-        options
+        commandOptions,
     )
 
     const result: ExpectWebdriverIO.AssertionResult = {
@@ -75,7 +66,7 @@ export async function toHaveHeight(
     }
 
     await options.afterAssertion?.({
-        matcherName: 'toHaveHeight',
+        matcherName,
         expectedValue,
         options,
         result

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -19,6 +19,20 @@ async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher)
 
 export async function toHaveHeight(
     received: WdioElementMaybePromise,
+    expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+    options?: ExpectWebdriverIO.CommandOptions
+):Promise<ExpectWebdriverIO.AssertionResult>
+
+/**
+ * @deprecated since 5.7.1, remove in 6.0.0. Use `toHaveHeight(received, NumberMatcher, options)` instead.
+ */
+export async function toHaveHeight(
+    received: WdioElementMaybePromise,
+    expectedValue: ExpectWebdriverIO.NumberOptions,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+export async function toHaveHeight(
+    received: WdioElementMaybePromise,
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -24,7 +24,7 @@ export async function toHaveHeight(
 ):Promise<ExpectWebdriverIO.AssertionResult>
 
 /**
- * @deprecated since 5.7.1, remove in 6.0.0. Use `toHaveHeight(received, NumberMatcher, options)` instead.
+ * deprecated since 5.7.1, remove in 6.0.0. Use `toHaveHeight(received, NumberMatcher, options)` instead.
  */
 export async function toHaveHeight(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -19,7 +19,7 @@ async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher)
 
 export async function toHaveHeight(
     received: WdioElementMaybePromise,
-    expectedValue: number | ExpectWebdriverIO.NumberOptions,
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     const matcherName = 'toHaveHeight'

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -11,7 +11,7 @@ import type { RectReturn } from '@wdio/protocols'
 
 export type Size = Pick<RectReturn, 'width' | 'height'>
 
-async function condition(el: WebdriverIO.Element, size: Partial<Size>) {
+async function condition(el: WebdriverIO.Element, size: Size) {
     const actualSize = await el.getSize()
 
     return compareObject(actualSize, size)
@@ -19,7 +19,7 @@ async function condition(el: WebdriverIO.Element, size: Partial<Size>) {
 
 export async function toHaveSize(
     received: WdioElementMaybePromise,
-    expectedValue: Partial<Size>,
+    expectedValue: Size,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     const matcherName = 'toHaveSize'

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -19,7 +19,7 @@ async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher)
 
 export async function toHaveWidth(
     received: WdioElementMaybePromise,
-    expectedValue: number | ExpectWebdriverIO.NumberOptions,
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     const matcherName = 'toHaveWidth'

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -19,9 +19,24 @@ async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher)
 
 export async function toHaveWidth(
     received: WdioElementMaybePromise,
+    expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+    options?: ExpectWebdriverIO.CommandOptions
+):Promise<ExpectWebdriverIO.AssertionResult>
+
+/**
+ * @deprecated since 5.7.1, remove in 6.0.0. Use `toHaveWidth(received, NumberMatcher, options)` instead.
+ */
+export async function toHaveWidth(
+    received: WdioElementMaybePromise,
+    expectedValue: ExpectWebdriverIO.NumberOptions,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+
+export async function toHaveWidth(
+    received: WdioElementMaybePromise,
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
-) {
+):Promise<ExpectWebdriverIO.AssertionResult> {
     const matcherName = 'toHaveWidth'
     const { expectation = 'width', verb = 'have', isNot } = this
 

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -1,18 +1,18 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise } from '../../types.js'
+import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
+import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
-    compareNumbers,
     enhanceError,
     executeCommand,
-    numberError,
     waitUntil,
 } from '../../utils.js'
 
-async function condition(el: WebdriverIO.Element, width: number, options: ExpectWebdriverIO.NumberOptions) {
+async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher) {
     const actualWidth = await el.getSize('width')
 
     return {
-        result: compareNumbers(actualWidth, options),
+        result: expectedNumber.match(actualWidth),
         value: actualWidth
     }
 }
@@ -22,31 +22,23 @@ export async function toHaveWidth(
     expectedValue: number | ExpectWebdriverIO.NumberOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
-    const isNot = this.isNot
-    const { expectation = 'width', verb = 'have' } = this
+    const matcherName = 'toHaveWidth'
+    const { expectation = 'width', verb = 'have', isNot } = this
 
     await options.beforeAssertion?.({
-        matcherName: 'toHaveWidth',
+        matcherName,
         expectedValue,
         options,
     })
 
-    // type check
-    let numberOptions: ExpectWebdriverIO.NumberOptions
-    if (typeof expectedValue === 'number') {
-        numberOptions = { eq: expectedValue } as ExpectWebdriverIO.NumberOptions
-    } else if (!expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')) {
-        throw new Error('Invalid params passed to toHaveHeight.')
-    } else {
-        numberOptions = expectedValue
-    }
+    const { numberMatcher: expectedNumber, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let el = await received?.getElement()
     let actualWidth
 
     const pass = await waitUntil(
         async () => {
-            const result = await executeCommand.call(this, el, condition, numberOptions, [expectedValue, numberOptions])
+            const result = await executeCommand.call(this, el, condition, commandOptions, [expectedNumber])
 
             el = result.el as WebdriverIO.Element
             actualWidth = result.values
@@ -54,19 +46,18 @@ export async function toHaveWidth(
             return result.success
         },
         isNot,
-        { ...numberOptions, ...options }
+        { wait: commandOptions.wait, interval: commandOptions.interval }
     )
 
-    const error = numberError(numberOptions)
     const message = enhanceError(
         el,
-        error,
+        expectedNumber,
         actualWidth,
         this,
         verb,
         expectation,
         '',
-        options
+        commandOptions,
     )
 
     const result: ExpectWebdriverIO.AssertionResult = {
@@ -75,7 +66,7 @@ export async function toHaveWidth(
     }
 
     await options.afterAssertion?.({
-        matcherName: 'toHaveWidth',
+        matcherName,
         expectedValue,
         options,
         result

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -24,7 +24,7 @@ export async function toHaveWidth(
 ):Promise<ExpectWebdriverIO.AssertionResult>
 
 /**
- * @deprecated since 5.7.1, remove in 6.0.0. Use `toHaveWidth(received, NumberMatcher, options)` instead.
+ * deprecated since 5.7.1, remove in 6.0.0. Use `toHaveWidth(received, NumberMatcher, options)` instead.
  */
 export async function toHaveWidth(
     received: WdioElementMaybePromise,

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -33,7 +33,7 @@ export async function toBeElementsArrayOfSize(
         options,
     })
 
-    const  { numberMatcher, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
+    const  { numberMatcher: expectNumber, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let elements = await received as WdioElements
     const originalLength = elements.length
@@ -42,7 +42,7 @@ export async function toBeElementsArrayOfSize(
             /**
              * check numbers first before refetching elements
              */
-            const isPassing = numberMatcher.match(elements.length)
+            const isPassing = expectNumber.match(elements.length)
             if (isPassing) {
                 return isPassing
             }
@@ -58,7 +58,7 @@ export async function toBeElementsArrayOfSize(
         }
     }
 
-    const message = enhanceError(elements, numberMatcher, originalLength, this, verb, expectation, '', commandOptions)
+    const message = enhanceError(elements, expectNumber, originalLength, this, verb, expectation, '', commandOptions)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -11,7 +11,7 @@ export async function toBeElementsArrayOfSize(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 /**
- * @deprecated since version 5.7.0. Use `toBeElementsArrayOfSize` with NumberMatcher instead. This matcher will be removed in version 6.0.0.
+ * deprecated since version 5.7.1. Use `toBeElementsArrayOfSize` with NumberMatcher instead. This matcher will be removed in version 6.0.0.
  */
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -2,7 +2,7 @@ import { waitUntil, enhanceError } from '../../utils.js'
 import { refetchElements } from '../../util/refetchElements.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElements, WdioElementsMaybePromise } from '../../types.js'
-import { validateNumberOptions as extractNumberAndOptions } from '../../util/numberOptionsUtil.js'
+import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,
@@ -33,7 +33,7 @@ export async function toBeElementsArrayOfSize(
         options,
     })
 
-    const  { numberMatcher, commandOptions } = extractNumberAndOptions(expectedValue, options)
+    const  { numberMatcher, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let elements = await received as WdioElements
     const originalLength = elements.length

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -1,44 +1,54 @@
-import { waitUntil, enhanceError, compareNumbers, numberError } from '../../utils.js'
+import { waitUntil, enhanceError } from '../../utils.js'
 import { refetchElements } from '../../util/refetchElements.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElements, WdioElementsMaybePromise } from '../../types.js'
+import { validateNumberOptions as extractNumberAndOptions } from '../../util/numberOptionsUtil.js'
 
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,
-    expectedValue: number | ExpectWebdriverIO.NumberOptions,
-    options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
+    expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+/**
+ * @deprecated since version 5.7.0. Use `toBeElementsArrayOfSize` with NumberMatcher instead. This matcher will be removed in version 6.0.0.
+ */
+export async function toBeElementsArrayOfSize(
+    received: WdioElementsMaybePromise,
+    expectedValue: ExpectWebdriverIO.NumberOptions,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+export async function toBeElementsArrayOfSize(
+    received: WdioElementsMaybePromise,
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
+    options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
-    const isNot = this.isNot
-    const { expectation = 'elements array of size', verb = 'be' } = this
+    const matcherName = 'toBeElementsArrayOfSize'
+    const { expectation = 'elements array of size', verb = 'be', isNot } = this
 
     await options.beforeAssertion?.({
-        matcherName: 'toBeElementsArrayOfSize',
+        matcherName,
         expectedValue,
         options,
     })
 
-    let numberOptions: ExpectWebdriverIO.NumberOptions
-    if (typeof expectedValue === 'number') {
-        numberOptions = { eq: expectedValue } satisfies ExpectWebdriverIO.NumberOptions
-    } else if (!expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')) {
-        throw new Error('Invalid params passed to toBeElementsArrayOfSize.')
-    } else {
-        numberOptions = expectedValue
-    }
+    const  { numberMatcher, commandOptions } = extractNumberAndOptions(expectedValue, options)
 
     let elements = await received as WdioElements
     const originalLength = elements.length
-    const pass = await waitUntil(async () => {
-        /**
-         * check numbers first before refetching elements
-         */
-        const isPassing = compareNumbers(elements.length, numberOptions)
-        if (isPassing) {
-            return isPassing
-        }
-        elements = await refetchElements(elements, numberOptions.wait, true)
-        return false
-    }, isNot, { ...numberOptions, ...options })
+    const pass = await waitUntil(
+        async () => {
+            /**
+             * check numbers first before refetching elements
+             */
+            const isPassing = numberMatcher.match(elements.length)
+            if (isPassing) {
+                return isPassing
+            }
+            elements = await refetchElements(elements, commandOptions.wait, true)
+            return false
+        },
+        isNot,
+        { wait: commandOptions.wait, interval: commandOptions.interval })
 
     if (Array.isArray(received) && pass) {
         for (let index = originalLength; index < elements.length; index++) {
@@ -46,8 +56,7 @@ export async function toBeElementsArrayOfSize(
         }
     }
 
-    const error = numberError(numberOptions)
-    const message = enhanceError(elements, error, originalLength, this, verb, expectation, '', numberOptions)
+    const message = enhanceError(elements, numberMatcher, originalLength, this, verb, expectation, '', commandOptions)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
@@ -55,7 +64,7 @@ export async function toBeElementsArrayOfSize(
     }
 
     await options.afterAssertion?.({
-        matcherName: 'toBeElementsArrayOfSize',
+        matcherName,
         expectedValue,
         options,
         result

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -9,6 +9,7 @@ export async function toBeElementsArrayOfSize(
     expectedValue: number | ExpectWebdriverIO.NumberMatcher,
     options?: ExpectWebdriverIO.CommandOptions
 ): Promise<ExpectWebdriverIO.AssertionResult>
+
 /**
  * @deprecated since version 5.7.0. Use `toBeElementsArrayOfSize` with NumberMatcher instead. This matcher will be removed in version 6.0.0.
  */
@@ -17,6 +18,7 @@ export async function toBeElementsArrayOfSize(
     expectedValue: ExpectWebdriverIO.NumberOptions,
     options?: ExpectWebdriverIO.CommandOptions
 ): Promise<ExpectWebdriverIO.AssertionResult>
+
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -35,7 +35,9 @@ export async function toBeRequestedTimes(
     const pass = await waitUntil(async () => {
         actual = received.calls.length
         return expectedNumberMatcher.match(actual)
-    }, isNot, { ...options, ...commandOptions })
+    },
+    isNot,
+    { wait: commandOptions.wait, interval: commandOptions.interval })
 
     const message = enhanceError('mock', expectedNumberMatcher, actual, this, verb, expectation, '', commandOptions)
 

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -29,17 +29,17 @@ export async function toBeRequestedTimes(
         options,
     })
 
-    const { numberMatcher: expectedNumberMatcher, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
+    const { numberMatcher: expectedNumber, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let actual
     const pass = await waitUntil(async () => {
         actual = received.calls.length
-        return expectedNumberMatcher.match(actual)
+        return expectedNumber.match(actual)
     },
     isNot,
     { wait: commandOptions.wait, interval: commandOptions.interval })
 
-    const message = enhanceError('mock', expectedNumberMatcher, actual, this, verb, expectation, '', commandOptions)
+    const message = enhanceError('mock', expectedNumber, actual, this, verb, expectation, '', commandOptions)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -1,14 +1,27 @@
-import { waitUntil, enhanceError, compareNumbers } from '../../utils.js'
-import { numberError } from '../../util/formatMessage.js'
+import { waitUntil, enhanceError } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
+import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
 
 export async function toBeRequestedTimes(
     received: WebdriverIO.Mock,
-    expectedValue: number | ExpectWebdriverIO.NumberOptions = {},
+    expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+    options?: ExpectWebdriverIO.CommandOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+
+/**
+ * @deprecated since 5.7.1, will remove in 6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
+ */
+export async function toBeRequestedTimes(
+    received: WebdriverIO.Mock,
+    expectedValue: ExpectWebdriverIO.NumberOptions,
+    options?: ExpectWebdriverIO.CommandOptions
+):Promise<ExpectWebdriverIO.AssertionResult>
+export async function toBeRequestedTimes(
+    received: WebdriverIO.Mock,
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher = {}, // TODO empty default object?
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
-    const isNot = this.isNot || false
-    const { expectation = `called${typeof expectedValue === 'number' ? ' ' + expectedValue : '' } time${expectedValue !== 1 ? 's' : ''}`, verb = 'be' } = this
+): Promise<ExpectWebdriverIO.AssertionResult> {
+    const { expectation = `called${typeof expectedValue === 'number' ? ' ' + expectedValue : '' } time${expectedValue !== 1 ? 's' : ''}`, verb = 'be', isNot = false } = this
 
     await options.beforeAssertion?.({
         matcherName: 'toBeRequestedTimes',
@@ -16,19 +29,15 @@ export async function toBeRequestedTimes(
         options,
     })
 
-    // type check
-    const numberOptions: ExpectWebdriverIO.NumberOptions = typeof expectedValue === 'number'
-        ? { eq: expectedValue } as ExpectWebdriverIO.NumberOptions
-        : expectedValue || {}
+    const { numberMatcher: expectedNumberMatcher, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
     let actual
     const pass = await waitUntil(async () => {
         actual = received.calls.length
-        return compareNumbers(actual, numberOptions)
-    }, isNot, { ...numberOptions, ...options })
+        return expectedNumberMatcher.match(actual)
+    }, isNot, { ...commandOptions, ...options })
 
-    const error = numberError(numberOptions)
-    const message = enhanceError('mock', error, actual, this, verb, expectation, '', numberOptions)
+    const message = enhanceError('mock', expectedNumberMatcher, actual, this, verb, expectation, '', commandOptions)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -16,6 +16,7 @@ export async function toBeRequestedTimes(
     expectedValue: ExpectWebdriverIO.NumberOptions,
     options?: ExpectWebdriverIO.CommandOptions
 ):Promise<ExpectWebdriverIO.AssertionResult>
+
 export async function toBeRequestedTimes(
     received: WebdriverIO.Mock,
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -35,7 +35,7 @@ export async function toBeRequestedTimes(
     const pass = await waitUntil(async () => {
         actual = received.calls.length
         return expectedNumberMatcher.match(actual)
-    }, isNot, { ...commandOptions, ...options })
+    }, isNot, { ...options, ...commandOptions })
 
     const message = enhanceError('mock', expectedNumberMatcher, actual, this, verb, expectation, '', commandOptions)
 

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -9,7 +9,7 @@ export async function toBeRequestedTimes(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 /**
- * @deprecated since 5.7.1, will remove in 6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
+ * deprecated since 5.7.1, will remove in 6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
  */
 export async function toBeRequestedTimes(
     received: WebdriverIO.Mock,

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -18,7 +18,7 @@ export async function toBeRequestedTimes(
 ):Promise<ExpectWebdriverIO.AssertionResult>
 export async function toBeRequestedTimes(
     received: WebdriverIO.Mock,
-    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher = {}, // TODO empty default object?
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<ExpectWebdriverIO.AssertionResult> {
     const { expectation = `called${typeof expectedValue === 'number' ? ' ' + expectedValue : '' } time${expectedValue !== 1 ? 's' : ''}`, verb = 'be', isNot = false } = this

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -19,7 +19,7 @@ export async function toBeRequestedTimes(
 export async function toBeRequestedTimes(
     received: WebdriverIO.Mock,
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
-    options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
+    options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ): Promise<ExpectWebdriverIO.AssertionResult> {
     const { expectation = `called${typeof expectedValue === 'number' ? ' ' + expectedValue : '' } time${expectedValue !== 1 ? 's' : ''}`, verb = 'be', isNot = false } = this
 

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -43,7 +43,7 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
     return objKeys.every(key => STRING_OPTIONS_ALLOWED_KEY_LIST.has(key))
 }
 
-export const isStriclyCommandOptions = (obj: unknown): obj is ExpectWebdriverIO.CommandOptions => {
+export const isStrictlyCommandOptions = (obj: unknown): obj is ExpectWebdriverIO.CommandOptions => {
     if (obj === null ||
         obj === undefined ||
         typeof obj !== 'object' ||

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -1,3 +1,13 @@
+const COMMAND_OPTIONS_ALLOWED_KEY_LIST = new Set([
+    // CommandOptions
+    'message',
+    // DefaultOptions
+    'wait',
+    'interval',
+    'beforeAssertion',
+    'afterAssertion'
+])
+
 const STRING_OPTIONS_ALLOWED_KEY_LIST = new Set([
     // StringOptions
     'ignoreCase',
@@ -8,13 +18,7 @@ const STRING_OPTIONS_ALLOWED_KEY_LIST = new Set([
     'atIndex',
     'replace',
     'asString',
-    // CommandOptions
-    'message',
-    // DefaultOptions
-    'wait',
-    'interval',
-    'beforeAssertion',
-    'afterAssertion'
+    ...COMMAND_OPTIONS_ALLOWED_KEY_LIST
 ])
 
 export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOptions {
@@ -37,4 +41,28 @@ export function isStringOptions(obj: unknown): obj is ExpectWebdriverIO.StringOp
     }
 
     return objKeys.every(key => STRING_OPTIONS_ALLOWED_KEY_LIST.has(key))
+}
+
+export const isStriclyCommandOptions = (obj: unknown): obj is ExpectWebdriverIO.CommandOptions => {
+    if (obj === null ||
+        obj === undefined ||
+        typeof obj !== 'object' ||
+        obj instanceof RegExp ||
+        Array.isArray(obj) ||
+        'asymmetricMatch' in obj ||
+        Object.prototype.toString.call(obj) !== '[object Object]' // This instantly filters out null, primitives, Arrays, Dates, RegExps, Maps, Sets, etc.
+    ) {
+        return false
+    }
+
+    const objKeys = Object.keys(obj)
+
+    return objKeys.every(key => COMMAND_OPTIONS_ALLOWED_KEY_LIST.has(key))
+}
+
+export const isDefinedObject = (obj: unknown): obj is object => {
+    if (typeof obj === 'object' && obj !== null) {
+        return true
+    }
+    return false
 }

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -57,6 +57,10 @@ export const isStrictlyCommandOptions = (obj: unknown): obj is ExpectWebdriverIO
 
     const objKeys = Object.keys(obj)
 
+    if (objKeys.length === 0) {
+        return false
+    }
+
     return objKeys.every(key => COMMAND_OPTIONS_ALLOWED_KEY_LIST.has(key))
 }
 

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -2,6 +2,9 @@ import { printDiffOrStringify, printExpected, printReceived } from 'jest-matcher
 import { equals } from '../jasmineUtils.js'
 import type { WdioElements } from '../types.js'
 import { isElementArray } from './elementsUtil.js'
+import { numberMatcherTester } from './numberOptionsUtil.js'
+
+const CUSTOM_EQUALITY_TESTER = [numberMatcherTester]
 
 export const getSelector = (el: WebdriverIO.Element | WebdriverIO.ElementArray) => {
     let result = typeof el.selector === 'string' ? el.selector : '<fn>'
@@ -66,7 +69,7 @@ export const enhanceError = (
     }
 
     // Using `printDiffOrStringify()` with equals values output `Received: serializes to the same string`, so we need to tweak.
-    const diffString = equals(actual, expected) ?`\
+    const diffString = equals(actual, expected, CUSTOM_EQUALITY_TESTER) ?`\
 ${label.expected}: ${printExpected(expected)}
 ${label.received}: ${printReceived(actual)}`
         : printDiffOrStringify(expected, actual, label.expected, label.received, true)

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -4,6 +4,7 @@ import type { WdioElements } from '../types.js'
 import { isElementArray } from './elementsUtil.js'
 import { numberMatcherTester } from './numberOptionsUtil.js'
 
+// TODO one day use a real asymmetric matcher for number options instead of this custom equality tester
 const CUSTOM_EQUALITY_TESTER = [numberMatcherTester]
 
 export const getSelector = (el: WebdriverIO.Element | WebdriverIO.ElementArray) => {

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -101,23 +101,3 @@ export const enhanceErrorBe = (
 
     return enhanceError(subject, expected, actual, { ...context, useNotInLabel: false }, verb, expectation, '', options)
 }
-
-export const numberError = (options: ExpectWebdriverIO.NumberOptions = {}): string | number => {
-    if (typeof options.eq === 'number') {
-        return options.eq
-    }
-
-    if (options.gte && options.lte) {
-        return `>= ${options.gte} && <= ${options.lte}`
-    }
-
-    if (options.gte) {
-        return `>= ${options.gte}`
-    }
-
-    if (options.lte) {
-        return ` <= ${options.lte}`
-    }
-
-    return 'no params'
-}

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,6 +1,6 @@
 import { isDefinedObject } from './commandOptionsUtils.js'
 
-export const isNumber = (value: unknown): value is number => typeof value === 'number'
+export const isNumber = (value: unknown): value is number => typeof value === 'number' && !isNaN(value)
 export const isDefinedNotNumber = (value: unknown) => typeof value !== 'number' && value !== undefined
 export const isDefinedNumberOrObject = (value: unknown): value is NonNullable<number | object> => typeof value === 'number' || (typeof value === 'object' && value !== null && !Array.isArray(value))
 /**
@@ -47,7 +47,7 @@ export function validateNumberAndExtractOptions(
  * Using a class to univerally handle number matching and stringification the same way everywhere and with Global Apis like equal() toString() and toJSON()
  */
 export class NumberMatcher {
-    constructor(private options: ExpectWebdriverIO.NumberOptions = {}) {}
+    constructor(private options: ExpectWebdriverIO.NumberMatcher | ExpectWebdriverIO.NumberOptions) {}
 
     equals(other: unknown): boolean {
         if (isNumber(other)) {

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,0 +1,92 @@
+
+export const isNumber = (value: unknown): value is number => typeof value === 'number'
+const isDefined = (value: unknown): boolean =>  value !== undefined && value !== null
+
+export function validateNumberOptions(expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher, commandOptions: ExpectWebdriverIO.CommandOptions = {}): { numberMatcher: NumberMatcher, commandOptions: ExpectWebdriverIO.CommandOptions } {
+    if (isNumber(expectedValue)) {
+        return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
+    } else if (!expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')) {
+        throw new Error(`Invalid NumberOptions. Received: ${JSON.stringify(expectedValue)}`)
+    } else {
+        const { eq, gte, lte, ...restCommandOptions } = expectedValue
+        return { numberMatcher: new NumberMatcher({ eq, gte, lte }), commandOptions: { ...commandOptions, ...restCommandOptions } }
+    }
+}
+
+/**
+ * Using a class to univerally handle number matching and stringification the same way everywhere and with Global Apis like equal() toString() and toJSON()
+ */
+export class NumberMatcher {
+    constructor(private options: ExpectWebdriverIO.NumberOptions = {}) {}
+
+    match(actual: number | undefined): boolean {
+        if ( actual === undefined ) {
+            return false
+        }
+
+        if (isNumber(this.options.eq)) {
+            return actual === this.options.eq
+        }
+
+        if (isNumber(this.options.gte) && isNumber(this.options.lte)) {
+            return actual >= this.options.gte && actual <= this.options.lte
+        }
+
+        if (isNumber(this.options.gte)) {
+            return actual >= this.options.gte
+        }
+
+        if (isNumber(this.options.lte)) {
+            return actual <= this.options.lte
+        }
+
+        return false
+    }
+
+    toString(): string {
+        if (isNumber(this.options.eq)) {
+            return String(this.options.eq)
+        }
+
+        if (isDefined(this.options.gte) && isDefined(this.options.lte)) {
+            return `>= ${this.options.gte} && <= ${this.options.lte}`
+        }
+
+        if (isDefined(this.options.gte)) {
+            return `>= ${this.options.gte}`
+        }
+
+        if (isDefined(this.options.lte))     {
+            return `<= ${this.options.lte}`
+        }
+
+        return 'Incorrect number options provided'
+    }
+
+    toJSON(): string | number {
+        // Return the actual number for exact equality, so it serializes as 0 not "0"
+        if (isNumber(this.options.eq)) {
+            return this.options.eq
+        }
+        return this.toString()
+    }
+}
+
+/**
+ * Custom tester for number matchers to be used by the equal of expect during failure message generation
+ */
+export const numberMatcherTester = (a: unknown, b: unknown): boolean | undefined => {
+    const isNumberMatcherA = a instanceof NumberMatcher
+    const isNumberMatcherB = b instanceof NumberMatcher
+
+    if (isNumberMatcherA && isNumber(b)) {
+        return a.match(b)
+    }
+
+    if (isNumberMatcherB && isNumber(a)) {
+        return b.match(a)
+    }
+
+    // Return undefined to let other testers handle it
+    return undefined
+}

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,18 +1,30 @@
 import { isDefinedObject } from './commandOptionsUtils.js'
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
-
+export const isDefinedNotNumber = (value: unknown) => typeof value !== 'number' && value !== undefined
+export const isDefinedNumberOrObject = (value: unknown): value is NonNullable<number | object> => typeof value === 'number' || (typeof value === 'object' && value !== null && !Array.isArray(value))
+/**
+ * Utility to parse legacy `NumberOptions` and modern `NumberMatcher` into standard matcher
+ * criteria and command options for expect-webdriverio matchers.
+ *
+ * If `supportDefaultAsGteThen1` is true, `undefined` is treated as `{ gte: 1 }`.
+ * An empty object `{}` is also temporarily treated as `{ gte: 1 }` for backward compatibility,
+ * but this behavior will be removed in a future release.
+ *
+ * Legacy properties extracted from `NumberOptions` take priority and are merged into
+ * the final `commandOptions` object so they are not overridden by `DEFAULT_OPTIONS`.
+ */
 export function validateNumberAndExtractOptions(
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher | undefined,
     commandOptions: ExpectWebdriverIO.CommandOptions = {},
-    supportUndefinedAsGteThen1: boolean = false
+    supportDefaultAsGteThen1: boolean = false
 ): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
-    if (supportUndefinedAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && Object.keys(expectedValue).length === 0)) /** supporting {} for backward reason to remove later */) {
+    if (supportDefaultAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && Object.keys(expectedValue).length === 0)) /** supporting {} for backward reason to remove later */) {
         return { numberMatcher: new NumberMatcher({ gte: 1 }), commandOptions }
     } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
     } else if (
-        !expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')
+        !isDefinedNumberOrObject(expectedValue) || isDefinedNotNumber(expectedValue.eq) ||  isDefinedNotNumber(expectedValue.gte) || isDefinedNotNumber(expectedValue.lte)
     ) {
         throw new Error(`Invalid NumberMatcher. Received: ${JSON.stringify(expectedValue)}`)
     } else {

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -36,7 +36,7 @@ export class NumberMatcher {
 
     equals(other: unknown): boolean {
         if (isNumber(other)) {
-            this.match(other)
+            return this.match(other)
         }
         return false
     }

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -13,12 +13,12 @@ export function validateNumberAndExtractOptions(
     } else if (
         !expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')
     ) {
-        throw new Error(`Invalid NumberOptions. Received: ${JSON.stringify(expectedValue)}`)
+        throw new Error(`Invalid NumberMatcher. Received: ${JSON.stringify(expectedValue)}`)
     } else {
         const { eq, gte, lte, ...restCommandOptions } = expectedValue
 
         if (isNumber(gte) && isNumber(lte) && gte > lte) {
-            throw new Error(`Invalid NumberOptions range: 'gte' (${gte}) cannot be greater than 'lte' (${lte}).`)
+            throw new Error(`Invalid NumberMatcher range: 'gte' (${gte}) cannot be greater than 'lte' (${lte}).`)
         }
 
         return {
@@ -33,6 +33,13 @@ export function validateNumberAndExtractOptions(
  */
 export class NumberMatcher {
     constructor(private options: ExpectWebdriverIO.NumberOptions = {}) {}
+
+    equals(other: unknown): boolean {
+        if (isNumber(other)) {
+            this.match(other)
+        }
+        return false
+    }
 
     match(expected: number | undefined): boolean {
         if ( expected === undefined ) {
@@ -91,16 +98,8 @@ export class NumberMatcher {
  * Custom tester for number matchers to be used by the equal of expect during failure message generation
  */
 export const numberMatcherTester = (a: unknown, b: unknown): boolean | undefined => {
-    const isNumberMatcherA = a instanceof NumberMatcher
-    const isNumberMatcherB = b instanceof NumberMatcher
-
-    if (isNumberMatcherA && isNumber(b)) {
-        return a.match(b)
-    }
-
-    if (isNumberMatcherB && isNumber(a)) {
-        return b.match(a)
-    }
+    if (a instanceof NumberMatcher && isNumber(b)) {return a.match(b)}
+    if (b instanceof NumberMatcher && isNumber(a)) {return b.match(a)}
 
     // Return undefined to let other testers handle it
     return undefined

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,15 +1,27 @@
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
-const isDefined = (value: unknown): boolean =>  value !== undefined && value !== null
 
-export function validateNumberOptions(expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher, commandOptions: ExpectWebdriverIO.CommandOptions = {}): { numberMatcher: NumberMatcher, commandOptions: ExpectWebdriverIO.CommandOptions } {
+export function validateNumberAndExtractOptions(
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
+    commandOptions: ExpectWebdriverIO.CommandOptions = {}
+): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
     if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
-    } else if (!expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')) {
+    } else if (
+        !expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')
+    ) {
         throw new Error(`Invalid NumberOptions. Received: ${JSON.stringify(expectedValue)}`)
     } else {
         const { eq, gte, lte, ...restCommandOptions } = expectedValue
-        return { numberMatcher: new NumberMatcher({ eq, gte, lte }), commandOptions: { ...commandOptions, ...restCommandOptions } }
+
+        if (isNumber(gte) && isNumber(lte) && gte > lte) {
+            throw new Error(`Invalid NumberOptions range: 'gte' (${gte}) cannot be greater than 'lte' (${lte}).`)
+        }
+
+        return {
+            numberMatcher: new NumberMatcher({ eq, gte, lte }),
+            commandOptions: { ...commandOptions, ...restCommandOptions }
+        }
     }
 }
 
@@ -48,15 +60,15 @@ export class NumberMatcher {
             return String(this.options.eq)
         }
 
-        if (isDefined(this.options.gte) && isDefined(this.options.lte)) {
+        if (isNumber(this.options.gte) && isNumber(this.options.lte)) {
             return `>= ${this.options.gte} && <= ${this.options.lte}`
         }
 
-        if (isDefined(this.options.gte)) {
+        if (isNumber(this.options.gte)) {
             return `>= ${this.options.gte}`
         }
 
-        if (isDefined(this.options.lte))     {
+        if (isNumber(this.options.lte))     {
             return `<= ${this.options.lte}`
         }
 

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,3 +1,4 @@
+import { isDefinedObject } from './commandOptionsUtils.js'
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
 
@@ -6,7 +7,7 @@ export function validateNumberAndExtractOptions(
     commandOptions: ExpectWebdriverIO.CommandOptions = {},
     supportUndefinedAsGteThen1: boolean = false
 ): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
-    if (supportUndefinedAsGteThen1 && expectedValue === undefined) {
+    if (supportUndefinedAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && Object.keys(expectedValue).length === 0)) /** supporting {} for backward reason to remove later */) {
         return { numberMatcher: new NumberMatcher({ gte: 1 }), commandOptions }
     } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -2,7 +2,7 @@ import { isDefinedObject } from './commandOptionsUtils.js'
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number' && !isNaN(value)
 export const isDefinedNotNumber = (value: unknown) => typeof value !== 'number' && value !== undefined
-export const isDefinedNumberOrObject = (value: unknown): value is NonNullable<number | object> => typeof value === 'number' || (typeof value === 'object' && value !== null && !Array.isArray(value))
+export const isDefinedNumberOrNonEmptyObject = (value: unknown): value is NonNullable<number | object> => typeof value === 'number' || (typeof value === 'object' && value !== null && !Array.isArray(value) && Object.keys(value).length > 0)
 /**
  * Utility to parse legacy `NumberOptions` and modern `NumberMatcher` into standard matcher
  * criteria and command options for expect-webdriverio matchers.
@@ -25,7 +25,8 @@ export function validateNumberAndExtractOptions(
     } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
     } else if (
-        !isDefinedNumberOrObject(expectedValue) || isDefinedNotNumber(expectedValue.eq) ||  isDefinedNotNumber(expectedValue.gte) || isDefinedNotNumber(expectedValue.lte)
+        !isDefinedNumberOrNonEmptyObject(expectedValue) || isDefinedNotNumber(expectedValue.eq) ||  isDefinedNotNumber(expectedValue.gte) || isDefinedNotNumber(expectedValue.lte)
+            || (expectedValue.eq === undefined && expectedValue.gte === undefined && expectedValue.lte === undefined)
     ) {
         throw new Error(`Invalid NumberMatcher. Received: ${JSON.stringify(expectedValue)}`)
     }

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -2,10 +2,13 @@
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
 
 export function validateNumberAndExtractOptions(
-    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher,
-    commandOptions: ExpectWebdriverIO.CommandOptions = {}
+    expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher | undefined,
+    commandOptions: ExpectWebdriverIO.CommandOptions = {},
+    supportUndefinedAsGteThen1: boolean = false
 ): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
-    if (isNumber(expectedValue)) {
+    if (supportUndefinedAsGteThen1 && expectedValue === undefined) {
+        return { numberMatcher: new NumberMatcher({ gte: 1 }), commandOptions }
+    } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
     } else if (
         !expectedValue || (typeof expectedValue.eq !== 'number' && typeof expectedValue.gte !== 'number' && typeof expectedValue.lte !== 'number')

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,7 +1,7 @@
 import { isDefinedObject } from './commandOptionsUtils.js'
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number' && !isNaN(value)
-export const isDefinedNotNumber = (value: unknown) => typeof value !== 'number' && value !== undefined
+export const isDefinedNotNumber = (value: unknown) => value !== undefined && !isNumber(value)
 export const isDefinedNumberOrNonEmptyObject = (value: unknown): value is NonNullable<number | object> => typeof value === 'number' || (typeof value === 'object' && value !== null && !Array.isArray(value) && Object.keys(value).length > 0)
 /**
  * Utility to parse legacy `NumberOptions` and modern `NumberMatcher` into standard matcher

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -16,28 +16,30 @@ export const isDefinedNumberOrObject = (value: unknown): value is NonNullable<nu
  */
 export function validateNumberAndExtractOptions(
     expectedValue: number | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.NumberMatcher | undefined,
-    commandOptions: ExpectWebdriverIO.CommandOptions = {},
-    supportDefaultAsGteThen1: boolean = false
+    commandOptions: ExpectWebdriverIO.CommandOptions,
+    { supportDefaultAsGteThen1 }: { supportDefaultAsGteThen1?: boolean } = {}
 ): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
-    if (supportDefaultAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && Object.keys(expectedValue).length === 0)) /** supporting {} for backward reason to remove later */) {
-        return { numberMatcher: new NumberMatcher({ gte: 1 }), commandOptions }
+    let defaultExpectedValue: NumberMatcher | undefined = undefined
+    if (supportDefaultAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && expectedValue.eq === undefined && expectedValue.gte === undefined && expectedValue.lte === undefined))) {
+        defaultExpectedValue = new NumberMatcher({ gte: 1 })
     } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
     } else if (
         !isDefinedNumberOrObject(expectedValue) || isDefinedNotNumber(expectedValue.eq) ||  isDefinedNotNumber(expectedValue.gte) || isDefinedNotNumber(expectedValue.lte)
     ) {
         throw new Error(`Invalid NumberMatcher. Received: ${JSON.stringify(expectedValue)}`)
-    } else {
-        const { eq, gte, lte, ...restCommandOptions } = expectedValue
+    }
 
-        if (isNumber(gte) && isNumber(lte) && gte > lte) {
-            throw new Error(`Invalid NumberMatcher range: 'gte' (${gte}) cannot be greater than 'lte' (${lte}).`)
-        }
+    const { eq, gte, lte, ...restCommandOptions } = expectedValue ?? {}
 
-        return {
-            numberMatcher: new NumberMatcher({ eq, gte, lte }),
-            commandOptions: { ...commandOptions, ...restCommandOptions }
-        }
+    if (isNumber(gte) && isNumber(lte) && gte > lte) {
+        throw new Error(`Invalid NumberMatcher range: 'gte' (${gte}) cannot be greater than 'lte' (${lte}).`)
+    }
+
+    return {
+        numberMatcher: defaultExpectedValue ?? new NumberMatcher({ eq, gte, lte }),
+        // Ensure DEFAULT_OPTIONS are applied first, then any command options from the legacy number options.
+        commandOptions: { ...commandOptions, ...restCommandOptions }
     }
 }
 

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -34,25 +34,25 @@ export function validateNumberAndExtractOptions(
 export class NumberMatcher {
     constructor(private options: ExpectWebdriverIO.NumberOptions = {}) {}
 
-    match(actual: number | undefined): boolean {
-        if ( actual === undefined ) {
+    match(expected: number | undefined): boolean {
+        if ( expected === undefined ) {
             return false
         }
 
         if (isNumber(this.options.eq)) {
-            return actual === this.options.eq
+            return expected === this.options.eq
         }
 
         if (isNumber(this.options.gte) && isNumber(this.options.lte)) {
-            return actual >= this.options.gte && actual <= this.options.lte
+            return expected >= this.options.gte && expected <= this.options.lte
         }
 
         if (isNumber(this.options.gte)) {
-            return actual >= this.options.gte
+            return expected >= this.options.gte
         }
 
         if (isNumber(this.options.lte)) {
-            return actual <= this.options.lte
+            return expected <= this.options.lte
         }
 
         return false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,6 +149,11 @@ async function executeCommandBe(
     }
 }
 
+/**
+ * @deprecated not longer used in 5.7.1, replaced by `NumberMatcher.match()`. To remove in 6.0.0
+ * @see src/util/numberOptionsUtil.ts#NumberMatcher.match
+ */
+/* v8 ignore next */
 const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions = {}): boolean => {
     // Equals case
     if (typeof options.eq === 'number') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import { DEFAULT_OPTIONS } from './constants.js'
 import type { WdioElementMaybePromise } from './types.js'
 import { wrapExpectedWithArray } from './util/elementsUtil.js'
 import { executeCommand } from './util/executeCommand.js'
-import { enhanceError, enhanceErrorBe, numberError } from './util/formatMessage.js'
+import { enhanceError, enhanceErrorBe } from './util/formatMessage.js'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -419,7 +419,7 @@ function aliasFn(
 
 export {
     aliasFn, compareNumbers, enhanceError, executeCommand,
-    executeCommandBe, numberError, waitUntil, wrapExpectedWithArray
+    executeCommandBe, waitUntil, wrapExpectedWithArray
 }
 
 function replaceActual(

--- a/test-types/jasmine-global-expect-async/jasmine-expect-global.test-d.ts
+++ b/test-types/jasmine-global-expect-async/jasmine-expect-global.test-d.ts
@@ -174,11 +174,6 @@ describe('Jasmine global type augmentations under `wdio/jasmine-framework`', () 
                     expectTypeOf(expect(element).not.toHaveHeight(100)).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).not.toHaveHeight(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
 
-                    expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-
                     expectTypeOf(expect(browser).toHaveHeight).toBeNever()
                 })
 

--- a/test-types/jasmine/jasmine.test-d.ts
+++ b/test-types/jasmine/jasmine.test-d.ts
@@ -175,11 +175,6 @@ describe('Jasmine type agumentations', () => {
                     expectTypeOf(expectAsync(element).not.toHaveHeight(100)).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expectAsync(element).not.toHaveHeight(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
 
-                    expectTypeOf(expectAsync(element).toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expectAsync(element).toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expectAsync(element).not.toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                    expectTypeOf(expectAsync(element).not.toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-
                     expectTypeOf(expectAsync(browser).toHaveHeight).toBeNever()
                 })
 

--- a/test-types/jest-@types_jest/jest.test-d.ts
+++ b/test-types/jest-@types_jest/jest.test-d.ts
@@ -169,11 +169,6 @@ describe('Jest augmentation typing assertions tests paired with `@types/jest`', 
                 expectTypeOf(expect(element).not.toHaveHeight(100)).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).not.toHaveHeight(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
 
-                expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-
                 expectTypeOf(expect(browser).toHaveHeight).toBeNever()
             })
 

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -537,6 +537,25 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveStyle({ color: 'red' })).toEqualTypeOf<Promise<void>>()
             })
         })
+
+        describe('toHaveChildren', () => {
+            it('should support various signatures', async () => {
+                // Preferred Signatures
+                expectTypeOf(expect(element).toHaveChildren()).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren({ wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren(5)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren(5, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren({ eq: 5 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren({ eq: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+
+                // Deprecated Signatures
+                expectTypeOf(expect(element).toHaveChildren(undefined)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren(undefined, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveChildren({ eq: 5, wait: 1000 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                // Deprecating this is just too hard but let's not support this!
+                expectTypeOf(expect(element).toHaveChildren({})).toEqualTypeOf<Promise<void>>()
+            })
+        })
     })
 
     describe('Expect', () => {

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -486,7 +486,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             })).toEqualTypeOf<Promise<void>>()
         })
 
-        it('should be deprecated', async () => {
+        it('should be deprecated with NumberOptions', async () => {
             expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes({ gte: 5, lte: 10, wait: 0 })).toEqualTypeOf<Promise<void>>()
         })
     })

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -403,6 +403,9 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             expectTypeOf(expect(promiseNetworkMock).toBeRequested()).toEqualTypeOf<Promise<void>>()
             expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes(2)).toEqualTypeOf<Promise<void>>()
             expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes({ gte: 5, lte: 10 })).toEqualTypeOf<Promise<void>>()
+            expectTypeOf(expect(promiseNetworkMock).toBeRequested({ wait: 0 })).toEqualTypeOf<Promise<void>>()
+            expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes(2, { wait: 0 })).toEqualTypeOf<Promise<void>>()
+            expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes({ gte: 5, lte: 10 }, { wait: 0 })).toEqualTypeOf<Promise<void>>()
 
             expectTypeOf(expect(promiseNetworkMock).not.toBeRequested()).toEqualTypeOf<Promise<void>>()
             expectTypeOf(expect(promiseNetworkMock).not.toBeRequestedTimes(2)).toEqualTypeOf<Promise<void>>()
@@ -436,6 +439,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 postData: expect.objectContaining({ released: true, title: expect.stringContaining('foobar') }),
                 response: (r: { data: { items: unknown[] } }) => Array.isArray(r) && r.data.items.length === 20
             })).toEqualTypeOf<Promise<void>>()
+        })
+
+        it('should be deprecated', async () => {
+            expectTypeOf(expect(promiseNetworkMock).toBeRequestedTimes({ gte: 5, lte: 10, wait: 0 })).toEqualTypeOf<Promise<void>>()
         })
     })
 

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -228,6 +228,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             it('should return Promise<void> when actual is chainableArray', async () => {
                 expectTypeOf(expect(chainableArray).toBeElementsArrayOfSize(5)).toExtend<Promise<void>>()
                 expectTypeOf(expect(chainableArray).toBeElementsArrayOfSize({ lte: 10 })).toExtend<Promise<void>>()
+                expectTypeOf(expect(chainableArray).toBeElementsArrayOfSize({ lte: 10 }, { wait: 1000 })).toExtend<Promise<void>>()
             })
 
             it('should return Promise<void> when actual is element array', async () => {
@@ -243,6 +244,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             it('should not work when actual is not chainableArray', async () => {
                 expectTypeOf(expect(chainableElement).toBeElementsArrayOfSize).toBeNever()
                 expectTypeOf(expect(true).toBeElementsArrayOfSize).toBeNever()
+            })
+
+            it('should be deprecated with NumberOptions', async () => {
+                expectTypeOf(expect(chainableArray).toBeElementsArrayOfSize({ lte: 10, wait: 1000 })).toExtend<Promise<void>>()
             })
         })
     })

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -169,11 +169,11 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveHeight(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).not.toHaveHeight(100)).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).not.toHaveHeight(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveHeight({ gte: 100 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveHeight({ gte: 100, lte: 200 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveHeight({ gte: 100 })).toEqualTypeOf<Promise<void>>()
 
-                expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).not.toHaveHeight({ width: 100, height: 200 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHeight(100)).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(browser).toHaveHeight).toBeNever()
             })
@@ -182,6 +182,51 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect('text').toHaveHeight).toBeNever()
                 expectTypeOf(expect(Promise.resolve('text')).toHaveHeight).toBeNever()
                 expectTypeOf(expect(Promise.resolve('text')).toHaveHeight).toBeNever()
+            })
+        })
+
+        describe('toHaveWidth', () => {
+            it('should return Promise<void>', async () => {
+                expectTypeOf(expect(element).toHaveWidth(100)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveWidth(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveWidth(100)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveWidth(100, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveWidth({ gte: 100 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveWidth({ gte: 100, lte: 200 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveWidth({ gte: 100 })).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(chainableElement).toHaveWidth(100)).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(browser).toHaveWidth).toBeNever()
+            })
+
+            it('should have ts errors when actual is string or Promise<string>', async () => {
+                expectTypeOf(expect('text').toHaveWidth).toBeNever()
+                expectTypeOf(expect(Promise.resolve('text')).toHaveWidth).toBeNever()
+                expectTypeOf(expect(Promise.resolve('text')).toHaveWidth).toBeNever()
+            })
+        })
+
+        describe('toHaveSize', () => {
+            it('should return Promise<void>', async () => {
+                expectTypeOf(expect(element).toHaveSize({ height: 100, width: 100 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveSize({ height: 100, width: 100 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveSize({ height: 100, width: 100 })).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).not.toHaveSize({ height: 100, width: 100 }, { message: 'Custom error message' })).toEqualTypeOf<Promise<void>>()
+                // TODO one day
+                // expectTypeOf(expect(element).toHaveSize({ gte: 100 })).toEqualTypeOf<Promise<void>>()
+                // expectTypeOf(expect(element).toHaveSize({ gte: 100, lte: 200 })).toEqualTypeOf<Promise<void>>()
+                // expectTypeOf(expect(element).not.toHaveSize({ gte: 100 })).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(chainableElement).toHaveSize({ height: 100, width: 100 })).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(browser).toHaveWidth).toBeNever()
+            })
+
+            it('should have ts errors when actual is string or Promise<string>', async () => {
+                expectTypeOf(expect('text').toHaveSize).toBeNever()
+                expectTypeOf(expect(Promise.resolve('text')).toHaveSize).toBeNever()
+                expectTypeOf(expect(Promise.resolve('text')).toHaveSize).toBeNever()
             })
         })
 

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -112,12 +112,6 @@ describe('globals mock', () => {
             expect(text).toBe(' Valid Text ')
         })
 
-        it('should returns ElementArray on getElements', async () => {
-            const els = await $$('foo')
-
-            expect(await els.getElements()).toEqual(els)
-        })
-
         it('should return a promise-like object when accessing index out of bounds', () => {
             const el = $$('foo')[3]
             // It shouldn't throw synchronously

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -218,8 +218,8 @@ Received      : "some attribute"`
             await expect(() => expectLib(el).not.toHaveAttribute('someAttribute')).rejects.toThrow(`\
 Expect $(\`selector\`) not to have attribute someAttribute
 
-Expected [not]: false
-Received      : true`
+Expected [not]: "to have a defined value"
+Received      : "value some attribute"`
             )
 
             await expect(() => expectLib(el).not.toHaveAttr('someAttribute', 'some attribute')).rejects.toThrow(`\
@@ -335,8 +335,8 @@ Received: "some attribute"`)
             await expect(() => expectLib(el).toHaveAttribute('notExistingAttribute')).rejects.toThrow(`\
 Expect $(\`selector\`) to have attribute notExistingAttribute
 
-Expected: true
-Received: false`)
+Expected: "to have a defined value"
+Received: "value null"`)
             await expect(() => expectLib(el).toHaveAttr('someAttribute', 'some other attribute', { wait: 1 })).rejects.toThrow(`\
 Expect $(\`selector\`) to have attribute someAttribute
 

--- a/test/matchers/beMatchers.test.ts
+++ b/test/matchers/beMatchers.test.ts
@@ -21,7 +21,6 @@ const beMatchers = {
 } satisfies Partial<Record<keyof typeof Matchers, keyof WebdriverIO.Element>>
 
 vi.mock('../../src/utils.js', async (importOriginal) => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const actual = await importOriginal<typeof import('../../src/utils.js')>()
     return {
         ...actual,

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -9,7 +9,6 @@ import type { ChainablePromiseElement } from 'webdriverio'
 
 vi.mock('@wdio/globals')
 vi.mock('../../../src/utils.js', async (importOriginal) => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const actual = await importOriginal<typeof import('../../../src/utils.js')>()
     return {
         ...actual,

--- a/test/matchers/element/toHaveAttribute.test.ts
+++ b/test/matchers/element/toHaveAttribute.test.ts
@@ -75,8 +75,8 @@ describe(toHaveAttribute, () => {
                     expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have attribute attribute_name
 
-Expected: true
-Received: false`
+Expected: "to have a defined value"
+Received: "value null"`
                     )
                 })
             })
@@ -164,8 +164,8 @@ Received: "Wrong"`
                 expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have attribute attribute_name
 
-Expected: true
-Received: false`
+Expected: "to have a defined value"
+Received: "value ${attributeValue}"`
                 )
             })
 
@@ -217,12 +217,11 @@ Received: false`
                 const result = await thisIsNotContext.toHaveAttribute(el, 'attribute_name')
 
                 expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-                // TODO: The error message is misleading to fix one day?
                 expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have attribute attribute_name
 
-Expected [not]: false
-Received      : true`
+Expected [not]: "to have a defined value"
+Received      : "value Correct Value"`
                 )
             })
         })

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -75,6 +75,18 @@ describe(toHaveChildren, () => {
 
                 expect(result.pass).toBe(true)
             })
+
+            test('no value - success - default to gte 1 (with empty object and separate wait options) -- deprecated officially even if not striked-- TODO add runtime check on next major version', async () => {
+                const result = await thisContext.toHaveChildren(el, {}, { wait: 0 })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('no value - success - default to gte 1 (with empty object and double wait options) -- deprecated', async () => {
+                const result = await thisContext.toHaveChildren(el, { wait: 0 }, { wait: 0 })
+
+                expect(result.pass).toBe(true)
+            })
         })
 
         test('use numberOption wait and internal and command options - deprecated', async () => {

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -1,90 +1,215 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
 
-import { toHaveChildren } from '../../../src/matchers/element/toHaveChildren.js'
+import { toHaveChildren } from '../../../src/matchers/element/toHaveChildren'
+import { chainableElementArrayFactory } from '../../__mocks__/@wdio/globals'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveChildren', () => {
-    test('no value', async () => {
-        const beforeAssertion = vi.fn()
-        const afterAssertion = vi.fn()
-        const el = await $('sel')
+describe(toHaveChildren, () => {
+    const thisContext = { toHaveChildren }
+    const thisNotContext = { isNot: true, toHaveChildren }
 
-        const result = await toHaveChildren.call({}, el, undefined, { wait: 0, beforeAssertion, afterAssertion })
-        expect(result.pass).toBe(true)
-        expect(beforeAssertion).toBeCalledWith({
-            matcherName: 'toHaveChildren',
-            options: { wait: 0, beforeAssertion, afterAssertion }
+    describe('given a single element', () => {
+        let el: ChainablePromiseElement
+
+        beforeEach(async () => {
+            el = await $('sel')
         })
-        expect(afterAssertion).toBeCalledWith({
-            matcherName: 'toHaveChildren',
-            options: { wait: 0, beforeAssertion, afterAssertion },
-            result
+
+        describe('given no value', () => {
+
+            test('no value - success - default to gte 1', async () => {
+                const result = await thisContext.toHaveChildren(el)
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('no value - success - default to gte 1 with options', async () => {
+                const beforeAssertion = vi.fn()
+                const afterAssertion = vi.fn()
+
+                const result = await thisContext.toHaveChildren(el, { wait: 0, interval: 5, beforeAssertion, afterAssertion })
+
+                expect(result.pass).toBe(true)
+                expect(beforeAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveChildren',
+                    expectedValue: undefined,
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion }
+                })
+                expect(afterAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveChildren',
+                    expectedValue: undefined,
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion },
+                    result
+                })
+            })
+
+            test('no value - success - default to gte 1 (with undefined) and with command options - deprecated', async () => {
+                const beforeAssertion = vi.fn()
+                const afterAssertion = vi.fn()
+
+                const result = await thisContext.toHaveChildren(el, undefined, { wait: 0, interval: 5, beforeAssertion, afterAssertion })
+
+                // TODO bring back later
+                // expect(waitUntil).toHaveBeenCalledExactlyOnceWith(expect.any(Function), undefined, { wait: 0, interval: 5 })
+
+                expect(result.pass).toBe(true)
+                expect(beforeAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveChildren',
+                    expectedValue: undefined,
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion }
+                })
+                expect(afterAssertion).toHaveBeenCalledWith({
+                    matcherName: 'toHaveChildren',
+                    expectedValue: undefined,
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion },
+                    result
+                })
+            })
+
+            test('no value - success - default to gte 1 (with empty object) -- deprecated officially even if not striked', async () => {
+                const result = await thisContext.toHaveChildren(el, {})
+
+                expect(result.pass).toBe(true)
+            })
         })
-    })
 
-    test('If no options passed in + children exists', async () => {
-        const el = await $('sel')
+        test('use numberOption wait and internal - deprecated', async () => {
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
 
-        const result = await toHaveChildren.call({}, el, {})
-        expect(result.pass).toBe(true)
-    })
+            const result = await thisContext.toHaveChildren(el, { eq: 2, wait: 0, interval: 5 }, { beforeAssertion, afterAssertion } )
 
-    test('exact number value', async () => {
-        const el = await $('sel')
+            expect(result.pass).toBe(true)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveChildren',
+                options: { beforeAssertion, afterAssertion },
+                expectedValue: { eq: 2, wait: 0, interval: 5 }
 
-        const result = await toHaveChildren.call({}, el, 2, { wait: 1 })
-        expect(result.pass).toBe(true)
-    })
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveChildren',
+                options: { beforeAssertion, afterAssertion },
+                result,
+                expectedValue: { eq: 2, wait: 0, interval: 5 }
+            })
+        })
 
-    test('exact value', async () => {
-        const el = await $('sel')
+        test('use numberMatcher and wait and internal', async () => {
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
 
-        const result = await toHaveChildren.call({}, el, { eq: 2, wait: 1 })
-        expect(result.pass).toBe(true)
-    })
+            const result = await thisContext.toHaveChildren(el, { eq: 2 }, { beforeAssertion, afterAssertion, wait: 0, interval: 5 } )
 
-    test('gte value', async () => {
-        const el = await $('sel')
+            expect(result.pass).toBe(true)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveChildren',
+                options: { beforeAssertion, afterAssertion, wait: 0, interval: 5 },
+                expectedValue: { eq: 2 }
 
-        const result = await toHaveChildren.call({}, el, { gte: 2, wait: 1 })
-        expect(result.pass).toBe(true)
-    })
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveChildren',
+                options: { beforeAssertion, afterAssertion, wait: 0, interval: 5 },
+                result,
+                expectedValue: { eq: 2 }
+            })
+        })
 
-    test('exact value - failure', async () => {
-        const el = await $('sel')
+        test('success - If no options passed in + children exists', async () => {
+            const result = await thisContext.toHaveChildren(el)
 
-        const result = await toHaveChildren.call({}, el, { eq: 3, wait: 1 })
-        expect(result.pass).toBe(false)
-    })
+            expect(result.pass).toBe(true)
+        })
 
-    test('lte value - failure', async () => {
-        const el = await $('sel')
+        // TODO dprevost to fix
+        test.skip('fails - If no options passed in + children do not exist', async () => {
+            vi.mocked(el.$$).mockReturnValueOnce(chainableElementArrayFactory('./child', 0))
 
-        const result = await toHaveChildren.call({}, el, { lte: 1, wait: 0 })
-        expect(result.pass).toBe(false)
-    })
+            const result = await thisContext.toHaveChildren(el)
 
-    test('.not exact value - failure - pass should be true', async () => {
-        const el = await $('sel')
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have children
 
-        const result = await toHaveChildren.bind({ isNot: true })(el, { eq: 2, wait: 0 })
+Expected: ">= 1"
+Received: 0`
+            )
+        })
 
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-        expect(result.message()).toEqual(`\
+        test('exact number value', async () => {
+            const result = await thisContext.toHaveChildren(el, 2)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test('exact value', async () => {
+            const result = await thisContext.toHaveChildren(el, { eq: 2 })
+
+            expect(result.pass).toBe(true)
+        })
+
+        test('gte value', async () => {
+            const result = await thisContext.toHaveChildren(el, { gte: 2 })
+
+            expect(result.pass).toBe(true)
+        })
+
+        test('exact value - failure', async () => {
+            const result = await thisContext.toHaveChildren(el, { eq: 3 })
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have children
+
+Expected: 3
+Received: 2`
+            )
+        })
+
+        test('lte value - failure', async () => {
+            const result = await thisContext.toHaveChildren(el, { lte: 1 })
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have children
+
+Expected: "<= 1"
+Received: 2`
+            )
+        })
+
+        test('.not, exact value - failure - pass should be true', async () => {
+            const result = await thisNotContext.toHaveChildren(el, { eq: 2 })
+
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have children
 
 Expected [not]: 2
-Received      : 2`)
+Received      : 2`
+            )
+        })
 
-    })
+        // This is not outputting the right colors in the test output console, to enhance!
+        test('.not, lte value - failure - pass should be true', async () => {
+            const result = await thisNotContext.toHaveChildren(el, { lte: 2 })
 
-    test('.not exact value - success - pass should be false', async () => {
-        const el = await $('sel')
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) not to have children
 
-        const result = await toHaveChildren.bind({ isNot: true })(el, { eq: 3, wait: 1 })
+Expected [not]: "<= 2"
+Received      : 2`
+            )
+        })
 
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        test('.not, exact value - success - pass should be false', async () => {
+            const result = await thisNotContext.toHaveChildren(el, { eq: 3 })
+
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        })
     })
 })

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -16,6 +16,7 @@ describe(toHaveChildren, () => {
 
         beforeEach(async () => {
             el = await $('sel')
+            vi.mocked(el.$$).mockRestore()
         })
 
         describe('given no value', () => {
@@ -76,7 +77,7 @@ describe(toHaveChildren, () => {
             })
         })
 
-        test('use numberOption wait and internal - deprecated', async () => {
+        test('use numberOption wait and internal and command options - deprecated', async () => {
             const beforeAssertion = vi.fn()
             const afterAssertion = vi.fn()
 
@@ -95,6 +96,12 @@ describe(toHaveChildren, () => {
                 result,
                 expectedValue: { eq: 2, wait: 0, interval: 5 }
             })
+        })
+
+        test('use numberOption wait and internal wait but no command options - deprecated', async () => {
+            const result = await thisContext.toHaveChildren(el, { eq: 2, wait: 0, interval: 5 } )
+
+            expect(result.pass).toBe(true)
         })
 
         test('use numberMatcher and wait and internal', async () => {
@@ -124,9 +131,8 @@ describe(toHaveChildren, () => {
             expect(result.pass).toBe(true)
         })
 
-        // TODO dprevost to fix
-        test.skip('fails - If no options passed in + children do not exist', async () => {
-            vi.mocked(el.$$).mockReturnValueOnce(chainableElementArrayFactory('./child', 0))
+        test('fails - If no options passed in + children do not exist', async () => {
+            vi.mocked(el.$$).mockReturnValue(chainableElementArrayFactory('./child', 0))
 
             const result = await thisContext.toHaveChildren(el)
 

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -48,6 +48,20 @@ describe(toHaveElementProperty, () => {
             expect(result.pass).toBe(true)
         })
 
+        test('fail with when property value is number and expected is the not same number', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', 10)
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
+
+Expected: 10
+Received: 5`
+            )
+        })
+
         test('fail with when property value is number and expected is a string without asString option', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
@@ -162,12 +176,11 @@ Received      : "iphone"`)
             const result = await thisContext.toHaveElementProperty(el, 'myPropertyName')
 
             expect(result.pass).toBe(false)
-            // TODO error message is ambiguous, should be "Expected: true" instead of "Expected: false"
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have property myPropertyName
 
-Expected: true
-Received: false`
+Expected: "to have a defined value"
+Received: "value ${propertyValue}"`
             )
         })
 
@@ -178,8 +191,8 @@ Received: false`
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have property myPropertyName
 
-Expected [not]: false
-Received      : true`)
+Expected [not]: "to have a defined value"
+Received      : "value iphone"`)
         })
 
         test.for([
@@ -192,13 +205,6 @@ Received      : true`)
             const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName')
 
             expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-            // TODO error message is ambiguous, should be "Expected [not]: true" instead of "Expected [not]: false"
-            expect(stripAnsi(result.message())).toEqual(`\
-Expect $(\`sel\`) not to have property myPropertyName
-
-Expected [not]: false
-Received      : false`
-            )
         })
 
         test('should return false for undefined input', async () => {

--- a/test/matchers/element/toHaveHeight.test.ts
+++ b/test/matchers/element/toHaveHeight.test.ts
@@ -1,136 +1,124 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
 import { toHaveHeight } from '../../../src/matchers/element/toHaveHeight.js'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveHeight', () => {
-    test('wait for success', async () => {
-        const el = await $('sel')
+describe(toHaveHeight, () => {
 
-        el.getSize = vi.fn()
-            .mockResolvedValueOnce(null)
-            .mockResolvedValueOnce(null)
-            .mockResolvedValueOnce(32)
-        const beforeAssertion = vi.fn()
-        const afterAssertion = vi.fn()
+    let thisContext: { 'toHaveHeight': typeof toHaveHeight }
+    let thisNotContext: { 'toHaveHeight': typeof toHaveHeight, isNot: boolean }
 
-        const result = await toHaveHeight.call({}, el, 32, { beforeAssertion, afterAssertion })
+    beforeEach(() => {
+        thisContext = { 'toHaveHeight': toHaveHeight }
+        thisNotContext = { 'toHaveHeight': toHaveHeight, isNot: true }
+    })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(3)
-        expect(beforeAssertion).toBeCalledWith({
-            matcherName: 'toHaveHeight',
-            expectedValue: 32,
-            options: { beforeAssertion, afterAssertion }
+    describe('given a single element', () => {
+        let el: ChainablePromiseElement
+
+        beforeEach(async () => {
+            el = await $('sel')
+
+            el.getSize = vi.fn().mockResolvedValue(32)
         })
-        expect(afterAssertion).toBeCalledWith({
-            matcherName: 'toHaveHeight',
-            expectedValue: 32,
-            options: { beforeAssertion, afterAssertion },
-            result
+
+        test('wait for success', async () => {
+            el.getSize = vi.fn()
+                .mockResolvedValueOnce(50)
+                .mockResolvedValueOnce(32)
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
+
+            const result = await thisContext.toHaveHeight(el, 32, { beforeAssertion, afterAssertion, wait: 500 })
+
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(2)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveHeight',
+                expectedValue: 32,
+                options: { beforeAssertion, afterAssertion, wait: 500 }
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveHeight',
+                expectedValue: 32,
+                options: { beforeAssertion, afterAssertion, wait: 500 },
+                result
+            })
         })
-    })
 
-    test('wait but failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockRejectedValue(new Error('some error'))
+        test('wait but failure', async () => {
+            vi.mocked(el.getSize).mockRejectedValue(new Error('some error'))
 
-        await expect(() => toHaveHeight.call({}, el, 10, {}))
-            .rejects.toThrow('some error')
-    })
+            await expect(() => thisContext.toHaveHeight(el, 10))
+                .rejects.toThrow('some error')
+        })
 
-    test('success on the first attempt', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
+        test('success on the first attempt', async () => {
+            const result = await thisContext.toHaveHeight(el, 32)
 
-        const result = await toHaveHeight.call({}, el, 32, {})
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+        test('no wait - failure', async () => {
+            const result = await thisContext.toHaveHeight(el, 10, { wait: 0 })
 
-    test('no wait - failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have height
 
-        const result = await toHaveHeight.call({}, el, 10, { wait: 0 })
-        expect(result.message()).toEqual('Expect $(`sel`) to have height\n\nExpected: 10\nReceived: 32')
-        expect(result.pass).toBe(false)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+Expected: 10
+Received: 32`
+            )
+            expect(result.pass).toBe(false)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-    test('no wait - success', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
+        test('no wait - success', async () => {
+            const result = await thisContext.toHaveHeight(el, 32, { wait: 0 })
 
-        const result = await toHaveHeight.call({}, el, 32, { wait: 0 })
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+        test('gte and lte', async () => {
+            const result = await thisContext.toHaveHeight(el, { gte: 31, lte: 33 })
 
-    test('gte and lte', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        const result = await toHaveHeight.call({}, el, { gte: 31, lte: 33 }, { wait: 0 })
+        test('not - failure - pass should be true', async () => {
+            const result = await thisNotContext.toHaveHeight(el, 32)
 
-        expect(result.message()).toEqual('Expect $(`sel`) to have height\n\nExpected: ">= 31 && <= 33"\nReceived: 32')
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
-
-    test('not - failure - pass should be true', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
-        const result = await toHaveHeight.call({ isNot: true }, el, 32, { wait: 0 })
-
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have height
 
 Expected [not]: 32
 Received      : 32`
-        )
-    })
+            )
+        })
 
-    test('not - success - pass should be false', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(31)
+        test('not - success - pass should be false', async () => {
+            const result = await thisNotContext.toHaveHeight(el, 10)
 
-        const result = await toHaveHeight.call({ isNot: true }, el, 32, { wait: 0 })
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        })
 
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
+        test('message', async () => {
+            el.getSize = vi.fn().mockResolvedValue(1)
 
-    test("should return false if sizes don't match", async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
+            const result = await thisContext.toHaveHeight(el, 50)
 
-        const result = await toHaveHeight.bind({})(el, 10, { wait: 1 })
-        expect(result.pass).toBe(false)
-    })
-
-    test('should return true if sizes match', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(32)
-
-        const result = await toHaveHeight.bind({})(el, 32, { wait: 1 })
-
-        expect(result.pass).toBe(true)
-    })
-
-    test('message', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(null)
-
-        const result = await toHaveHeight.call({}, el, 50)
-
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have height
 
 Expected: 50
-Received: null`)
+Received: 1`
+            )
+        })
     })
 })

--- a/test/matchers/element/toHaveWidth.test.ts
+++ b/test/matchers/element/toHaveWidth.test.ts
@@ -1,132 +1,119 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
-
-import { getExpectMessage } from '../../__fixtures__/utils.js'
 import { toHaveWidth } from '../../../src/matchers/element/toHaveWidth.js'
+import type { Size } from '../../../src/matchers/element/toHaveSize.js'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveWidth', () => {
-    test('wait for success', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
-        const beforeAssertion = vi.fn()
-        const afterAssertion = vi.fn()
+describe(toHaveWidth, () => {
 
-        const result = await toHaveWidth.call({}, el, 50, { beforeAssertion, afterAssertion })
+    let thisContext: { toHaveWidth: typeof toHaveWidth }
+    let thisNotContext: { toHaveWidth: typeof toHaveWidth, isNot: boolean }
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-        expect(beforeAssertion).toBeCalledWith({
-            matcherName: 'toHaveWidth',
-            expectedValue: 50,
-            options: { beforeAssertion, afterAssertion }
+    beforeEach(() => {
+        thisContext = { toHaveWidth }
+        thisNotContext = { toHaveWidth, isNot: true }
+    })
+
+    describe('given single element', () => {
+        let el: ChainablePromiseElement
+
+        beforeEach(async () => {
+            el = await $('sel')
+            vi.mocked(el.getSize).mockResolvedValue(50 as unknown as Size & number) // vitest does not support overloads function well
         })
-        expect(afterAssertion).toBeCalledWith({
-            matcherName: 'toHaveWidth',
-            expectedValue: 50,
-            options: { beforeAssertion, afterAssertion },
-            result
+
+        test('success', async () => {
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
+
+            const result = await thisContext.toHaveWidth(el, 50, { beforeAssertion, afterAssertion })
+
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveWidth',
+                expectedValue: 50,
+                options: { beforeAssertion, afterAssertion }
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveWidth',
+                expectedValue: 50,
+                options: { beforeAssertion, afterAssertion },
+                result
+            })
         })
-    })
 
-    test('wait but failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockRejectedValue(new Error('some error'))
+        test('error', async () => {
+            vi.mocked(el.getSize).mockRejectedValue(new Error('some error'))
 
-        await expect(() => toHaveWidth.call({}, el, 10, {}))
-            .rejects.toThrow('some error')
-    })
+            await expect(() => thisContext.toHaveWidth(el, 10))
+                .rejects.toThrow('some error')
+        })
 
-    test('success on the first attempt', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+        test('success on the first attempt', async () => {
+            const result = await thisContext.toHaveWidth(el, 50)
 
-        const result = await toHaveWidth.call({}, el, 50, {})
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+        test('no wait - failure', async () => {
+            const result = await thisContext.toHaveWidth(el, 10, { wait: 0 })
 
-    test('no wait - failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have width
 
-        const result = await toHaveWidth.call({}, el, 10, { wait: 0 })
+Expected: 10
+Received: 50`)
+            expect(result.pass).toBe(false)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        expect(result.message()).toEqual('Expect $(`sel`) to have width\n\nExpected: 10\nReceived: 50')
-        expect(result.pass).toBe(false)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+        test('no wait - success', async () => {
+            const result = await thisContext.toHaveWidth(el, 50, { wait: 0 })
 
-    test('no wait - success', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        const result = await toHaveWidth.call({}, el, 50, { wait: 0 })
+        test('gte and lte', async () => {
+            const result = await thisContext.toHaveWidth(el, { gte: 49, lte: 51 })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-    test('gte and lte', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+        test('not - failure - pass should be true', async () => {
+            const result = await thisNotContext.toHaveWidth(el, 50)
 
-        const result = await toHaveWidth.call({}, el, { gte: 49, lte: 51 }, { wait: 0 })
-
-        expect(result.message()).toEqual('Expect $(`sel`) to have width\n\nExpected: ">= 49 && <= 51"\nReceived: 50')
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
-
-    test('not - failure - pass should be true', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
-        const result = await toHaveWidth.call({ isNot: true }, el, 50, { wait: 0 })
-
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have width
 
 Expected [not]: 50
 Received      : 50`
-        )
-    })
+            )
+        })
 
-    test('not - success - pass should be false', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+        test('not - success - pass should be false', async () => {
+            const result = await thisNotContext.toHaveWidth(el, 100)
 
-        const result = await toHaveWidth.call({ isNot: true }, el, 40, { wait: 0 })
+            expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+        })
 
-        expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
-    })
+        test('message', async () => {
+            el.getSize = vi.fn().mockResolvedValue(0)
 
-    test("should return false if sizes don't match", async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
+            const result = await thisContext.toHaveWidth(el, 50)
 
-        const result = await toHaveWidth.bind({})(el, 10, { wait: 1 })
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have width
 
-        expect(result.pass).toBe(false)
-    })
-
-    test('should return true if sizes match', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(50)
-
-        const result = await toHaveWidth.bind({})(el, 50, { wait: 1 })
-
-        expect(result.pass).toBe(true)
-    })
-
-    test('message', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(null)
-
-        const result = await toHaveWidth.call({}, el, 50)
-
-        expect(getExpectMessage(result.message())).toContain('to have width')
+Expected: 50
+Received: 0`
+            )
+        })
     })
 })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -125,7 +125,7 @@ Received      : 2`
 
         describe('error catching', () => {
             test('throws error with incorrect size param', async () => {
-                await expect(thisContext.toBeElementsArrayOfSize(els, '5' as any)).rejects.toThrow('Invalid NumberOptions. Received: "5"')
+                await expect(thisContext.toBeElementsArrayOfSize(els, '5' as any)).rejects.toThrow('Invalid NumberMatcher. Received: "5"')
             })
 
             test('works if size contains options', async () => {
@@ -209,7 +209,7 @@ Received      : 2`
             vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
             const elements = await $$('elements')
 
-            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 100, interval: 20 })
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 100, interval: 19 })
 
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -19,10 +19,12 @@ describe(toBeElementsArrayOfSize, async () => {
 
     describe.each([
         { elements: await $$('elements'), title: 'awaited ChainablePromiseArray', selectorName: '$$(`elements`)' },
-        // { elements: await $$('elements').getElements(), title: 'awaited getElements of ChainablePromiseArray (e.g. WebdriverIO.ElementArray)' },
-        // { elements: await $$('elements').filter((t) => t.isEnabled()), selectorName: '$(`elements`), $$(`elements`)[1]', title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])' },
+        { elements: await $$('elements').getElements(), title: 'awaited getElements of ChainablePromiseArray (e.g. WebdriverIO.ElementArray)' },
+
+        // TODO to bring back later in PR supporting $$.
+        // { elements: await $$('elements').filter((t) => t.isEnabled()), title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])', selectorName: '$(`elements`), $$(`elements`)[1]' },
         // { elements: [elementFactory('element'), elementFactory('element')], selectorName: '$(`element`), $(`element`)', title: 'Array of element (e.g. WebdriverIO.Element[])' },
-        // { elements: $$('elements'), title: 'non-awaited of ChainablePromiseArray' },
+        { elements: $$('elements'), title: 'non-awaited of ChainablePromiseArray' },
 
         // // TODO to support, since the below return Promise<WebdriverIO.ElementArray|Element[]>, we do not support it type wise yet, but we could
         // { elements: $$('elements').getElements() as unknown as ChainablePromiseArray, title: 'non-awaited of ChainablePromiseArray' },
@@ -166,12 +168,27 @@ Received      : 2`
         let elementArrayOf5: ChainablePromiseArray
 
         beforeEach(async () => {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
             const actuatlRefetchElements = await vi.importActual<typeof import('../../../src/util/refetchElements.js')>('../../../src/util/refetchElements.js')
             vi.spyOn(actuatlRefetchElements, 'refetchElements')
 
             elementArrayOf2 = await chainableElementArrayFactory('elements', 2)
             elementArrayOf5 = await chainableElementArrayFactory('elements', 5)
+        })
+
+        test('does not refresh the element array with the wait 0', async () => {
+            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
+            const elements = await $$('elements')
+
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 2, { beforeAssertion: undefined, afterAssertion: undefined, wait: 0 })
+
+            expect(result.pass).toBe(true)
+            expect(browser.$$).toHaveBeenCalledTimes(1)
+            // TODO bring back later in PR supporting $$
+            // expect(waitUntil).toHaveBeenCalledWith(
+            //     expect.any(Function),
+            //     undefined,
+            //     expect.objectContaining({ wait: 1 })
+            // )
         })
 
         test('refresh once the elements array using parent $$ and update actual element with newly fetched elements', async () => {
@@ -242,6 +259,8 @@ Received      : 2`
             expect(result.pass).toBe(true)
             expect(elements.length).toBe(5)
             expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 450, true)
+            expect(browser.$$).toHaveBeenCalledTimes(2)
+            // TODO bring back later in PR supporting $$
             // expect(waitUntil).toHaveBeenCalledWith(
             //     expect.any(Function),
             //     undefined,
@@ -255,8 +274,10 @@ Received      : 2`
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5 }, { beforeAssertion: undefined, afterAssertion: undefined })
 
-            expect(result.pass).toBe(false)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 1, true)
+            expect(result.pass).toBe(true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, undefined, true)
+            expect(browser.$$).toHaveBeenCalledTimes(2)
+            // TODO bring back later in PR supporting $$
             // expect(waitUntil).toHaveBeenCalledWith(
             //     expect.any(Function),
             //     undefined,
@@ -294,33 +315,6 @@ Received      : 2`
             const result = await thisContext.toBeElementsArrayOfSize(els, size)
 
             expect(result.pass).toBe(true)
-        })
-    })
-
-    // TODO dprevost to support?
-    describe.skip('Fails for unsupported types', () => {
-
-        test.for([
-            { els: undefined, selectorName: 'undefined' },
-            { els: null, selectorName: 'null' },
-            { els: 0, selectorName: '0' },
-            { els: 1, selectorName: '1' },
-            { els: true, selectorName: 'true' },
-            { els: false, selectorName: 'false' },
-            { els: '', selectorName: '' },
-            { els: 'test', selectorName: 'test' },
-            { els: {}, selectorName: '{}' },
-            { els: [1, 'test'], selectorName: '[1,"test"]' },
-            { els: Promise.resolve(true), selectorName: 'true' }
-        ])('fails for %s', async ({ els, selectorName }) => {
-            const result = await thisContext.toBeElementsArrayOfSize(els as any, 0)
-
-            expect(result.pass).toBe(false)
-            expect(stripAnsi(result.message())).toEqual(`\
-Expect ${selectorName} to be elements array of size
-
-Expected: 0
-Received: undefined`)
         })
     })
 })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -69,6 +69,12 @@ describe(toBeElementsArrayOfSize, async () => {
                 const result = await thisNotContext.toBeElementsArrayOfSize(els, expectedNotToBeSizeOf)
 
                 expect(result.pass).toBe(false) // success, boolean is inverted later in .not cases
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} not to be elements array of size
+
+Expected [not]: ${expectedNotToBeSizeOf}
+Received      : 2`)
+
             })
         })
 
@@ -81,6 +87,18 @@ describe(toBeElementsArrayOfSize, async () => {
 Expect ${selectorName} to be elements array of size
 
 Expected: 5
+Received: 2`
+                )
+            })
+
+            test('fails - in between - with proper error message', async () => {
+                const result = await thisContext.toBeElementsArrayOfSize(els, { gte: 3, lte: 5 })
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} to be elements array of size
+
+Expected: ">= 3 && <= 5"
 Received: 2`
                 )
             })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -192,7 +192,7 @@ Received      : 2`
         })
 
         test('refresh once the elements array using parent $$ and update actual element with newly fetched elements', async () => {
-            vi.fn(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
+            vi.mocked(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
             const elements = await $$('elements')
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, 5, { wait: 95, interval: 50 })
@@ -209,19 +209,19 @@ Received      : 2`
             vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
             const elements = await $$('elements')
 
-            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 100, interval: 19 })
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 200, interval: 20 })
 
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)
             expect(elements).toBe(elementArrayOf2)
-            expect(browser.$$).toHaveBeenCalledTimes(7)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 100, true)
-            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 100, true)
+            expect(browser.$$).toHaveBeenCalledTimes(11)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 200, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 200, true)
         })
 
         // TODO: By awaiting the promise we could update the actual elements array, so should we support that?
         test('refresh once but does not update actual elements since they are not of type ElementArray or Element[]', async () => {
-            vi.fn(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
+            vi.mocked(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
             const nonAwaitedElements = $$('elements')
 
             const result = await thisContext.toBeElementsArrayOfSize(nonAwaitedElements, 5, { wait: 500 })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -214,7 +214,7 @@ Received      : 2`
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)
             expect(elements).toBe(elementArrayOf2)
-            expect(browser.$$).toHaveBeenCalledTimes(6)
+            expect(browser.$$).toHaveBeenCalledTimes(7)
             expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 100, true)
             expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 100, true)
         })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -317,4 +317,11 @@ Received      : 2`
             expect(result.pass).toBe(true)
         })
     })
+
+    test('fails for empty expected value', async () => {
+        const els = await $$('elements')
+
+        await expect(thisContext.toBeElementsArrayOfSize(els, {})).rejects.toThrow('Invalid NumberMatcher. Received: {}')
+        await expect(thisContext.toBeElementsArrayOfSize(els, {},  { wait: 0 })).rejects.toThrow('Invalid NumberMatcher. Received: {}')
+    })
 })

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -1,266 +1,326 @@
 import { vi, test, describe, expect, beforeEach } from 'vitest'
-import { $$ } from '@wdio/globals'
+import { $$, browser } from '@wdio/globals'
 
-import { getExpectMessage, getReceived, getExpected } from '../../__fixtures__/utils.js'
 import { toBeElementsArrayOfSize } from '../../../src/matchers/elements/toBeElementsArrayOfSize.js'
-import type { AssertionResult } from 'expect-webdriverio'
+import { chainableElementArrayFactory, elementArrayFactory, elementFactory } from '../../__mocks__/@wdio/globals.js'
+import { refetchElements } from '../../../src/util/refetchElements.js'
+import stripAnsi from 'strip-ansi'
 
-const createMockElementArray = (length: number): WebdriverIO.ElementArray => {
-    const array = Array.from({ length }, () => ({}))
-    const mockArray = {
-        selector: 'parent',
-        get length() { return array.length },
-        set length(newLength: number) { array.length = newLength },
-        parent: {
-            $: vi.fn(),
-            $$: vi.fn().mockReturnValue(array),
-        },
-        foundWith: '$$',
-        props: [],
-        [Symbol.iterator]: array[Symbol.iterator].bind(array),
-        filter: vi.fn().mockReturnThis(),
-        map: vi.fn().mockReturnThis(),
-        find: vi.fn().mockReturnThis(),
-        forEach: vi.fn(),
-        some: vi.fn(),
-        every: vi.fn(),
-        slice: vi.fn().mockReturnThis(),
-        toArray: vi.fn().mockReturnThis(),
-    }
-    return Object.assign(array, mockArray) as unknown as WebdriverIO.ElementArray
-}
+vi.mock('@wdio/globals')
 
-vi.mock('@wdio/globals', () => ({
-    $$: vi.fn().mockImplementation(() => createMockElementArray(2))
-}))
+describe(toBeElementsArrayOfSize, async () => {
+    let thisContext: { toBeElementsArrayOfSize: typeof toBeElementsArrayOfSize }
+    let thisNotContext: { toBeElementsArrayOfSize: typeof toBeElementsArrayOfSize, isNot: boolean }
 
-describe('toBeElementsArrayOfSize', () => {
-    describe('given an elements of type WebdriverIO.ElementArray', () => {
-        let els: WebdriverIO.ElementArray
+    beforeEach(() => {
+        thisContext = { toBeElementsArrayOfSize }
+        thisNotContext = { toBeElementsArrayOfSize, isNot: true }
+    })
+
+    describe.each([
+        { elements: await $$('elements'), title: 'awaited ChainablePromiseArray', selectorName: '$$(`elements`)' },
+        // { elements: await $$('elements').getElements(), title: 'awaited getElements of ChainablePromiseArray (e.g. WebdriverIO.ElementArray)' },
+        // { elements: await $$('elements').filter((t) => t.isEnabled()), selectorName: '$(`elements`), $$(`elements`)[1]', title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])' },
+        // { elements: [elementFactory('element'), elementFactory('element')], selectorName: '$(`element`), $(`element`)', title: 'Array of element (e.g. WebdriverIO.Element[])' },
+        // { elements: $$('elements'), title: 'non-awaited of ChainablePromiseArray' },
+
+        // // TODO to support, since the below return Promise<WebdriverIO.ElementArray|Element[]>, we do not support it type wise yet, but we could
+        // { elements: $$('elements').getElements() as unknown as ChainablePromiseArray, title: 'non-awaited of ChainablePromiseArray' },
+        // { elements: $$('elements').filter((t) => t.isEnabled()) as unknown as ChainablePromiseArray, selectorName:'$(`elements`), $$(`elements`)[1]', title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])' },
+    ])('given multiple elements when $title', ({ elements, selectorName = '$$(`elements`)' }) => {
+        let els: ChainablePromiseArray | WebdriverIO.Element[] | WebdriverIO.ElementArray
 
         beforeEach(() => {
-            els = $$('parent') as unknown as WebdriverIO.ElementArray
+            els = elements
         })
 
         describe('success', () => {
             test('array of size 2', async () => {
                 const beforeAssertion = vi.fn()
                 const afterAssertion = vi.fn()
-                const result = await toBeElementsArrayOfSize.call({}, els, 2, { beforeAssertion, afterAssertion, wait: 0 })
+
+                const result = await thisContext.toBeElementsArrayOfSize(els, 2, { beforeAssertion, afterAssertion, wait: 0 })
+
+                // TODO bring back later in PR supporting $$
+                // expect(waitUntil).toHaveBeenCalledWith(
+                //     expect.any(Function),
+                //     undefined,
+                //     expect.objectContaining({ wait: 0 })
+                // )
                 expect(result.pass).toBe(true)
-                expect(beforeAssertion).toBeCalledWith({
+                expect(beforeAssertion).toHaveBeenCalledWith({
                     matcherName: 'toBeElementsArrayOfSize',
                     expectedValue: 2,
                     options: { beforeAssertion, afterAssertion, wait: 0 }
                 })
-                expect(afterAssertion).toBeCalledWith({
+                expect(afterAssertion).toHaveBeenCalledWith({
                     matcherName: 'toBeElementsArrayOfSize',
                     expectedValue: 2,
                     options: { beforeAssertion, afterAssertion, wait: 0 },
                     result
                 })
             })
-            test('array of size 5', async () => {
-                els = createMockElementArray(5)
-                const result = await toBeElementsArrayOfSize.call({}, els, 5, { wait : 0 })
-                expect(result.pass).toBe(true)
+
+            test.for([
+                0, 1, 3
+            ])('not - success - pass should be false', async (expectedNotToBeSizeOf) => {
+                const result = await thisNotContext.toBeElementsArrayOfSize(els, expectedNotToBeSizeOf)
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later in .not cases
             })
         })
 
         describe('failure', () => {
-            let result: AssertionResult
+            test('fails with proper error message', async () => {
+                const result = await thisContext.toBeElementsArrayOfSize(els, 5)
 
-            beforeEach(async () => {
-                result = await toBeElementsArrayOfSize.call({}, els, 5, { wait: 0 })
-            })
-
-            test('fails', () => {
                 expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} to be elements array of size
+
+Expected: 5
+Received: 2`
+                )
             })
 
-            describe('message shows correctly', () => {
-                test('expect message', () => {
-                    expect(getExpectMessage(result.message())).toContain('to be elements array of size')
-                })
-                test('expected message', () => {
-                    expect(getExpected(result.message())).toContain('5')
-                })
-                test('received message', () => {
-                    expect(getReceived(result.message())).toContain('2')
-                })
+            test('not - failure - pass should be true', async () => {
+                const result = await thisNotContext.toBeElementsArrayOfSize(els, 2)
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later in .not cases
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} not to be elements array of size
+
+Expected [not]: 2
+Received      : 2`
+                )
             })
+
+            test('not - failure - lte - pass should be true', async () => {
+                const result = await thisNotContext.toBeElementsArrayOfSize(els, { lte: 3 })
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later in .not cases
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} not to be elements array of size
+
+Expected [not]: "<= 3"
+Received      : 2`
+                )
+            })
+
+            test('not - failure - gte - pass should be true', async () => {
+                const result = await thisNotContext.toBeElementsArrayOfSize(els, { gte: 1 })
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later in .not cases
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} not to be elements array of size
+
+Expected [not]: ">= 1"
+Received      : 2`
+                )
+            })
+
         })
 
         describe('error catching', () => {
             test('throws error with incorrect size param', async () => {
-                await expect(toBeElementsArrayOfSize.call({}, els, '5' as any)).rejects.toThrow('Invalid params passed to toBeElementsArrayOfSize.')
+                await expect(thisContext.toBeElementsArrayOfSize(els, '5' as any)).rejects.toThrow('Invalid NumberOptions. Received: "5"')
             })
 
             test('works if size contains options', async () => {
-                const result = await toBeElementsArrayOfSize.call({}, els, { lte: 5 }, { wait: 0 })
+                const result = await thisContext.toBeElementsArrayOfSize(els, { lte: 5 })
                 expect(result.pass).toBe(true)
             })
         })
 
         describe('number options', () => {
             test.each([
-                ['lte', 10, true],
-                ['lte', 1, false],
-                ['gte', 1, true],
-                ['gte', 10, false],
-                ['gte and lte', { gte: 1, lte: 10, wait: 0 }, true],
-                ['not gte but is lte', { gte: 10, lte: 10, wait: 0 }, false],
-                ['not lte but is gte', { gte: 1, lte: 1, wait: 0 }, false],
-            ])('should handle %s correctly', async (_, option, expected) => {
-                const result = await toBeElementsArrayOfSize.call({}, els, typeof option === 'object' ? option : { [_ as string]: option })
-                expect(result.pass).toBe(expected)
-            })
-        })
+                ['number - equal', 2, true],
+                ['number - equal - fail 1', 1, false],
+                ['number - equal - fail 2', 3, false],
+            ])('should handle %s correctly', async (_title, expectedNumberValue, expectedPass) => {
+                const result = await thisContext.toBeElementsArrayOfSize(els, expectedNumberValue,  { wait: 0 })
 
-        describe('array update', () => {
-            test('updates the received array when assertion passes', async () => {
-                const receivedArray = createMockElementArray(2);
-                (receivedArray.parent as any)._length = 5;
-                (receivedArray.parent as any).$$ = vi.fn().mockReturnValue(createMockElementArray(5))
-
-                const result = await toBeElementsArrayOfSize.call({}, receivedArray, 5)
-
-                expect(result.pass).toBe(true)
-                expect(receivedArray.length).toBe(5)
+                expect(result.pass).toBe(expectedPass)
             })
 
-            test('does not update the received array when assertion fails', async () => {
-                const receivedArray = createMockElementArray(2)
+            test.each([
+                ['gte - equal', { gte: 2 } satisfies ExpectWebdriverIO.NumberOptions, true],
+                ['gte - fail', { gte: 1 } satisfies ExpectWebdriverIO.NumberOptions, true],
+                ['gte', { gte: 3 } satisfies ExpectWebdriverIO.NumberOptions, false],
+                ['lte - equal', { lte: 2 } satisfies ExpectWebdriverIO.NumberOptions, true],
+                ['lte - fail', { lte: 3 } satisfies ExpectWebdriverIO.NumberOptions, true],
+                ['lte', { lte: 1 } satisfies ExpectWebdriverIO.NumberOptions, false],
+                ['gte and lte', { gte: 1, lte: 10 } satisfies ExpectWebdriverIO.NumberOptions, true],
+                ['not gte but is lte', { gte: 10, lte: 10 } satisfies ExpectWebdriverIO.NumberOptions, false],
+                ['not lte but is gte', { gte: 1, lte: 1 } satisfies ExpectWebdriverIO.NumberOptions, false],
+            ])('should handle %s correctly', async (_title, expectedNumberValue: ExpectWebdriverIO.NumberOptions, expectedPass) => {
+                const result = await thisContext.toBeElementsArrayOfSize(els, expectedNumberValue)
 
-                const result = await toBeElementsArrayOfSize.call({}, receivedArray, 10)
-
-                expect(result.pass).toBe(false)
-                expect(receivedArray.length).toBe(2)
-            })
-
-            test('does not modify non-array received values', async () => {
-                const nonArrayEls = {
-                    selector: 'parent',
-                    length: 2,
-                    parent: {
-                        $: vi.fn(),
-                        $$: vi.fn().mockReturnValue(createMockElementArray(5)),
-                    },
-                    foundWith: '$$',
-                    props: [],
-                } as unknown as WebdriverIO.ElementArray
-
-                const result = await toBeElementsArrayOfSize.call({}, nonArrayEls, 5)
-
-                expect(result.pass).toBe(true)
-                expect(nonArrayEls.length).toBe(2)
-            })
-
-            test('does not alter the array when checking', async () => {
-                const receivedArray = createMockElementArray(2)
-                const result = await toBeElementsArrayOfSize.call({}, receivedArray, 2)
-
-                expect(result.pass).toBe(true)
-                expect(receivedArray.length).toBe(2)
+                expect(result.pass).toBe(expectedPass)
             })
         })
     })
 
-    describe('given an elements of type WebdriverIO.Element[]', () => {
-        describe('when elements is empty array', () => {
-            const elements: WebdriverIO.Element[] = []
-            describe('success', () => {
-                test('array of size 0', async () => {
-                    const beforeAssertion = vi.fn()
-                    const afterAssertion = vi.fn()
-                    const result = await toBeElementsArrayOfSize.call({}, elements, 0, { beforeAssertion, afterAssertion, wait: 0 })
-                    expect(result.pass).toBe(true)
-                    expect(beforeAssertion).toBeCalledWith({
-                        matcherName: 'toBeElementsArrayOfSize',
-                        expectedValue: 0,
-                        options: { beforeAssertion, afterAssertion, wait: 0 }
-                    })
-                    expect(afterAssertion).toBeCalledWith({
-                        matcherName: 'toBeElementsArrayOfSize',
-                        expectedValue: 0,
-                        options: { beforeAssertion, afterAssertion, wait: 0 },
-                        result
-                    })
-                })
-            })
+    describe('Refresh ElementArray', async () => {
+        let elementArrayOf2: ChainablePromiseArray
+        let elementArrayOf5: ChainablePromiseArray
 
-            describe('failure', () => {
-                let result: AssertionResult
+        beforeEach(async () => {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+            const actuatlRefetchElements = await vi.importActual<typeof import('../../../src/util/refetchElements.js')>('../../../src/util/refetchElements.js')
+            vi.spyOn(actuatlRefetchElements, 'refetchElements')
 
-                beforeEach(async () => {
-                    result = await toBeElementsArrayOfSize.call({}, elements, 5, { wait: 0 })
-                })
-
-                test('fails', () => {
-                    expect(result.pass).toBe(false)
-                })
-
-                describe('message shows correctly', () => {
-                    test('expect message', () => {
-                        expect(getExpectMessage(result.message())).toContain('to be elements array of size')
-                    })
-                    test('expected message', () => {
-                        expect(getExpected(result.message())).toContain('5')
-                    })
-                    test('received message', () => {
-                        expect(getReceived(result.message())).toContain('0')
-                    })
-                })
-            })
+            elementArrayOf2 = await chainableElementArrayFactory('elements', 2)
+            elementArrayOf5 = await chainableElementArrayFactory('elements', 5)
         })
 
-        describe('when elements is not empty array', () => {
-            const elements: WebdriverIO.Element[] = [{
-                elementId: 'element-1'
-            } satisfies Partial<WebdriverIO.Element> as WebdriverIO.Element,]
-            describe('success', () => {
-                test('array of size 1', async () => {
-                    const beforeAssertion = vi.fn()
-                    const afterAssertion = vi.fn()
-                    const result = await toBeElementsArrayOfSize.call({}, elements, 1, { beforeAssertion, afterAssertion, wait: 0 })
-                    expect(result.pass).toBe(true)
-                    expect(beforeAssertion).toBeCalledWith({
-                        matcherName: 'toBeElementsArrayOfSize',
-                        expectedValue: 1,
-                        options: { beforeAssertion, afterAssertion, wait: 0 }
-                    })
-                    expect(afterAssertion).toBeCalledWith({
-                        matcherName: 'toBeElementsArrayOfSize',
-                        expectedValue: 1,
-                        options: { beforeAssertion, afterAssertion, wait: 0 },
-                        result
-                    })
-                })
-            })
+        test('refresh once the elements array using parent $$ and update actual element with newly fetched elements', async () => {
+            vi.fn(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
+            const elements = await $$('elements')
 
-            describe('failure', () => {
-                let result: AssertionResult
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 5, { wait: 95, interval: 50 })
 
-                beforeEach(async () => {
-                    result = await toBeElementsArrayOfSize.call({}, elements, 5, { wait: 0 })
-                })
+            expect(result.pass).toBe(true)
+            expect(elements).toBe(elementArrayOf2) // Original actual elements array but altered
+            expect(elements.length).toBe(5) // Altered actual elements array
+            expect(browser.$$).toHaveBeenCalledTimes(2)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 95, true)
+            expect(refetchElements).toHaveBeenCalledTimes(1)
+        })
 
-                test('fails', () => {
-                    expect(result.pass).toBe(false)
-                })
+        test('refresh multiple time actual elements but does not update it since it failed', async () => {
+            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
+            const elements = await $$('elements')
 
-                describe('message shows correctly', () => {
-                    test('expect message', () => {
-                        expect(getExpectMessage(result.message())).toContain('to be elements array of size')
-                    })
-                    test('expected message', () => {
-                        expect(getExpected(result.message())).toContain('5')
-                    })
-                    test('received message', () => {
-                        expect(getReceived(result.message())).toContain('1')
-                    })
-                })
-            })
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 100, interval: 20 })
+
+            expect(result.pass).toBe(false)
+            expect(elements.length).toBe(2)
+            expect(elements).toBe(elementArrayOf2)
+            expect(browser.$$).toHaveBeenCalledTimes(6)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 100, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 100, true)
+        })
+
+        // TODO: By awaiting the promise we could update the actual elements array, so should we support that?
+        test('refresh once but does not update actual elements since they are not of type ElementArray or Element[]', async () => {
+            vi.fn(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
+            const nonAwaitedElements = $$('elements')
+
+            const result = await thisContext.toBeElementsArrayOfSize(nonAwaitedElements, 5, { wait: 500 })
+
+            expect(result.pass).toBe(true)
+            expect(nonAwaitedElements).toBeInstanceOf(Promise)
+            expect((await nonAwaitedElements).length).toBe(2)
+            expect(await nonAwaitedElements).toBe(elementArrayOf2)
+            expect(browser.$$).toHaveBeenCalledTimes(2)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 500, true)
+            expect(refetchElements).toHaveBeenCalledTimes(1)
+        })
+
+        test.for([
+            elementArrayFactory('elements', 2),
+            await chainableElementArrayFactory('elements', 2),
+            [elementFactory('elements', 0), elementFactory('elements', 1)]
+        ])('Does not refetch and does not alter the actual elements array when it size matches on first try', async () => {
+            const receivedArray = elementArrayFactory('elements', 2)
+            const result = await thisContext.toBeElementsArrayOfSize(receivedArray, 2)
+
+            expect(result.pass).toBe(true)
+            expect(receivedArray.length).toBe(2)
+            expect(receivedArray).toBe(receivedArray)
+            expect(browser.$$).not.toHaveBeenCalled()
+            expect(refetchElements).not.toHaveBeenCalled()
+        })
+
+        test('refresh once the element array with the NumberOptions wait value', async () => {
+            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
+            const elements = await $$('elements')
+
+            const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5, wait: 450 })
+
+            expect(result.pass).toBe(true)
+            expect(elements.length).toBe(5)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 450, true)
+            // expect(waitUntil).toHaveBeenCalledWith(
+            //     expect.any(Function),
+            //     undefined,
+            //     expect.objectContaining({ wait: 450 })
+            // )
+        })
+
+        test('refresh once the element array with the DEFAULT_OPTIONS wait value', async () => {
+            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
+            const elements = await $$('elements')
+
+            const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5 }, { beforeAssertion: undefined, afterAssertion: undefined })
+
+            expect(result.pass).toBe(false)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 1, true)
+            // expect(waitUntil).toHaveBeenCalledWith(
+            //     expect.any(Function),
+            //     undefined,
+            //     expect.objectContaining({ wait: 1 })
+            // )
+        })
+    })
+
+    describe('Works with differenet ElementArray or Element[] sizes', () => {
+        test.for([
+            0, 1, 2, 3, 4, 5, 10
+        ])('ChainablePromiseArray of size %i', async (size) => {
+            const els = chainableElementArrayFactory('elements', size)
+
+            const result = await thisContext.toBeElementsArrayOfSize(els, size)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test.for([
+            0, 1, 2, 3, 4, 5, 10
+        ])('ElementArray of size %i', async (size) => {
+            const els = elementArrayFactory('elements', size)
+
+            const result = await thisContext.toBeElementsArrayOfSize(els, size)
+
+            expect(result.pass).toBe(true)
+        })
+
+        test.for([
+            0, 1, 2, 3, 4, 5, 10
+        ])('Element[] of size %i', async (size) => {
+            const els = Array(size).fill(null).map((_, index) => elementFactory('element', index))
+
+            const result = await thisContext.toBeElementsArrayOfSize(els, size)
+
+            expect(result.pass).toBe(true)
+        })
+    })
+
+    // TODO dprevost to support?
+    describe.skip('Fails for unsupported types', () => {
+
+        test.for([
+            { els: undefined, selectorName: 'undefined' },
+            { els: null, selectorName: 'null' },
+            { els: 0, selectorName: '0' },
+            { els: 1, selectorName: '1' },
+            { els: true, selectorName: 'true' },
+            { els: false, selectorName: 'false' },
+            { els: '', selectorName: '' },
+            { els: 'test', selectorName: 'test' },
+            { els: {}, selectorName: '{}' },
+            { els: [1, 'test'], selectorName: '[1,"test"]' },
+            { els: Promise.resolve(true), selectorName: 'true' }
+        ])('fails for %s', async ({ els, selectorName }) => {
+            const result = await thisContext.toBeElementsArrayOfSize(els as any, 0)
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} to be elements array of size
+
+Expected: 0
+Received: undefined`)
         })
     })
 })

--- a/test/matchers/mock/toBeRequestedTimes.test.ts
+++ b/test/matchers/mock/toBeRequestedTimes.test.ts
@@ -1,10 +1,20 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 // @ts-ignore TODO fix me
 import type { Matches, Mock } from 'webdriverio'
 
 import { toBeRequestedTimes } from '../../../src/matchers/mock/toBeRequestedTimes.js'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
+vi.mock('../../../src/constants.js', async () => ({
+    DEFAULT_OPTIONS: {
+
+        ...(await vi.importActual<typeof import('../../../src/constants.js')>('../../../src/constants.js')).DEFAULT_OPTIONS,
+        // speed up tests by lowering default wait timeout
+        wait : 30,
+        interval: 10
+    }
+}))
 
 class TestMock implements Mock {
     _calls: Matches[]
@@ -37,6 +47,14 @@ const mockMatch: Matches = {
 }
 
 describe('toBeRequestedTimes', () => {
+    let thisNotContext: { isNot: true; toBeRequestedTimes: typeof toBeRequestedTimes }
+    let thisContext: { toBeRequestedTimes: typeof toBeRequestedTimes }
+
+    beforeEach(() => {
+        thisNotContext = { isNot: true, toBeRequestedTimes }
+        thisContext = { toBeRequestedTimes }
+    })
+
     test('wait for success', async () => {
         const mock: Mock = new TestMock()
 
@@ -46,17 +64,19 @@ describe('toBeRequestedTimes', () => {
 
         const beforeAssertion = vi.fn()
         const afterAssertion = vi.fn()
-        const result = await toBeRequestedTimes.call({}, mock, 1, { beforeAssertion, afterAssertion })
+
+        const result = await thisContext.toBeRequestedTimes(mock, 1, { beforeAssertion, afterAssertion, wait: 500 })
+
         expect(result.pass).toBe(true)
-        expect(beforeAssertion).toBeCalledWith({
+        expect(beforeAssertion).toHaveBeenCalledWith({
             matcherName: 'toBeRequestedTimes',
             expectedValue: 1,
-            options: { beforeAssertion, afterAssertion }
+            options: { beforeAssertion, afterAssertion, wait: 500 }
         })
-        expect(afterAssertion).toBeCalledWith({
+        expect(afterAssertion).toHaveBeenCalledWith({
             matcherName: 'toBeRequestedTimes',
             expectedValue: 1,
-            options: { beforeAssertion, afterAssertion },
+            options: { beforeAssertion, afterAssertion, wait: 500 },
             result
         })
     })
@@ -68,15 +88,15 @@ describe('toBeRequestedTimes', () => {
             mock.calls.push(mockMatch)
         }, 10)
 
-        const result = await toBeRequestedTimes.call({}, mock, { gte: 1 })
+        const result = await thisContext.toBeRequestedTimes(mock, { gte: 1, wait: 500 })
         expect(result.pass).toBe(true)
-        const result2 = await toBeRequestedTimes.call({}, mock, { eq: 1 })
+        const result2 = await thisContext.toBeRequestedTimes(mock, { eq: 1, wait: 500 })
         expect(result2.pass).toBe(true)
     })
 
     test('wait but failure', async () => {
         const mock: Mock = new TestMock()
-        const result = await toBeRequestedTimes.call({}, mock, 1)
+        const result = await thisContext.toBeRequestedTimes(mock, 1)
         expect(result.pass).toBe(false)
 
         setTimeout(() => {
@@ -84,15 +104,19 @@ describe('toBeRequestedTimes', () => {
             mock.calls.push(mockMatch)
         }, 10)
 
-        const result2 = await toBeRequestedTimes.call({}, mock, 1)
+        const result2 = await thisContext.toBeRequestedTimes(mock, 1)
         expect(result2.pass).toBe(false)
-        const result3 = await toBeRequestedTimes.call({}, mock, 2)
+
+        const result3 = await thisContext.toBeRequestedTimes(mock, 2)
         expect(result3.pass).toBe(true)
-        const result4 = await toBeRequestedTimes.call({}, mock, { gte: 2 })
+
+        const result4 = await thisContext.toBeRequestedTimes(mock, { gte: 2, wait: 1 })
         expect(result4.pass).toBe(true)
-        const result5 = await toBeRequestedTimes.call({}, mock, { lte: 2 })
+
+        const result5 = await thisContext.toBeRequestedTimes(mock, { lte: 2, wait: 1 })
         expect(result5.pass).toBe(true)
-        const result6 = await toBeRequestedTimes.call({}, mock, { lte: 3 })
+
+        const result6 = await thisContext.toBeRequestedTimes(mock, { lte: 3, wait: 1 })
         expect(result6.pass).toBe(true)
     })
 
@@ -100,9 +124,9 @@ describe('toBeRequestedTimes', () => {
         const mock: Mock = new TestMock()
 
         // expect(mock).not.toBeRequestedTimes(0) should fail
-        const result = await toBeRequestedTimes.call({ isNot: true }, mock, 0)
+        const result = await thisNotContext.toBeRequestedTimes(mock, 0)
         expect(result.pass).toBe(true) // failure, boolean inverted later because of .not
-        expect(result.message()).toEqual(`\
+        expect(stripAnsi(result.message())).toEqual(`\
 Expect mock not to be called 0 times
 
 Expected [not]: 0
@@ -110,17 +134,17 @@ Received      : 0`
         )
 
         // expect(mock).not.toBeRequestedTimes(1) should pass
-        const result2 = await toBeRequestedTimes.call({ isNot: true }, mock, 1)
+        const result2 = await thisNotContext.toBeRequestedTimes(mock, 1)
         expect(result2.pass).toBe(false) // success, boolean inverted later because of .not
 
         mock.calls.push(mockMatch)
 
         // expect(mock).not.toBeRequestedTimes(0) should pass
-        const result3 = await toBeRequestedTimes.call({ isNot: true }, mock, 0)
+        const result3 = await thisNotContext.toBeRequestedTimes(mock, 0)
         expect(result3.pass).toBe(false) // success, boolean inverted later because of .not
 
         // expect(mock).not.toBeRequestedTimes(1) should fail
-        const result4 = await toBeRequestedTimes.call({ isNot: true }, mock, 1)
+        const result4 = await thisNotContext.toBeRequestedTimes(mock, 1)
         expect(result4.pass).toBe(true) // failure, boolean inverted later because of .not
         expect(result4.message()).toEqual(`\
 Expect mock not to be called 1 time
@@ -133,16 +157,16 @@ Received      : 1`
     test('message', async () => {
         const mock: Mock = new TestMock()
 
-        const result = await toBeRequestedTimes.call({}, mock, 0, { wait: 1 })
-        expect(result.message()).toContain('Expect mock to be called 0 times')
+        const result = await thisContext.toBeRequestedTimes(mock, 0)
+        expect(stripAnsi(result.message())).toContain('Expect mock to be called 0 times')
 
-        const result2 = await toBeRequestedTimes.call({}, mock, 1, { wait: 1 })
+        const result2 = await thisContext.toBeRequestedTimes(mock, 1)
         expect(result2.message()).toContain('Expect mock to be called 1 time')
 
-        const result3 = await toBeRequestedTimes.call({}, mock, 2, { wait: 1 })
+        const result3 = await thisContext.toBeRequestedTimes(mock, 2)
         expect(result3.message()).toContain('Expect mock to be called 2 times')
 
-        const result4 = await toBeRequestedTimes.call({}, mock, { gte: 3 }, { wait: 1 })
+        const result4 = await thisContext.toBeRequestedTimes(mock, { gte: 3 })
         expect(result4.pass).toBe(false)
         expect(result4.message()).toEqual(`\
 Expect mock to be called times

--- a/test/matchers/mock/toBeRequestedTimes.test.ts
+++ b/test/matchers/mock/toBeRequestedTimes.test.ts
@@ -81,6 +81,21 @@ describe('toBeRequestedTimes', () => {
         })
     })
 
+    test('use wait from number options - deprecated', async () => {
+        const mock: Mock = new TestMock()
+
+        setTimeout(() => {
+            mock.calls.push(mockMatch)
+        }, 10)
+
+        const beforeAssertion = vi.fn()
+        const afterAssertion = vi.fn()
+
+        const result = await thisContext.toBeRequestedTimes(mock, { gte: 1, wait: 0 }, { beforeAssertion, afterAssertion, wait: 1000 })
+
+        expect(result.pass).toBe(false)
+    })
+
     test('wait for success using number options', async () => {
         const mock: Mock = new TestMock()
 

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -126,8 +126,8 @@ describe('Command Options Utility Functions', () => {
 
         // 1. Testing Requirement: Empty Objects
         describe('Empty Objects', () => {
-            it('should return true for a completely empty object literal', () => {
-                expect(isStrictlyCommandOptions({})).toBe(true)
+            it('should return false for a completely empty object literal - we do not need any backward compatibility for command options', () => {
+                expect(isStrictlyCommandOptions({})).toBe(false)
             })
         })
 

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -1,120 +1,225 @@
 import { describe, it, expect, vi } from 'vitest'
 import { isStringOptions } from '../../src/util/commandOptionsUtils'
+import { isStrictlyCommandOptions } from '../../src/util/commandOptionsUtils.js'
 
-describe('isStringOptions Type Guard', () => {
+describe('Command Options Utility Functions', () => {
 
-    // 1. Testing Requirement: Empty Objects
-    describe('Empty Objects', () => {
-        it('should return true for a completely empty object literal', () => {
-            expect(isStringOptions({})).toBe(true)
-        })
-    })
+    describe('isStringOptions Type Guard', () => {
 
-    // 2. Testing Requirement: StringOptions Properties
-    describe('StringOptions Properties', () => {
-        it('should return true for objects containing valid StringOptions properties', () => {
-            expect(isStringOptions({ ignoreCase: true })).toBe(true)
-            expect(isStringOptions({ trim: false })).toBe(true)
-            expect(isStringOptions({ containing: true })).toBe(true)
-            expect(isStringOptions({ atStart: true })).toBe(true)
-            expect(isStringOptions({ atEnd: false })).toBe(true)
-            expect(isStringOptions({ atIndex: 2 })).toBe(true)
-            expect(isStringOptions({ replace: ['foo', 'bar'] })).toBe(true)
-            expect(isStringOptions({ asString: true })).toBe(true)
-        })
-    })
-
-    // 3. Testing Requirement: Inherited CommandOptions & DefaultOptions Properties
-    describe('Parent Interface Properties (CommandOptions & DefaultOptions)', () => {
-        it('should return true for objects containing inherited properties', () => {
-            expect(isStringOptions({ message: 'Custom Error Message' })).toBe(true)
-            expect(isStringOptions({ wait: 5000 })).toBe(true)
-            expect(isStringOptions({ interval: 200 })).toBe(true)
-            expect(isStringOptions({ beforeAssertion: async () => { } })).toBe(true)
-            expect(isStringOptions({ afterAssertion: async () => { } })).toBe(true)
+        // 1. Testing Requirement: Empty Objects
+        describe('Empty Objects', () => {
+            it('should return true for a completely empty object literal', () => {
+                expect(isStringOptions({})).toBe(true)
+            })
         })
 
-        it('should return true for a fully valid mixed configuration object', () => {
-            const mixedOptions = {
-                trim: true,
-                wait: 1000,
-                message: 'Failed assertion'
-            }
-            expect(isStringOptions(mixedOptions)).toBe(true)
-        })
-    })
-
-    // 4. Testing Requirement: Invalid Configurations & False Positives
-    describe('Invalid Configurations & False Positives', () => {
-        it('should return false for primitive types and null', () => {
-            expect(isStringOptions('some-string-value')).toBe(false)
-            expect(isStringOptions(123)).toBe(false)
-            expect(isStringOptions(true)).toBe(false)
-            expect(isStringOptions(null)).toBe(false)
-            expect(isStringOptions(undefined)).toBe(false)
+        // 2. Testing Requirement: StringOptions Properties
+        describe('StringOptions Properties', () => {
+            it('should return true for objects containing valid StringOptions properties', () => {
+                expect(isStringOptions({ ignoreCase: true })).toBe(true)
+                expect(isStringOptions({ trim: false })).toBe(true)
+                expect(isStringOptions({ containing: true })).toBe(true)
+                expect(isStringOptions({ atStart: true })).toBe(true)
+                expect(isStringOptions({ atEnd: false })).toBe(true)
+                expect(isStringOptions({ atIndex: 2 })).toBe(true)
+                expect(isStringOptions({ replace: ['foo', 'bar'] })).toBe(true)
+                expect(isStringOptions({ asString: true })).toBe(true)
+            })
         })
 
-        it('should return false for RegExp instances', () => {
-            expect(isStringOptions(/test-regex/i)).toBe(false)
-            expect(isStringOptions(new RegExp('test'))).toBe(false)
+        // 3. Testing Requirement: Inherited CommandOptions & DefaultOptions Properties
+        describe('Parent Interface Properties (CommandOptions & DefaultOptions)', () => {
+            it('should return true for objects containing inherited properties', () => {
+                expect(isStringOptions({ message: 'Custom Error Message' })).toBe(true)
+                expect(isStringOptions({ wait: 5000 })).toBe(true)
+                expect(isStringOptions({ interval: 200 })).toBe(true)
+                expect(isStringOptions({ beforeAssertion: async () => { } })).toBe(true)
+                expect(isStringOptions({ afterAssertion: async () => { } })).toBe(true)
+            })
+
+            it('should return true for a fully valid mixed configuration object', () => {
+                const mixedOptions = {
+                    trim: true,
+                    wait: 1000,
+                    message: 'Failed assertion'
+                }
+                expect(isStringOptions(mixedOptions)).toBe(true)
+            })
         })
 
-        it('should return false for Asymmetric Matchers', () => {
-            const mockAsymmetricMatcher = {
-                asymmetricMatch: vi.fn(),
-                toString: vi.fn()
-            }
-            expect(isStringOptions(mockAsymmetricMatcher)).toBe(false)
+        // 4. Testing Requirement: Invalid Configurations & False Positives
+        describe('Invalid Configurations & False Positives', () => {
+            it('should return false for primitive types and null', () => {
+                expect(isStringOptions('some-string-value')).toBe(false)
+                expect(isStringOptions(123)).toBe(false)
+                expect(isStringOptions(true)).toBe(false)
+                expect(isStringOptions(null)).toBe(false)
+                expect(isStringOptions(undefined)).toBe(false)
+            })
+
+            it('should return false for RegExp instances', () => {
+                expect(isStringOptions(/test-regex/i)).toBe(false)
+                expect(isStringOptions(new RegExp('test'))).toBe(false)
+            })
+
+            it('should return false for Asymmetric Matchers', () => {
+                const mockAsymmetricMatcher = {
+                    asymmetricMatch: vi.fn(),
+                    toString: vi.fn()
+                }
+                expect(isStringOptions(mockAsymmetricMatcher)).toBe(false)
+            })
+
+            it('should return false for plain objects with all unrelated custom properties', () => {
+                expect(isStringOptions({ customKey: 'not-an-option' })).toBe(false)
+                expect(isStringOptions({ id: 'element-id', class: 'btn' })).toBe(false)
+            })
+
+            it('should return false for arrays and other object-type built-ins', () => {
+                expect(isStringOptions(['trim', 'ignoreCase'])).toBe(false)
+                expect(isStringOptions(new Date())).toBe(false)
+            })
+
+            it('should return false for objects containing valid options mixed with invalid/unrecognized keys', () => {
+                expect(isStringOptions({ trim: true, invalidProperty: 'malicious-or-typo' })).toBe(false)
+                expect(isStringOptions({ wait: 2000, href: '/path/to/element' })).toBe(false)
+                expect(isStringOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
+            })
         })
 
-        it('should return false for plain objects with all unrelated custom properties', () => {
-            expect(isStringOptions({ customKey: 'not-an-option' })).toBe(false)
-            expect(isStringOptions({ id: 'element-id', class: 'btn' })).toBe(false)
-        })
-
-        it('should return false for arrays and other object-type built-ins', () => {
-            expect(isStringOptions(['trim', 'ignoreCase'])).toBe(false)
-            expect(isStringOptions(new Date())).toBe(false)
-        })
-
-        it('should return false for objects containing valid options mixed with invalid/unrecognized keys', () => {
-            expect(isStringOptions({ trim: true, invalidProperty: 'malicious-or-typo' })).toBe(false)
-            expect(isStringOptions({ wait: 2000, href: '/path/to/element' })).toBe(false)
-            expect(isStringOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
-        })
-    })
-
-    describe('Interface Exhaustiveness Guard', () => {
-        it('should compile successfully only if all interface keys are covered', () => {
-        // This object maps EVERY allowed key from your Set.
-        // We cast it strictly to require all optional keys from the combined types.
-            const typeCompletenessCheck: Required<
+        describe('Interface Exhaustiveness Guard', () => {
+            it('should compile successfully only if all interface keys are covered', () => {
+                // This object maps EVERY allowed key from your Set.
+                // We cast it strictly to require all optional keys from the combined types.
+                const typeCompletenessCheck: Required<
             ExpectWebdriverIO.StringOptions &
             ExpectWebdriverIO.CommandOptions &
             ExpectWebdriverIO.DefaultOptions
-            > = {
-            // StringOptions
-                ignoreCase: true,
-                trim: true,
-                containing: true,
-                atStart: true,
-                atEnd: true,
-                atIndex: 1,
-                replace: ['searchPattern', 'replacementValue'],
-                asString: true,
+                > = {
+                    // StringOptions
+                    ignoreCase: true,
+                    trim: true,
+                    containing: true,
+                    atStart: true,
+                    atEnd: true,
+                    atIndex: 1,
+                    replace: ['searchPattern', 'replacementValue'],
+                    asString: true,
 
-                // CommandOptions
-                message: '',
+                    // CommandOptions
+                    message: '',
 
-                // DefaultOptions
-                wait: 0,
-                interval: 0,
-                beforeAssertion: async () => {},
-                afterAssertion: async () => {}
-            }
+                    // DefaultOptions
+                    wait: 0,
+                    interval: 0,
+                    beforeAssertion: async () => {},
+                    afterAssertion: async () => {}
+                }
 
-            // Run the runtime check against the fully-populated type asset
-            expect(isStringOptions(typeCompletenessCheck)).toBe(true)
+                // Run the runtime check against the fully-populated type asset
+                expect(isStringOptions(typeCompletenessCheck)).toBe(true)
+            })
+        })
+    })
+
+    describe('isStrictlyCommandOptions Type Guard', () => {
+
+        // 1. Testing Requirement: Empty Objects
+        describe('Empty Objects', () => {
+            it('should return true for a completely empty object literal', () => {
+                expect(isStrictlyCommandOptions({})).toBe(true)
+            })
+        })
+
+        // 2. Testing Requirement: CommandOptions & DefaultOptions Properties
+        describe('CommandOptions & DefaultOptions Properties', () => {
+            it('should return true for objects containing valid base command options', () => {
+                expect(isStrictlyCommandOptions({ message: 'Custom Error Message' })).toBe(true)
+                expect(isStrictlyCommandOptions({ wait: 5000 })).toBe(true)
+                expect(isStrictlyCommandOptions({ interval: 200 })).toBe(true)
+                expect(isStrictlyCommandOptions({ beforeAssertion: async () => { } })).toBe(true)
+                expect(isStrictlyCommandOptions({ afterAssertion: async () => { } })).toBe(true)
+            })
+
+            it('should return true for a fully valid mixed base configuration object', () => {
+                const mixedOptions = {
+                    wait: 1000,
+                    message: 'Failed assertion',
+                    interval: 50
+                }
+                expect(isStrictlyCommandOptions(mixedOptions)).toBe(true)
+            })
+        })
+
+        // 3. Testing Requirement: Invalid Configurations & False Positives
+        describe('Invalid Configurations & False Positives', () => {
+            it('should return false for primitive types and null', () => {
+                expect(isStrictlyCommandOptions('some-string-value')).toBe(false)
+                expect(isStrictlyCommandOptions(123)).toBe(false)
+                expect(isStrictlyCommandOptions(true)).toBe(false)
+                expect(isStrictlyCommandOptions(null)).toBe(false)
+                expect(isStrictlyCommandOptions(undefined)).toBe(false)
+            })
+
+            it('should return false for RegExp instances', () => {
+                expect(isStrictlyCommandOptions(/test-regex/i)).toBe(false)
+                expect(isStrictlyCommandOptions(new RegExp('test'))).toBe(false)
+            })
+
+            it('should return false for Asymmetric Matchers', () => {
+                const mockAsymmetricMatcher = {
+                    asymmetricMatch: vi.fn(),
+                    toString: vi.fn()
+                }
+                expect(isStrictlyCommandOptions(mockAsymmetricMatcher)).toBe(false)
+            })
+
+            it('should return false for plain objects with unrelated custom properties', () => {
+                expect(isStrictlyCommandOptions({ customKey: 'not-an-option' })).toBe(false)
+                expect(isStrictlyCommandOptions({ id: 'element-id', class: 'btn' })).toBe(false)
+            })
+
+            it('should return false for arrays and other object-type built-ins', () => {
+                expect(isStrictlyCommandOptions(['wait', 'message'])).toBe(false)
+                expect(isStrictlyCommandOptions(new Date())).toBe(false)
+            })
+
+            it('should return false for extended options (like StringOptions keys)', () => {
+            // String-specific options should fail a strict command-only option check
+                expect(isStrictlyCommandOptions({ trim: true })).toBe(false)
+                expect(isStrictlyCommandOptions({ ignoreCase: false })).toBe(false)
+                expect(isStrictlyCommandOptions({ wait: 2000, trim: true })).toBe(false)
+            })
+
+            it('should return false for objects containing valid options mixed with unrecognized keys', () => {
+                expect(isStrictlyCommandOptions({ wait: 2000, invalidProperty: 'malicious-or-typo' })).toBe(false)
+                expect(isStrictlyCommandOptions({ message: 'error', href: '/path' })).toBe(false)
+                expect(isStrictlyCommandOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
+            })
+        })
+
+        // 4. Exhaustiveness Guard to catch additions/deletions at compile time
+        describe('Interface Exhaustiveness Guard', () => {
+            it('should compile successfully only if all interface keys are covered', () => {
+            // This object maps EVERY allowed key from COMMAND_OPTIONS_ALLOWED_KEY_LIST.
+            // We cast it strictly to require all optional keys from the combined base types.
+                const typeCompletenessCheck: Required<
+                ExpectWebdriverIO.CommandOptions &
+                ExpectWebdriverIO.DefaultOptions
+                > = {
+                    // CommandOptions
+                    message: '',
+
+                    // DefaultOptions
+                    wait: 0,
+                    interval: 0,
+                    beforeAssertion: async () => {},
+                    afterAssertion: async () => {}
+                }
+
+                // Run the runtime check against the fully-populated type asset
+                expect(isStrictlyCommandOptions(typeCompletenessCheck)).toBe(true)
+            })
         })
     })
 })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -1,7 +1,7 @@
 import { test, describe, beforeEach, expect } from 'vitest'
 import { printDiffOrStringify } from 'jest-matcher-utils'
 
-import { enhanceError, enhanceErrorBe, numberError } from '../../src/util/formatMessage.js'
+import { enhanceError, enhanceErrorBe } from '../../src/util/formatMessage.js'
 
 describe('formatMessage', () => {
     describe(enhanceError, () => {
@@ -214,16 +214,6 @@ Expected [not]: "Expected Property Value"
 Received      : "Actual Property Value"`)
                 })
             })
-        })
-    })
-
-    describe(numberError, () => {
-        test('should return correct message', () => {
-            expect(numberError()).toBe('no params')
-            expect(numberError({ eq: 0 })).toBe(0)
-            expect(numberError({ gte: 1 })).toBe('>= 1')
-            expect(numberError({ lte: 1 })).toBe(' <= 1')
-            expect(numberError({ gte: 2, lte: 1 })).toBe('>= 2 && <= 1')
         })
     })
 

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -2,7 +2,8 @@ import { test, describe, expect } from 'vitest'
 import {
     isNumber,
     NumberMatcher,
-    numberMatcherTester
+    numberMatcherTester,
+    validateNumberAndExtractOptions
 } from '../../src/util/numberOptionsUtil.js'
 
 describe('numberOptionsUtil', () => {
@@ -32,8 +33,13 @@ describe('numberOptionsUtil', () => {
 
     describe(NumberMatcher, () => {
         describe('equals', () => {
-            test('returns false for undefined', () => {
+            test('returns false for undefined on exact matchers', () => {
                 const matcher = new NumberMatcher({ eq: 5 })
+                expect(matcher.match(undefined)).toBe(false)
+            })
+
+            test('returns false for undefined on range matchers', () => {
+                const matcher = new NumberMatcher({ gte: 5, lte: 10 })
                 expect(matcher.match(undefined)).toBe(false)
             })
 
@@ -107,6 +113,7 @@ describe('numberOptionsUtil', () => {
                     expect(matcher.match(0)).toBe(false)
                     expect(matcher.match(5)).toBe(false)
                     expect(matcher.match(100)).toBe(false)
+                    expect(matcher.match(undefined)).toBe(false)
                 })
             })
         })
@@ -147,62 +154,66 @@ describe('numberOptionsUtil', () => {
 
             test('returns string for range options', () => {
                 expect(new NumberMatcher({ gte: 5, lte: 10 }).toJSON()).toBe('>= 5 && <= 10')
+                expect(new NumberMatcher({ gte: 0, lte: 10 }).toJSON()).toBe('>= 0 && <= 10')
+                expect(new NumberMatcher({ gte: 10, lte: 0 }).toJSON()).toBe('>= 10 && <= 0')
+                expect(new NumberMatcher({ gte: 0, lte: 0 }).toJSON()).toBe('>= 0 && <= 0')
+                expect(new NumberMatcher({ gte: -10, lte: -1 }).toJSON()).toBe('>= -10 && <= -1')
                 expect(new NumberMatcher({ gte: 5 }).toJSON()).toBe('>= 5')
                 expect(new NumberMatcher({ lte: 10 }).toJSON()).toBe('<= 10')
-            })
-
-            test('serializes correctly with JSON.stringify', () => {
-                expect(JSON.stringify(new NumberMatcher({ eq: 5 }))).toBe('5')
-                expect(JSON.stringify(new NumberMatcher({ gte: 5, lte: 10 }))).toBe('">= 5 && <= 10"')
-                expect(JSON.stringify([new NumberMatcher({ eq: 1 }), new NumberMatcher({ eq: 2 })])).toBe('[1,2]')
             })
         })
     })
 
-    describe(numberMatcherTester, () => {
-        test('returns true when NumberMatcher matches number', () => {
-            const matcher = new NumberMatcher({ eq: 5 })
-
-            expect(numberMatcherTester(matcher, 5)).toBe(true)
-            expect(numberMatcherTester(5, matcher)).toBe(true)
+    describe('validateNumberOptions', () => {
+        test('successfully extracts number literal configurations', () => {
+            const result = validateNumberAndExtractOptions(5, { wait: 1000 })
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(5)).toBe(true)
+            expect(result.commandOptions).toEqual({ wait: 1000 })
         })
 
-        test('returns false when NumberMatcher does not match number', () => {
-            const matcher = new NumberMatcher({ eq: 5 })
-
-            expect(numberMatcherTester(matcher, 10)).toBe(false)
-            expect(numberMatcherTester(10, matcher)).toBe(false)
+        test('successfully extracts valid interface configurations and returns remaining command options', () => {
+            const result = validateNumberAndExtractOptions({ gte: 2, lte: 5, wait: 2000 })
+            expect(result.numberMatcher.match(3)).toBe(true)
+            expect(result.commandOptions).toEqual({ wait: 2000 })
         })
 
-        test('works with range matchers', () => {
-            const matcher = new NumberMatcher({ gte: 5, lte: 10 })
+        test('throws error for empty or entirely invalid options objects', () => {
+            expect(() => validateNumberAndExtractOptions(null as any)).toThrow(/Invalid NumberOptions/)
+            expect(() => validateNumberAndExtractOptions(undefined as any)).toThrow(/Invalid NumberOptions/)
+            expect(() => validateNumberAndExtractOptions({} as any)).toThrow(/Invalid NumberOptions/)
+            expect(() => validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toThrow(/Invalid NumberOptions/)
+        })
 
-            expect(numberMatcherTester(matcher, 7)).toBe(true)
-            expect(numberMatcherTester(7, matcher)).toBe(true)
-            expect(numberMatcherTester(matcher, 3)).toBe(false)
+        test('throws error when gte option is greater than lte option', () => {
+            expect(() => validateNumberAndExtractOptions({ gte: 10, lte: 5 })).toThrow(
+                "Invalid NumberOptions range: 'gte' (10) cannot be greater than 'lte' (5)."
+            )
+        })
+
+        test('does not throw when gte equals lte', () => {
+            expect(() => validateNumberAndExtractOptions({ gte: 5, lte: 5 })).not.toThrow()
+            const result = validateNumberAndExtractOptions({ gte: 5, lte: 5 })
+            expect(result.numberMatcher.match(5)).toBe(true)
+        })
+    })
+
+    describe('numberMatcherTester', () => {
+        test('returns true/false when argument A is a NumberMatcher and argument B is a valid number', () => {
+            const matcher = new NumberMatcher({ eq: 10 })
+            expect(numberMatcherTester(matcher, 10)).toBe(true)
+            expect(numberMatcherTester(matcher, 5)).toBe(false)
+        })
+
+        test('returns true/false symmetrically when argument B is a NumberMatcher and argument A is a valid number', () => {
+            const matcher = new NumberMatcher({ gte: 5 })
+            expect(numberMatcherTester(10, matcher)).toBe(true)
             expect(numberMatcherTester(3, matcher)).toBe(false)
         })
 
-        test('returns undefined for non-NumberMatcher comparisons', () => {
-            expect(numberMatcherTester(5, 5)).toBeUndefined()
-            expect(numberMatcherTester('5', 5)).toBeUndefined()
-            expect(numberMatcherTester({}, 5)).toBeUndefined()
-            expect(numberMatcherTester(null, 5)).toBeUndefined()
-        })
-
-        test('returns undefined when both are NumberMatchers', () => {
-            const matcher1 = new NumberMatcher({ eq: 5 })
-            const matcher2 = new NumberMatcher({ eq: 5 })
-
-            expect(numberMatcherTester(matcher1, matcher2)).toBeUndefined()
-        })
-
-        test('returns undefined when neither is a number', () => {
-            const matcher = new NumberMatcher({ eq: 5 })
-
-            expect(numberMatcherTester(matcher, '5')).toBeUndefined()
-            expect(numberMatcherTester(matcher, null)).toBeUndefined()
-            expect(numberMatcherTester(matcher, undefined)).toBeUndefined()
+        test('returns undefined when neither argument is a NumberMatcher instance', () => {
+            expect(numberMatcherTester(5, 10)).toBeUndefined()
+            expect(numberMatcherTester('string', {})).toBeUndefined()
         })
     })
 })

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -18,7 +18,7 @@ describe('numberOptionsUtil', () => {
             expect(isNumber(Number.MIN_VALUE)).toBe(true)
             expect(isNumber(Infinity)).toBe(true)
             expect(isNumber(-Infinity)).toBe(true)
-            expect(isNumber(NaN)).toBe(true)
+            expect(isNumber(NaN)).toBe(false)
         })
 
         test('returns false for non-numbers', () => {

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -1,0 +1,208 @@
+import { test, describe, expect } from 'vitest'
+import {
+    isNumber,
+    NumberMatcher,
+    numberMatcherTester
+} from '../../src/util/numberOptionsUtil.js'
+
+describe('numberOptionsUtil', () => {
+    describe(isNumber, () => {
+        test('returns true for numbers', () => {
+            expect(isNumber(0)).toBe(true)
+            expect(isNumber(1)).toBe(true)
+            expect(isNumber(-1)).toBe(true)
+            expect(isNumber(3.14)).toBe(true)
+            expect(isNumber(Number.MAX_VALUE)).toBe(true)
+            expect(isNumber(Number.MIN_VALUE)).toBe(true)
+            expect(isNumber(Infinity)).toBe(true)
+            expect(isNumber(-Infinity)).toBe(true)
+            expect(isNumber(NaN)).toBe(true)
+        })
+
+        test('returns false for non-numbers', () => {
+            expect(isNumber('5')).toBe(false)
+            expect(isNumber(null)).toBe(false)
+            expect(isNumber(undefined)).toBe(false)
+            expect(isNumber(true)).toBe(false)
+            expect(isNumber({})).toBe(false)
+            expect(isNumber([])).toBe(false)
+            expect(isNumber(() => {})).toBe(false)
+        })
+    })
+
+    describe(NumberMatcher, () => {
+        describe('equals', () => {
+            test('returns false for undefined', () => {
+                const matcher = new NumberMatcher({ eq: 5 })
+                expect(matcher.match(undefined)).toBe(false)
+            })
+
+            describe('with eq option', () => {
+                test('returns true for exact match', () => {
+                    const matcher = new NumberMatcher({ eq: 5 })
+                    expect(matcher.match(5)).toBe(true)
+                })
+
+                test('returns false for non-match', () => {
+                    const matcher = new NumberMatcher({ eq: 5 })
+                    expect(matcher.match(4)).toBe(false)
+                    expect(matcher.match(6)).toBe(false)
+                })
+
+                test('works with 0', () => {
+                    const matcher = new NumberMatcher({ eq: 0 })
+                    expect(matcher.match(0)).toBe(true)
+                    expect(matcher.match(1)).toBe(false)
+                })
+            })
+
+            describe('with gte option', () => {
+                test('returns true for values greater than or equal', () => {
+                    const matcher = new NumberMatcher({ gte: 5 })
+                    expect(matcher.match(5)).toBe(true)
+                    expect(matcher.match(6)).toBe(true)
+                    expect(matcher.match(100)).toBe(true)
+                })
+
+                test('returns false for values less than', () => {
+                    const matcher = new NumberMatcher({ gte: 5 })
+                    expect(matcher.match(4)).toBe(false)
+                    expect(matcher.match(0)).toBe(false)
+                })
+            })
+
+            describe('with lte option', () => {
+                test('returns true for values less than or equal', () => {
+                    const matcher = new NumberMatcher({ lte: 10 })
+                    expect(matcher.match(10)).toBe(true)
+                    expect(matcher.match(9)).toBe(true)
+                    expect(matcher.match(0)).toBe(true)
+                })
+
+                test('returns false for values greater than', () => {
+                    const matcher = new NumberMatcher({ lte: 10 })
+                    expect(matcher.match(11)).toBe(false)
+                    expect(matcher.match(100)).toBe(false)
+                })
+            })
+
+            describe('with gte and lte options', () => {
+                test('returns true for values in range', () => {
+                    const matcher = new NumberMatcher({ gte: 5, lte: 10 })
+                    expect(matcher.match(5)).toBe(true)
+                    expect(matcher.match(7)).toBe(true)
+                    expect(matcher.match(10)).toBe(true)
+                })
+
+                test('returns false for values outside range', () => {
+                    const matcher = new NumberMatcher({ gte: 5, lte: 10 })
+                    expect(matcher.match(4)).toBe(false)
+                    expect(matcher.match(11)).toBe(false)
+                })
+            })
+
+            describe('with no options', () => {
+                test('returns false for any value', () => {
+                    const matcher = new NumberMatcher({})
+                    expect(matcher.match(0)).toBe(false)
+                    expect(matcher.match(5)).toBe(false)
+                    expect(matcher.match(100)).toBe(false)
+                })
+            })
+        })
+
+        describe('toString', () => {
+            test('returns string number for eq option', () => {
+                expect(new NumberMatcher({ eq: 5 }).toString()).toBe('5')
+                expect(new NumberMatcher({ eq: 0 }).toString()).toBe('0')
+                expect(new NumberMatcher({ eq: -10 }).toString()).toBe('-10')
+            })
+
+            test('returns range string for gte and lte options', () => {
+                expect(new NumberMatcher({ gte: 5, lte: 10 }).toString()).toBe('>= 5 && <= 10')
+                expect(new NumberMatcher({ gte: 0, lte: 100 }).toString()).toBe('>= 0 && <= 100')
+            })
+
+            test('returns gte string for gte option only', () => {
+                expect(new NumberMatcher({ gte: 5 }).toString()).toBe('>= 5')
+                expect(new NumberMatcher({ gte: 0 }).toString()).toBe('>= 0')
+            })
+
+            test('returns lte string for lte option only', () => {
+                expect(new NumberMatcher({ lte: 10 }).toString()).toBe('<= 10')
+                expect(new NumberMatcher({ lte: 0 }).toString()).toBe('<= 0')
+            })
+
+            test('returns error message for invalid options', () => {
+                expect(new NumberMatcher({}).toString()).toBe('Incorrect number options provided')
+            })
+        })
+
+        describe('toJSON', () => {
+            test('returns number for eq option', () => {
+                expect(new NumberMatcher({ eq: 5 }).toJSON()).toBe(5)
+                expect(new NumberMatcher({ eq: 0 }).toJSON()).toBe(0)
+                expect(new NumberMatcher({ eq: -10 }).toJSON()).toBe(-10)
+            })
+
+            test('returns string for range options', () => {
+                expect(new NumberMatcher({ gte: 5, lte: 10 }).toJSON()).toBe('>= 5 && <= 10')
+                expect(new NumberMatcher({ gte: 5 }).toJSON()).toBe('>= 5')
+                expect(new NumberMatcher({ lte: 10 }).toJSON()).toBe('<= 10')
+            })
+
+            test('serializes correctly with JSON.stringify', () => {
+                expect(JSON.stringify(new NumberMatcher({ eq: 5 }))).toBe('5')
+                expect(JSON.stringify(new NumberMatcher({ gte: 5, lte: 10 }))).toBe('">= 5 && <= 10"')
+                expect(JSON.stringify([new NumberMatcher({ eq: 1 }), new NumberMatcher({ eq: 2 })])).toBe('[1,2]')
+            })
+        })
+    })
+
+    describe(numberMatcherTester, () => {
+        test('returns true when NumberMatcher matches number', () => {
+            const matcher = new NumberMatcher({ eq: 5 })
+
+            expect(numberMatcherTester(matcher, 5)).toBe(true)
+            expect(numberMatcherTester(5, matcher)).toBe(true)
+        })
+
+        test('returns false when NumberMatcher does not match number', () => {
+            const matcher = new NumberMatcher({ eq: 5 })
+
+            expect(numberMatcherTester(matcher, 10)).toBe(false)
+            expect(numberMatcherTester(10, matcher)).toBe(false)
+        })
+
+        test('works with range matchers', () => {
+            const matcher = new NumberMatcher({ gte: 5, lte: 10 })
+
+            expect(numberMatcherTester(matcher, 7)).toBe(true)
+            expect(numberMatcherTester(7, matcher)).toBe(true)
+            expect(numberMatcherTester(matcher, 3)).toBe(false)
+            expect(numberMatcherTester(3, matcher)).toBe(false)
+        })
+
+        test('returns undefined for non-NumberMatcher comparisons', () => {
+            expect(numberMatcherTester(5, 5)).toBeUndefined()
+            expect(numberMatcherTester('5', 5)).toBeUndefined()
+            expect(numberMatcherTester({}, 5)).toBeUndefined()
+            expect(numberMatcherTester(null, 5)).toBeUndefined()
+        })
+
+        test('returns undefined when both are NumberMatchers', () => {
+            const matcher1 = new NumberMatcher({ eq: 5 })
+            const matcher2 = new NumberMatcher({ eq: 5 })
+
+            expect(numberMatcherTester(matcher1, matcher2)).toBeUndefined()
+        })
+
+        test('returns undefined when neither is a number', () => {
+            const matcher = new NumberMatcher({ eq: 5 })
+
+            expect(numberMatcherTester(matcher, '5')).toBeUndefined()
+            expect(numberMatcherTester(matcher, null)).toBeUndefined()
+            expect(numberMatcherTester(matcher, undefined)).toBeUndefined()
+        })
+    })
+})

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -5,6 +5,7 @@ import {
     numberMatcherTester,
     validateNumberAndExtractOptions
 } from '../../src/util/numberOptionsUtil.js'
+import { DEFAULT_OPTIONS } from '../../src/constants.js'
 
 describe('numberOptionsUtil', () => {
     describe(isNumber, () => {
@@ -248,6 +249,14 @@ describe('numberOptionsUtil', () => {
             expect(result.numberMatcher.match(1)).toBe(true)
             expect(result.numberMatcher.match(2)).toBe(true)
             expect(result.numberMatcher.match(0)).toBe(false)
+        })
+
+        test('merge with DEFAULT_OPTIONS and  prioritizes number options over command options', () => {
+            const result = validateNumberAndExtractOptions( { gte: 5, wait: 0 },  DEFAULT_OPTIONS)
+
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(5)).toBe(true)
+            expect(result.commandOptions).toEqual({ wait: 0, interval: 100, afterAssertion : DEFAULT_OPTIONS.afterAssertion, beforeAssertion: DEFAULT_OPTIONS.beforeAssertion })
         })
     })
 

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -164,12 +164,33 @@ describe('numberOptionsUtil', () => {
         })
     })
 
-    describe('validateNumberOptions', () => {
+    describe(validateNumberAndExtractOptions, () => {
         test('successfully extracts number literal configurations', () => {
             const result = validateNumberAndExtractOptions(5, { wait: 1000 })
             expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
             expect(result.numberMatcher.match(5)).toBe(true)
             expect(result.commandOptions).toEqual({ wait: 1000 })
+        })
+
+        test('successfully extracts number literal 0', () => {
+            const result = validateNumberAndExtractOptions(0)
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(0)).toBe(true)
+            expect(result.commandOptions).toEqual({})
+        })
+
+        test('successfully extracts number literal as gte', () => {
+            const result = validateNumberAndExtractOptions({ gte: 0 })
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(0)).toBe(true)
+            expect(result.commandOptions).toEqual({})
+        })
+
+        test('successfully extracts number literal as lte', () => {
+            const result = validateNumberAndExtractOptions({ lte: 0 })
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(0)).toBe(true)
+            expect(result.commandOptions).toEqual({})
         })
 
         test('successfully extracts valid interface configurations and returns remaining command options', () => {
@@ -178,11 +199,29 @@ describe('numberOptionsUtil', () => {
             expect(result.commandOptions).toEqual({ wait: 2000 })
         })
 
+        test('support deprecated cases from NumberOptions', () => {
+            // TODO dprevost to review
+            expect(validateNumberAndExtractOptions({})).toEqual({
+                numberMatcher: new NumberMatcher({}),
+                commandOptions: {}
+            })
+            expect(validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toEqual({
+                numberMatcher: new NumberMatcher({}),
+                commandOptions: { invalidKey: 10 }
+            })
+            expect(validateNumberAndExtractOptions({ wait: 10 })).toEqual({
+                numberMatcher: new NumberMatcher({}),
+                commandOptions: { wait: 10 }
+            })
+        })
+
         test('throws error for empty or entirely invalid options objects', () => {
             expect(() => validateNumberAndExtractOptions(null as any)).toThrow(/Invalid NumberMatcher/)
             expect(() => validateNumberAndExtractOptions(undefined as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({} as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ gte: '5' } as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ lte: '5' } as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ eq: '5' } as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ gte: '5', lte: 10 } as any)).toThrow(/Invalid NumberMatcher/)
         })
 
         test('throws error when gte option is greater than lte option', () => {

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -187,7 +187,7 @@ describe('numberOptionsUtil', () => {
 
         test('throws error when gte option is greater than lte option', () => {
             expect(() => validateNumberAndExtractOptions({ gte: 10, lte: 5 })).toThrow(
-                "Invalid NumberOptions range: 'gte' (10) cannot be greater than 'lte' (5)."
+                "Invalid NumberMatcher range: 'gte' (10) cannot be greater than 'lte' (5)."
             )
         })
 

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -179,10 +179,10 @@ describe('numberOptionsUtil', () => {
         })
 
         test('throws error for empty or entirely invalid options objects', () => {
-            expect(() => validateNumberAndExtractOptions(null as any)).toThrow(/Invalid NumberOptions/)
-            expect(() => validateNumberAndExtractOptions(undefined as any)).toThrow(/Invalid NumberOptions/)
-            expect(() => validateNumberAndExtractOptions({} as any)).toThrow(/Invalid NumberOptions/)
-            expect(() => validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toThrow(/Invalid NumberOptions/)
+            expect(() => validateNumberAndExtractOptions(null as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions(undefined as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({} as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toThrow(/Invalid NumberMatcher/)
         })
 
         test('throws error when gte option is greater than lte option', () => {

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -196,6 +196,20 @@ describe('numberOptionsUtil', () => {
             const result = validateNumberAndExtractOptions({ gte: 5, lte: 5 })
             expect(result.numberMatcher.match(5)).toBe(true)
         })
+
+        test('return default gte 1 when undefined is passed and supportUndefinedAsGteThen1 is true', () => {
+            const result = validateNumberAndExtractOptions(undefined, {}, true)
+            expect(result.numberMatcher.match(1)).toBe(true)
+            expect(result.numberMatcher.match(2)).toBe(true)
+            expect(result.numberMatcher.match(0)).toBe(false)
+        })
+
+        test('return default gte 1 when {} is passed and supportUndefinedAsGteThen1 is true', () => {
+            const result = validateNumberAndExtractOptions({}, {}, true)
+            expect(result.numberMatcher.match(1)).toBe(true)
+            expect(result.numberMatcher.match(2)).toBe(true)
+            expect(result.numberMatcher.match(0)).toBe(false)
+        })
     })
 
     describe('numberMatcherTester', () => {

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect } from 'vitest'
+import { test, describe, expect, vi } from 'vitest'
 import {
     isNumber,
     NumberMatcher,
@@ -174,89 +174,119 @@ describe('numberOptionsUtil', () => {
         })
 
         test('successfully extracts number literal 0', () => {
-            const result = validateNumberAndExtractOptions(0)
+            const result = validateNumberAndExtractOptions(0, DEFAULT_OPTIONS)
             expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
             expect(result.numberMatcher.match(0)).toBe(true)
-            expect(result.commandOptions).toEqual({})
+            expect(result.commandOptions).toEqual(DEFAULT_OPTIONS)
         })
 
         test('successfully extracts number literal as gte', () => {
-            const result = validateNumberAndExtractOptions({ gte: 0 })
+            const result = validateNumberAndExtractOptions({ gte: 0 }, DEFAULT_OPTIONS)
             expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
             expect(result.numberMatcher.match(0)).toBe(true)
-            expect(result.commandOptions).toEqual({})
+            expect(result.commandOptions).toEqual(DEFAULT_OPTIONS)
         })
 
         test('successfully extracts number literal as lte', () => {
-            const result = validateNumberAndExtractOptions({ lte: 0 })
+            const result = validateNumberAndExtractOptions({ lte: 0 }, DEFAULT_OPTIONS)
             expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
             expect(result.numberMatcher.match(0)).toBe(true)
-            expect(result.commandOptions).toEqual({})
+            expect(result.commandOptions).toEqual(DEFAULT_OPTIONS)
         })
 
         test('successfully extracts valid interface configurations and returns remaining command options', () => {
-            const result = validateNumberAndExtractOptions({ gte: 2, lte: 5, wait: 2000 })
+            const result = validateNumberAndExtractOptions({ gte: 2, lte: 5, wait: 2000 }, DEFAULT_OPTIONS)
             expect(result.numberMatcher.match(3)).toBe(true)
-            expect(result.commandOptions).toEqual({ wait: 2000 })
+            expect(result.commandOptions).toEqual({ wait: 2000, interval: 100, afterAssertion : DEFAULT_OPTIONS.afterAssertion, beforeAssertion: DEFAULT_OPTIONS.beforeAssertion })
         })
 
         test('support deprecated cases from NumberOptions', () => {
             // TODO dprevost to review
-            expect(validateNumberAndExtractOptions({})).toEqual({
+            expect(validateNumberAndExtractOptions({}, DEFAULT_OPTIONS)).toEqual({
                 numberMatcher: new NumberMatcher({}),
-                commandOptions: {}
+                commandOptions: DEFAULT_OPTIONS
             })
-            expect(validateNumberAndExtractOptions({ invalidKey: 10 } as any)).toEqual({
+            expect(validateNumberAndExtractOptions({ invalidKey: 10 } as any, DEFAULT_OPTIONS)).toEqual({
                 numberMatcher: new NumberMatcher({}),
-                commandOptions: { invalidKey: 10 }
+                commandOptions: { ...DEFAULT_OPTIONS, invalidKey: 10 }
             })
-            expect(validateNumberAndExtractOptions({ wait: 10 })).toEqual({
+            expect(validateNumberAndExtractOptions({ wait: 10 }, DEFAULT_OPTIONS)).toEqual({
                 numberMatcher: new NumberMatcher({}),
-                commandOptions: { wait: 10 }
+                commandOptions: { ...DEFAULT_OPTIONS, wait: 10 }
             })
         })
 
         test('throws error for empty or entirely invalid options objects', () => {
-            expect(() => validateNumberAndExtractOptions(null as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions(undefined as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({ gte: '5' } as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({ lte: '5' } as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({ eq: '5' } as any)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions({ gte: '5', lte: 10 } as any)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions(null as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions(undefined as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ gte: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ lte: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ eq: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({ gte: '5', lte: 10 } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
         })
 
         test('throws error when gte option is greater than lte option', () => {
-            expect(() => validateNumberAndExtractOptions({ gte: 10, lte: 5 })).toThrow(
+            expect(() => validateNumberAndExtractOptions({ gte: 10, lte: 5 }, DEFAULT_OPTIONS)).toThrow(
                 "Invalid NumberMatcher range: 'gte' (10) cannot be greater than 'lte' (5)."
             )
         })
 
         test('does not throw when gte equals lte', () => {
-            expect(() => validateNumberAndExtractOptions({ gte: 5, lte: 5 })).not.toThrow()
-            const result = validateNumberAndExtractOptions({ gte: 5, lte: 5 })
+            expect(() => validateNumberAndExtractOptions({ gte: 5, lte: 5 }, DEFAULT_OPTIONS)).not.toThrow()
+            const result = validateNumberAndExtractOptions({ gte: 5, lte: 5 }, DEFAULT_OPTIONS)
             expect(result.numberMatcher.match(5)).toBe(true)
         })
 
         test('return default gte 1 when undefined is passed and supportUndefinedAsGteThen1 is true', () => {
-            const result = validateNumberAndExtractOptions(undefined, {}, true)
+            const result = validateNumberAndExtractOptions(undefined, {}, { supportDefaultAsGteThen1: true })
             expect(result.numberMatcher.match(1)).toBe(true)
             expect(result.numberMatcher.match(2)).toBe(true)
             expect(result.numberMatcher.match(0)).toBe(false)
         })
 
         test('return default gte 1 when {} is passed and supportUndefinedAsGteThen1 is true', () => {
-            const result = validateNumberAndExtractOptions({}, {}, true)
+            const result = validateNumberAndExtractOptions({}, {},  { supportDefaultAsGteThen1: true })
             expect(result.numberMatcher.match(1)).toBe(true)
             expect(result.numberMatcher.match(2)).toBe(true)
             expect(result.numberMatcher.match(0)).toBe(false)
         })
 
-        test('merge with DEFAULT_OPTIONS and  prioritizes number options over command options', () => {
+        test('merge with DEFAULT_OPTIONS and prioritizes number options over command options - wait only', () => {
             const result = validateNumberAndExtractOptions( { gte: 5, wait: 0 },  DEFAULT_OPTIONS)
 
             expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
             expect(result.numberMatcher.match(5)).toBe(true)
             expect(result.commandOptions).toEqual({ wait: 0, interval: 100, afterAssertion : DEFAULT_OPTIONS.afterAssertion, beforeAssertion: DEFAULT_OPTIONS.beforeAssertion })
+        })
+
+        test('merge with DEFAULT_OPTIONS and prioritizes number options over command options - before/after assertions options', () => {
+            const beforeAssertion = vi.fn().mockReturnValue(1)
+            const afterAssertion = vi.fn().mockReturnValue(2)
+            const result = validateNumberAndExtractOptions( { gte: 5, wait: 0, beforeAssertion, afterAssertion },  DEFAULT_OPTIONS)
+
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(5)).toBe(true)
+            expect(result.commandOptions).toEqual({ wait: 0, interval: 100, afterAssertion, beforeAssertion })
+
+            expect(result.commandOptions?.beforeAssertion?.({} as any)).toBe(1)
+            expect(result.commandOptions?.afterAssertion?.({} as any)).toBe(2)
+            expect(beforeAssertion).toHaveBeenCalledTimes(1)
+            expect(afterAssertion).toHaveBeenCalledTimes(1)
+        })
+
+        test('merge with DEFAULT_OPTIONS and prioritizes number options over command options - useDefault - before/after assertions options', () => {
+            const beforeAssertion = vi.fn().mockReturnValue(1)
+            const afterAssertion = vi.fn().mockReturnValue(2)
+            const result = validateNumberAndExtractOptions( { wait: 0, beforeAssertion, afterAssertion },  DEFAULT_OPTIONS, { supportDefaultAsGteThen1: true })
+
+            expect(result.numberMatcher).toBeInstanceOf(NumberMatcher)
+            expect(result.numberMatcher.match(1)).toBe(true)
+            expect(result.commandOptions).toEqual({ wait: 0, interval: 100, afterAssertion, beforeAssertion })
+
+            expect(result.commandOptions?.beforeAssertion?.({} as any)).toBe(1)
+            expect(result.commandOptions?.afterAssertion?.({} as any)).toBe(2)
+            expect(beforeAssertion).toHaveBeenCalledTimes(1)
+            expect(afterAssertion).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -200,25 +200,14 @@ describe('numberOptionsUtil', () => {
             expect(result.commandOptions).toEqual({ wait: 2000, interval: 100, afterAssertion : DEFAULT_OPTIONS.afterAssertion, beforeAssertion: DEFAULT_OPTIONS.beforeAssertion })
         })
 
-        test('support deprecated cases from NumberOptions', () => {
-            // TODO dprevost to review
-            expect(validateNumberAndExtractOptions({}, DEFAULT_OPTIONS)).toEqual({
-                numberMatcher: new NumberMatcher({}),
-                commandOptions: DEFAULT_OPTIONS
-            })
-            expect(validateNumberAndExtractOptions({ invalidKey: 10 } as any, DEFAULT_OPTIONS)).toEqual({
-                numberMatcher: new NumberMatcher({}),
-                commandOptions: { ...DEFAULT_OPTIONS, invalidKey: 10 }
-            })
-            expect(validateNumberAndExtractOptions({ wait: 10 }, DEFAULT_OPTIONS)).toEqual({
-                numberMatcher: new NumberMatcher({}),
-                commandOptions: { ...DEFAULT_OPTIONS, wait: 10 }
-            })
-        })
-
         test('throws error for empty or entirely invalid options objects', () => {
             expect(() => validateNumberAndExtractOptions(null as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
-            expect(() => validateNumberAndExtractOptions(undefined as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions({}, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions(undefined, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions( { invalidkey:'test' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+            expect(() => validateNumberAndExtractOptions( { wait: 0 } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
+
+            // Wrong types for eq, gte, lte
             expect(() => validateNumberAndExtractOptions({ gte: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
             expect(() => validateNumberAndExtractOptions({ lte: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)
             expect(() => validateNumberAndExtractOptions({ eq: '5' } as any, DEFAULT_OPTIONS)).toThrow(/Invalid NumberMatcher/)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest'
-import { compareNumbers, compareObject, compareText, compareTextWithArray, getAsymmetricMatcherValue, isAsymmetricMatcher, isInversedStringContainingMatcher, isStringContainingMatcherLike, waitUntil } from '../src/utils'
+import { compareObject, compareText, compareTextWithArray, getAsymmetricMatcherValue, isAsymmetricMatcher, isInversedStringContainingMatcher, isStringContainingMatcherLike, waitUntil } from '../src/utils'
 import { jasmine } from './__mocks__/jasmine'
 
 describe('utils', () => {
@@ -119,47 +119,6 @@ describe('utils', () => {
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), jasmine.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(true)
             expect(compareTextWithArray('foo', [jasmine.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).result).toBe(true)
-        })
-    })
-
-    describe('compareNumbers', () => {
-        test('should work when equal', () => {
-            const actual = 10
-            const eq = 10
-            expect(compareNumbers(actual, { eq })).toBe(true)
-        })
-
-        test('should pass when using gte and number is greater', () => {
-            const actual = 10
-            const gte = 5
-            expect(compareNumbers(actual, { gte })).toBe(true)
-        })
-
-        test('should pass when using lte and number is lower', () => {
-            const actual = 10
-            const lte = 20
-            expect(compareNumbers(actual, { lte })).toBe(true)
-        })
-
-        test('should pass when using lte and gte and number is in between', () => {
-            const actual = 10
-            const lte = 20
-            const gte = 1
-            expect(compareNumbers(actual, { lte, gte })).toBe(true)
-        })
-
-        test('should fail when using lte and gte and is lte but not gte', () => {
-            const actual = 10
-            const lte = 20
-            const gte = 15
-            expect(compareNumbers(actual, { lte, gte })).toBe(false)
-        })
-
-        test('should fail when using lte and gte and is gte but not lte', () => {
-            const actual = 10
-            const lte = 9
-            const gte = 1
-            expect(compareNumbers(actual, { lte, gte })).toBe(false)
         })
     })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -114,7 +114,7 @@ describe('utils', () => {
             expect(compareTextWithArray('foo', [jasmine.stringContaining('oobb'), jasmine.stringContaining('oo')], {}).result).toBe(true)
         })
 
-        test('should support asymmetric matchers and using ignoreCase', () => {
+        test('should support jasmine asymmetric matchers and using ignoreCase', () => {
             expect(compareTextWithArray(' FOO ', [jasmine.stringContaining('foo'), jasmine.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), jasmine.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(true)

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -358,14 +358,6 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     ) => Promise<void>>
 
     /**
-     * `WebdriverIO.Element` -> `getSize` value
-     */
-    toHaveSize: FnWhenElementOrArrayLike<ActualT, (
-        size: { height: number; width: number },
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
-
-    /**
      * `WebdriverIO.Element` -> `getText`
      * Element's text equals the text provided
      *
@@ -420,24 +412,37 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * `WebdriverIO.Element` -> `getSize('width')`
      * Element's width equals the width provided
      */
-    toHaveWidth: FnWhenElementOrArrayLike<ActualT, (width: number, options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+    toHaveWidth: FnWhenElementOrArrayLike<ActualT, (
+        width: number | ExpectWebdriverIO.NumberMatcher,
+        options?: ExpectWebdriverIO.CommandOptions
+    ) => Promise<void>
+    >
 
     /**
-     * `WebdriverIO.Element` -> `getSize('height')` or `getSize()`
-     * Checks if the element's height equals the given number, or its size equals the given object.
+     * `WebdriverIO.Element` -> `getSize('height')`
+     * Checks if the element's height equals the given number.
      *
-     * @param heightOrSize - Either a number (height) or an object with height and width.
+     * @param height - The expected height of the element.
      * @param options - Optional command options.
      *
      * **Usage Example:**
      * ```js
      * await expect(element).toHaveHeight(42)
-     * await expect(element).toHaveHeight({ height: 42, width: 42 })
      * ```
      */
     toHaveHeight: FnWhenElementOrArrayLike<ActualT, (
-        heightOrSize: number | { height: number; width: number },
+        height: number | ExpectWebdriverIO.NumberMatcher,
         options?: ExpectWebdriverIO.CommandOptions
+    ) => Promise<void>>
+
+    /**
+     * `WebdriverIO.Element` -> `getSize` value
+     * Element's size equals the size provided
+     * // TODO: add support for NumberMatcher on width and height
+     */
+    toHaveSize: FnWhenElementOrArrayLike<ActualT, (
+        size: { height: number; width: number },
+        options?: ExpectWebdriverIO.StringOptions
     ) => Promise<void>>
 
     /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -787,6 +787,7 @@ declare namespace ExpectWebdriverIO {
         asString?: boolean
     }
 
+    // TODO dprevost to deprecated
     interface NumberOptions extends CommandOptions {
         /**
          * equals
@@ -828,6 +829,22 @@ declare namespace ExpectWebdriverIO {
          */
 
         visibilityProperty?: boolean
+    }
+
+    interface NumberMatcher {
+        /**
+         * equals
+         */
+        eq?: number
+        /**
+         * less than or equals
+         */
+        lte?: number
+
+        /**
+         * greater than or equals
+         */
+        gte?: number
     }
 
     type RequestedWith = {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -317,7 +317,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         ): Promise<void>;
 
         /**
-         * When called with an expected child count or number options.
+         * When called with an expected child count or number matcher.
          */
         (
             expectedValue: number | ExpectWebdriverIO.NumberMatcher,

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -123,7 +123,7 @@ interface WdioNetworkMatchers<_R, ActualT> {
         ): Promise<void>
 
         /**
-        * @deprecated since 5.7.1, Use `NumberMatcher` & `CommandOptions` separately `toBeRequestedTimes(NumberMatcher, options)`.
+        * deprecated since 5.7.1, remove in v6.0.0. Use `NumberMatcher` & `CommandOptions` separately `toBeRequestedTimes(NumberMatcher, options)`.
         */
         (
             times: ExpectWebdriverIO.NumberOptions,
@@ -167,7 +167,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
 
     toHaveAttribute: FnWhenElementOrArrayLike<ActualT, {
         /**
-         * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveAttribute(attribute, options)`.
+         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveAttribute(attribute, options)`.
          */
         (
             attribute: string,
@@ -190,7 +190,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }>
 
     /**
-     * @deprecated since v5.7.1 Use `toHaveAttribute` instead.
+     * deprecated since v5.7.1 Use `toHaveAttribute` instead.
      * `WebdriverIO.Element` -> `getAttribute`
      */
     toHaveAttr: FnWhenElementOrArrayLike<ActualT, (
@@ -231,7 +231,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
 
     toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, {
         /**
-         * @deprecated since 5.7.1 Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
+         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
          */
         (
             property: string,
@@ -302,7 +302,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      */
     toHaveChildren: FnWhenElementOrArrayLike<ActualT, {
         /**
-         * @deprecated Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(options)`.
+         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(options)`.
          */
         (
             expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
@@ -325,7 +325,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         ): Promise<void>;
 
         /**
-         * @deprecated since 5.7.1, NumberOptions is no longer supported. Use `toHaveChildren(numberMatcher, options)` instead.
+         * deprecated since 5.7.1, remove in v6.0.0. NumberOptions is no longer supported. Use `toHaveChildren(numberMatcher, options)` instead.
          */
         (
             expectedValue: ExpectWebdriverIO.NumberOptions,
@@ -469,7 +469,7 @@ interface WdioElementArrayOnlyMatchers<_R, ActualT = unknown> {
         ): Promise<void> & Promise<WebdriverIO.ElementArray>,
 
         /**
-         * @deprecated since 5.7.0. Use `toBeElementsArrayOfSize` with number | NumberMatcher instead. This matcher will be removed in version 6.0.0.
+         * deprecated since 5.7.1, remove in v6.0.0. Use `toBeElementsArrayOfSize` with number | NumberMatcher instead. This matcher will be removed in version 6.0.0.
          */
         (
             size: ExpectWebdriverIO.NumberOptions,
@@ -836,7 +836,7 @@ declare namespace ExpectWebdriverIO {
     }
 
     /**
-     * @deprecated since 5.7.1, will remove in 6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
+     * deprecated since 5.7.1, remove in v6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
      * @see NumberMatcher
      * @see CommandOptions
      */

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -424,7 +424,7 @@ interface WdioElementArrayOnlyMatchers<_R, ActualT = unknown> {
          * @deprecated since 5.7.0. Use `toBeElementsArrayOfSize` with number | NumberMatcher instead. This matcher will be removed in version 6.0.0.
          */
         (
-            size: ExpectWebdriverIO.CommandOptions,
+            size: ExpectWebdriverIO.NumberOptions,
             options?: ExpectWebdriverIO.CommandOptions
         ): Promise<void> & Promise<WebdriverIO.ElementArray>,
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -414,10 +414,20 @@ interface WdioElementArrayOnlyMatchers<_R, ActualT = unknown> {
      * `WebdriverIO.ElementArray` -> `$$('...').length`
      * supports less / greater then or equals to be passed in options
      */
-    toBeElementsArrayOfSize: FnWhenElementArrayLike<ActualT, (
-        size: number | ExpectWebdriverIO.NumberOptions,
-        options?: ExpectWebdriverIO.NumberOptions
-    ) => Promise<void> & Promise<WebdriverIO.ElementArray>>
+    toBeElementsArrayOfSize: FnWhenElementArrayLike<ActualT, {
+        (
+            size: number | ExpectWebdriverIO.NumberMatcher,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void> & Promise<WebdriverIO.ElementArray>,
+
+        /**
+         * @deprecated since 5.7.0. Use `toBeElementsArrayOfSize` with number | NumberMatcher instead. This matcher will be removed in version 6.0.0.
+         */
+        (
+            size: ExpectWebdriverIO.CommandOptions,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void> & Promise<WebdriverIO.ElementArray>,
+    }>
 }
 
 /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -285,10 +285,38 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
      * `WebdriverIO.Element` -> `$$('./*').length`
      * supports less / greater then or equals to be passed in options
      */
-    toHaveChildren: FnWhenElementOrArrayLike<ActualT, (
-        size?: number | ExpectWebdriverIO.NumberOptions,
-        options?: ExpectWebdriverIO.NumberOptions
-    ) => Promise<void>>
+    toHaveChildren: FnWhenElementOrArrayLike<ActualT, {
+        /**
+         * @deprecated Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(options)`.
+         */
+        (
+            expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>;
+
+        /**
+         * When called with only configuration options (omitting the expected count) where default is gte 1.
+         */
+        (
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>;
+
+        /**
+         * When called with an expected child count or number options.
+         */
+        (
+            expectedValue: number | ExpectWebdriverIO.NumberMatcher,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>;
+
+        /**
+         * @deprecated since 5.7.1, NumberOptions is no longer supported. Use `toHaveChildren(numberMatcher, options)` instead.
+         */
+        (
+            expectedValue: ExpectWebdriverIO.NumberOptions,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>;
+    }>
 
     /**
      * `WebdriverIO.Element` -> `getAttribute` href

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -112,10 +112,25 @@ interface WdioNetworkMatchers<_R, ActualT> {
      * Check that `WebdriverIO.Mock` was called
      */
     toBeRequested: FnWhenMock<ActualT, (options?: ExpectWebdriverIO.CommandOptions) => Promise<void>>
+
     /**
      * Check that `WebdriverIO.Mock` was called N times
      */
-    toBeRequestedTimes: FnWhenMock<ActualT, (times: number | ExpectWebdriverIO.NumberOptions, options?: ExpectWebdriverIO.NumberOptions) => Promise<void>>
+    toBeRequestedTimes: FnWhenMock<ActualT, {
+        (
+            times: number | ExpectWebdriverIO.NumberMatcher,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>
+
+        /**
+        * @deprecated since 5.7.1, Use `NumberMatcher` & `CommandOptions` separately `toBeRequestedTimes(NumberMatcher, options)`.
+        */
+        (
+            times: ExpectWebdriverIO.NumberOptions,
+            options?: ExpectWebdriverIO.CommandOptions
+        ): Promise<void>;
+
+    }>
 
     /**
      * Check that `WebdriverIO.Mock` was called with the specific parameters
@@ -815,7 +830,11 @@ declare namespace ExpectWebdriverIO {
         asString?: boolean
     }
 
-    // TODO dprevost to deprecated
+    /**
+     * @deprecated since 5.7.1, will remove in 6.0.0. Use `NumberMatcher` & `CommandOptions` as seperate parameters instead.
+     * @see NumberMatcher
+     * @see CommandOptions
+     */
     interface NumberOptions extends CommandOptions {
         /**
          * equals


### PR DESCRIPTION
NumberOptions is ambiguous and is sometimes used for both expected value and options configuration.
By using a NumberMatcher, we can distinguish the expected value from the command configuration and ensure the last parameter is the options.

Moreover, with the new NumberMatcher class, the stringy and compare are centralized.

So instead of the ambiguous:
```ts
                expect(element).toHaveChildren(undefined)
                expect(element).toHaveChildren(undefined, { wait: 1000 })
                expect(element).toHaveChildren({ eq: 5, wait: 1000 }, { wait: 1000 })
```

We have the clear following API:
```ts
                expect(element).toHaveChildren()
                expect(element).toHaveChildren({ wait: 1000 })
                expect(element).toHaveChildren(5)
                expect(element).toHaveChildren(5, { wait: 1000 })
                expect(element).toHaveChildren({ eq: 5 })
                expect(element).toHaveChildren({ eq: 5 }, { wait: 1000 })
```

For the support of `$$`, this alignment clarifies the API where we can pass different `NumberMatcher` and 1 commandOptions
```ts
expect(elements).toHaveChildren([{ eq: 5 }, { lte: 2 }], { wait: 1000 })
```

Other affected matchers:
- `toHaveHeight`
- `toHavewidth`
- `toBeElementsArrayOfSize`
- `toBeRequestedTimes`

In the future, I would see this as an asymmetric matcher instead, but that would be too much of a breaking change for now!
