### PR TITLE
chore: refactor toHaveSize + tests as a preparation for $$ support

### DIFF
--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -7,8 +7,11 @@ import {
     waitUntil,
     wrapExpectedWithArray,
 } from '../../utils.js'
+import type { RectReturn } from '@wdio/protocols'
 
-async function condition(el: WebdriverIO.Element, size: { height: number; width: number }) {
+export type Size = Pick<RectReturn, 'width' | 'height'>
+
+async function condition(el: WebdriverIO.Element, size: Partial<Size>) {
     const actualSize = await el.getSize()
 
     return compareObject(actualSize, size)
@@ -16,32 +19,32 @@ async function condition(el: WebdriverIO.Element, size: { height: number; width:
 
 export async function toHaveSize(
     received: WdioElementMaybePromise,
-    expectedValue: { height: number; width: number },
+    expectedValue: Partial<Size>,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
-    const isNot = this.isNot
-    const { expectation = 'size', verb = 'have' } = this
+    const matcherName = 'toHaveSize'
+    const { expectation = 'size', verb = 'have', isNot } = this
 
     await options.beforeAssertion?.({
-        matcherName: 'toHaveSize',
+        matcherName,
         expectedValue,
         options,
     })
 
     let el = await received?.getElement()
-    let actualSize
+    let actualSize: Size | undefined
 
     const pass = await waitUntil(
         async () => {
             const result = await executeCommand.call(this, el, condition, options, [expectedValue, options])
 
             el = result.el as WebdriverIO.Element
-            actualSize = result.values
+            actualSize = result.values as Size
 
             return result.success
         },
         isNot,
-        options
+        { wait: options.wait, interval: options.interval }
     )
 
     const message = enhanceError(
@@ -61,7 +64,7 @@ export async function toHaveSize(
     }
 
     await options.afterAssertion?.({
-        matcherName: 'toHaveSize',
+        matcherName,
         expectedValue,
         options,
         result

--- a/test/matchers/element/toHaveSize.test.ts
+++ b/test/matchers/element/toHaveSize.test.ts
@@ -1,115 +1,144 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $ } from '@wdio/globals'
 
+import type { Size } from '../../../src/matchers/element/toHaveSize.js'
 import { toHaveSize } from '../../../src/matchers/element/toHaveSize.js'
+import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
-describe('toHaveSize', () => {
-    test('wait for success', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
-        const beforeAssertion = vi.fn()
-        const afterAssertion = vi.fn()
+describe(toHaveSize, async () => {
+    let thisContext: { toHaveSize: typeof toHaveSize }
+    let thisNotContext: { isNot: true; toHaveSize: typeof toHaveSize }
 
-        const result = await toHaveSize.call({}, el, { width: 32, height: 32 }, { beforeAssertion, afterAssertion })
+    const expectedValue: Size = { width: 32, height: 32 }
+    const wrongValue: Size = { width: 15, height: 32 }
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-        expect(beforeAssertion).toBeCalledWith({
-            matcherName: 'toHaveSize',
-            expectedValue: { width: 32, height: 32 },
-            options: { beforeAssertion, afterAssertion }
+    beforeEach(async () => {
+        thisContext =  { toHaveSize }
+        thisNotContext = { isNot: true, ...thisContext }
+    })
+
+    describe.for([
+        { element: await $('sel'), type: 'awaited ChainablePromiseElement' },
+        { element: await $('sel').getElement(), type: 'awaited getElement of ChainablePromiseElement (e.g. WebdriverIO.Element)' },
+        { element: $('sel'), type: 'non-awaited of ChainablePromiseElement' }
+    ])('given a single element when $type', ({ element }) => {
+        let el: ChainablePromiseElement | WebdriverIO.Element
+
+        beforeEach(() => {
+            el = element
+            vi.mocked(el.getSize).mockResolvedValue(expectedValue as unknown as Size & number) // vitest does not support overloads function well
         })
-        expect(afterAssertion).toBeCalledWith({
-            matcherName: 'toHaveSize',
-            expectedValue: { width: 32, height: 32 },
-            options: { beforeAssertion, afterAssertion },
-            result
+
+        test('wait for success', async () => {
+            const beforeAssertion = vi.fn()
+            const afterAssertion = vi.fn()
+
+            const result = await thisContext.toHaveSize(el, expectedValue, { beforeAssertion, afterAssertion, wait: 500 })
+
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+            expect(beforeAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveSize',
+                expectedValue: expectedValue,
+                options: { beforeAssertion, afterAssertion, wait: 500 }
+            })
+            expect(afterAssertion).toHaveBeenCalledWith({
+                matcherName: 'toHaveSize',
+                expectedValue: expectedValue,
+                options: { beforeAssertion, afterAssertion, wait: 500 },
+                result
+            })
         })
-    })
 
-    test('wait but failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockRejectedValue(new Error('some error'))
+        test('wait but error', async () => {
+            vi.mocked(el.getSize).mockRejectedValue(new Error('some error'))
 
-        await expect(() => toHaveSize.call({}, el, { width: 32, height: 32 }, {}))
-            .rejects.toThrow('some error')
-    })
+            await expect(() => thisContext.toHaveSize(el, expectedValue))
+                .rejects.toThrow('some error')
+        })
 
-    test('success on the first attempt', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
+        test('success by default', async () => {
+            const result = await thisContext.toHaveSize(el, expectedValue)
 
-        const result = await toHaveSize.call({}, el, { width: 32, height: 32 }, {})
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+        test('no wait - failure with proper error message', async () => {
+            vi.mocked(el.getSize).mockResolvedValue(wrongValue as unknown as Size & number)
 
-    test('no wait - failure', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
+            const result = await thisContext.toHaveSize(el, expectedValue, { wait: 0 })
 
-        const result = await toHaveSize.call({}, el, { width: 15, height: 32 }, { wait: 0 })
+            expect(result.pass).toBe(false)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have size
 
-        expect(result.pass).toBe(false)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+- Expected  - 1
++ Received  + 1
 
-    test('no wait - success', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
+  Object {
+    "height": 32,
+-   "width": 32,
++   "width": 15,
+  }`
+            )
+        })
 
-        const result = await toHaveSize.call({}, el, { width: 32, height: 32 }, { wait: 0 })
+        test('no wait - success', async () => {
+            const result = await thisContext.toHaveSize(el, expectedValue, { wait: 0 })
 
-        expect(result.pass).toBe(true)
-        expect(el.getSize).toHaveBeenCalledTimes(1)
-    })
+            expect(result.pass).toBe(true)
+            expect(el.getSize).toHaveBeenCalledTimes(1)
+        })
 
-    test('not - failure - pass should be true', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
-        const result = await toHaveSize.call({ isNot: true }, el, { width: 32, height: 32 }, { wait: 0 })
+        test('not - failure - pass should be true', async () => {
+            const result = await thisNotContext.toHaveSize(el, expectedValue)
 
-        expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+            expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have size
 
 Expected [not]: {"height": 32, "width": 32}
 Received      : {"height": 32, "width": 32}`
-        )
-    })
+            )
+        })
 
-    test("should return false if sizes don't match", async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
+        test('should fails with custom failure message', async () => {
+            vi.mocked(el.getSize).mockResolvedValue(wrongValue as unknown as Size & number)
 
-        const result = await toHaveSize.bind({})(el, { width: 15, height: 32 }, { wait: 1 })
+            const result = await thisContext.toHaveSize(el, expectedValue, { wait: 1, message: 'Custom error message' })
 
-        expect(result.pass).toBe(false)
-    })
-
-    test('should return true if sizes match', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue({ width: 32, height: 32 })
-
-        const result = await toHaveSize.bind({})(el, { width: 32, height: 32 }, { wait: 1 })
-
-        expect(result.pass).toBe(true)
-    })
-
-    test('message', async () => {
-        const el = await $('sel')
-        el.getSize = vi.fn().mockResolvedValue(null)
-
-        const result = await toHaveSize.call({}, el, { width: 32, height: 32 })
-
-        expect(result.pass).toBe(false)
-        expect(result.message()).toEqual(`\
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Custom error message
 Expect $(\`sel\`) to have size
 
-Expected: {"height": 32, "width": 32}
-Received: null`)
+- Expected  - 1
++ Received  + 1
+
+  Object {
+    "height": 32,
+-   "width": 32,
++   "width": 15,
+  }`
+            )
+        })
+
+        // TODO bring back with PR supporting $$
+        test.skip('should fails when expected is an unsupported array type', async () => {
+            const result = await thisContext.toHaveSize(el, [expectedValue] as any)
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have size
+
+Expected: [{"height": 32, "width": 32}]
+Received: "Expected value cannot be an array"`
+            )
+        })
+
     })
 })

--- a/test/matchers/element/toHaveSize.test.ts
+++ b/test/matchers/element/toHaveSize.test.ts
@@ -14,7 +14,7 @@ describe(toHaveSize, async () => {
     const expectedValue: Size = { width: 32, height: 32 }
     const wrongValue: Size = { width: 15, height: 32 }
 
-    beforeEach(async () => {
+    beforeEach(() => {
         thisContext =  { toHaveSize }
         thisNotContext = { isNot: true, ...thisContext }
     })
@@ -55,7 +55,7 @@ describe(toHaveSize, async () => {
         test('wait but error', async () => {
             vi.mocked(el.getSize).mockRejectedValue(new Error('some error'))
 
-            await expect(() => thisContext.toHaveSize(el, expectedValue))
+            await expect(() => thisContext.toHaveSize(el, expectedValue, { wait: 500 }))
                 .rejects.toThrow('some error')
         })
 


### PR DESCRIPTION
Bringing back the refactoring of `toHaveSize` in the context of the $$ support branch to uncouple the work and have better visibility/assessment of changes