### PR TITLE
chore: Refactor refreshElement tests & add executeCommand coverage

### DIFF
--- a/test/softAssertions.test.ts
+++ b/test/softAssertions.test.ts
@@ -83,7 +83,7 @@ describe('Soft Assertions', () => {
             const softService = SoftAssertService.getInstance()
             softService.setCurrentTest('test-1', 'test name', 'test file')
 
-            await expectWdio.soft(el).toHaveText('Expected Text', { wait: 0 })
+            await expectWdio.soft(el).toHaveText('Expected Text')
 
             // Verify the failure was recorded
             const failures = expectWdio.getSoftFailures()
@@ -103,7 +103,7 @@ Received: "Actual Text"`
             softService.setCurrentTest('test-2', 'test name', 'test file')
 
             // This should not throw even though it fails
-            await expectWdio.soft(el).not.toHaveText('Actual Text', { wait: 0 })
+            await expectWdio.soft(el).not.toHaveText('Actual Text')
 
             // Verify the failure was recorded
             const failures = expectWdio.getSoftFailures()
@@ -117,9 +117,9 @@ Received: "Actual Text"`
             softService.setCurrentTest('test-3', 'test name', 'test file')
 
             // These should not throw even though they fail
-            await expectWdio.soft(el).toHaveText('First Expected', { wait: 0 })
-            await expectWdio.soft(el).toHaveText('Second Expected', { wait: 0 })
-            await expectWdio.soft(el).toHaveText('Third Expected', { wait: 0 })
+            await expectWdio.soft(el).toHaveText('First Expected')
+            await expectWdio.soft(el).toHaveText('Second Expected')
+            await expectWdio.soft(el).toHaveText('Third Expected')
 
             // Verify all failures were recorded
             const failures = expectWdio.getSoftFailures()
@@ -236,7 +236,7 @@ Received: "Actual Text"`
             const softService = SoftAssertService.getInstance()
             softService.setCurrentTest('multiple-elements-test-1', 'test name', 'test file')
 
-            await expectWdio.soft(await elements).toHaveText('Expected Text', { wait: 0 })
+            await expectWdio.soft(await elements).toHaveText('Expected Text')
 
             // Verify the failure was recorded
             const failures = expectWdio.getSoftFailures()
@@ -305,8 +305,8 @@ Expect $$(\`sel\`) to have text
             softService.setCurrentTest('boolean-test', 'boolean test', 'test file')
 
             // Test boolean matcher
-            await expectWdio.soft(el).toBeDisplayed({ wait: 0 })
-            await expectWdio.soft(el).toBeClickable({ wait: 0 })
+            await expectWdio.soft(el).toBeDisplayed()
+            await expectWdio.soft(el).toBeClickable()
 
             const failures = expectWdio.getSoftFailures()
             expect(failures.length).toBe(2)
@@ -318,7 +318,7 @@ Expect $$(\`sel\`) to have text
             const softService = SoftAssertService.getInstance()
             softService.setCurrentTest('attribute-test', 'attribute test', 'test file')
 
-            await expectWdio.soft(el).toHaveAttribute('class', 'expected-class', { wait: 0 })
+            await expectWdio.soft(el).toHaveAttribute('class', 'expected-class')
 
             const failures = expectWdio.getSoftFailures()
             expect(failures.length).toBe(1)
@@ -343,12 +343,12 @@ Expect $$(\`sel\`) to have text
 
             // Test 1
             softService.setCurrentTest('isolation-test-1', 'test 1', 'file1')
-            await expectWdio.soft(el).toHaveText('Expected Text 1', { wait: 0 })
+            await expectWdio.soft(el).toHaveText('Expected Text 1')
             expect(expectWdio.getSoftFailures().length).toBe(1)
 
             // Test 2 - should have separate failures
             softService.setCurrentTest('isolation-test-2', 'test 2', 'file2')
-            await expectWdio.soft(el).toHaveText('Expected Text 2', { wait: 0 })
+            await expectWdio.soft(el).toHaveText('Expected Text 2')
 
             // Test 2 should only see its own failure
             expect(expectWdio.getSoftFailures('isolation-test-2').length).toBe(1)
@@ -386,9 +386,9 @@ Expect $$(\`sel\`) to have text
 
             // Fire multiple assertions rapidly
             const promises = [
-                expectWdio.soft(el).toHaveText('Expected 1', { wait: 0 }),
-                expectWdio.soft(el).toBeDisplayed({ wait: 0 }),
-                expectWdio.soft(el).toBeClickable({ wait: 0 })
+                expectWdio.soft(el).toHaveText('Expected 1'),
+                expectWdio.soft(el).toBeDisplayed(),
+                expectWdio.soft(el).toBeClickable()
             ]
 
             await Promise.all(promises)
@@ -426,7 +426,7 @@ Expect $$(\`sel\`) to have text
             softService.setCurrentTest('long-error-test', 'long error', 'test file')
 
             const veryLongText = 'A'.repeat(10000)
-            await expectWdio.soft(el).toHaveText(veryLongText, { wait: 0 })
+            await expectWdio.soft(el).toHaveText(veryLongText)
 
             const failures = expectWdio.getSoftFailures()
             expect(failures.length).toBe(1)
@@ -439,7 +439,7 @@ Expect $$(\`sel\`) to have text
             softService.setCurrentTest('null-test', 'null test', 'test file')
 
             // Test with null/undefined values
-            await expectWdio.soft(el).toHaveText(null as any, { wait: 0 })
+            await expectWdio.soft(el).toHaveText(null as any)
             await expectWdio.soft(el).toHaveAttribute('class')
 
             const failures = expectWdio.getSoftFailures()
@@ -450,7 +450,7 @@ Expect $$(\`sel\`) to have text
             const softService = SoftAssertService.getInstance()
             softService.setCurrentTest('location-test', 'location test', 'test file')
 
-            await expectWdio.soft(el).toHaveText('Expected Text', { wait: 0 })
+            await expectWdio.soft(el).toHaveText('Expected Text')
 
             const failures = expectWdio.getSoftFailures()
             expect(failures.length).toBe(1)
@@ -469,7 +469,7 @@ Expect $$(\`sel\`) to have text
             // Generate many failures
             const promises = []
             for (let i = 0; i < 150; i++) {
-                promises.push(expectWdio.soft(el).toHaveText(`Expected ${i}`), { wait: 0 })
+                promises.push(expectWdio.soft(el).toHaveText(`Expected ${i}`))
             }
 
             await Promise.all(promises)

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { $ } from '@wdio/globals'
+import { executeCommand } from '../../src/util/executeCommand'
+
+vi.mock('@wdio/globals')
+
+describe(executeCommand, () => {
+    const conditionPass = vi.fn(async (_element: WebdriverIO.Element) => {
+        return ({ result: true, value: 'myValue' })
+    })
+
+    const conditionFail = vi.fn(async (_element: WebdriverIO.Element) => {
+        return ({ result: false })
+    })
+
+    describe('given single element', () => {
+        const selector = 'single-selector'
+        let element : WebdriverIO.Element
+
+        beforeEach(async () => {
+            element = await $(selector).getElement()
+        })
+
+        test('Element', async () => {
+            const result = await executeCommand(element, conditionPass)
+
+            expect(result).toEqual({
+                el: element,
+                success: true,
+                values: 'myValue'
+            })
+        })
+
+        test('Element with value result being an array', async () => {
+            const conditionPassWithValueArray = vi.fn(async (_element: WebdriverIO.Element) => {
+                return ({ result: true, value: ['myValue'] })
+            })
+
+            const result = await executeCommand(element, conditionPassWithValueArray)
+
+            expect(result).toEqual({
+                el: element,
+                success: true,
+                values: ['myValue']
+            })
+        })
+
+        test('Element with value result being an array of array', async () => {
+            const conditionPassWithValueArray = vi.fn(async (_element: WebdriverIO.Element) => {
+                return ({ result: true, value: [['myValue']] })
+            })
+
+            const result = await executeCommand(element, conditionPassWithValueArray)
+
+            expect(result).toEqual({
+                el: element,
+                success: true,
+                values: [['myValue']]
+            })
+        })
+
+        test('when condition is not met', async () => {
+            const result = await executeCommand(element, conditionFail)
+
+            expect(result).toEqual({
+                el: element,
+                success: false,
+                values: undefined,
+            })
+        })
+    })
+
+    describe('given not elements', () => {
+        test('undefined', async () => {
+
+            const result = await executeCommand(undefined as any, conditionFail)
+
+            expect(result).toEqual({
+                el: undefined,
+                success: false,
+                values: undefined,
+            })
+        })
+
+        test('empty array', async () => {
+            const result = await executeCommand([], conditionFail)
+
+            expect(result).toEqual({
+                el: [],
+                success: false,
+                values: undefined,
+            })
+        })
+
+        test('object', async () => {
+            const anyOjbect = { foo: 'bar' }
+
+            const result = await executeCommand(anyOjbect as any, conditionFail)
+
+            expect(result).toEqual({
+                el: { foo: 'bar' },
+                success: false,
+                values: undefined,
+            })
+        })
+
+        test('number', async () => {
+            const anyNumber = 42
+
+            const result = await executeCommand(anyNumber as any, conditionFail)
+
+            expect(result).toEqual({
+                el: 42,
+                success: false,
+                values: undefined,
+            })
+        })
+    })
+})

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -1,28 +1,30 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { $ } from '@wdio/globals'
+import { $, $$ } from '@wdio/globals'
 import { executeCommand } from '../../src/util/executeCommand'
+import { WdioElements } from '../../src/types'
 
 vi.mock('@wdio/globals')
 
 describe(executeCommand, () => {
-    const conditionPass = vi.fn(async (_element: WebdriverIO.Element) => {
-        return ({ result: true, value: 'myValue' })
-    })
-
-    const conditionFail = vi.fn(async (_element: WebdriverIO.Element) => {
-        return ({ result: false })
-    })
 
     describe('given single element', () => {
         const selector = 'single-selector'
         let element : WebdriverIO.Element
+
+        const conditionSingleElementPass = vi.fn(async (_element: WebdriverIO.Element) => {
+            return ({ result: true, value: 'myValue' })
+        })
+
+        const conditionSingleElementFail = vi.fn(async (_element: WebdriverIO.Element) => {
+            return ({ result: false })
+        })
 
         beforeEach(async () => {
             element = await $(selector).getElement()
         })
 
         test('Element', async () => {
-            const result = await executeCommand(element, conditionPass)
+            const result = await executeCommand(element, conditionSingleElementPass)
 
             expect(result).toEqual({
                 el: element,
@@ -60,7 +62,7 @@ describe(executeCommand, () => {
         })
 
         test('when condition is not met', async () => {
-            const result = await executeCommand(element, conditionFail)
+            const result = await executeCommand(element, conditionSingleElementFail)
 
             expect(result).toEqual({
                 el: element,
@@ -68,13 +70,70 @@ describe(executeCommand, () => {
                 values: undefined,
             })
         })
+
+        test('pass options to condition', async () => {
+            const options = { wait: 1000, interval: 100 }
+
+            await executeCommand(element, conditionSingleElementPass, options)
+
+            expect(conditionSingleElementPass).toHaveBeenCalledWith(element, options)
+        })
+    })
+
+    describe('given multiple elements', () => {
+        const selector = 'multi-selector'
+
+        const conditionMultipleElementPass = vi.fn(async (_element: WdioElements) => {
+            return ({ result: true, value: ['myValue1', 'myValue2'] })
+        })
+
+        test('ElementArray', async () => {
+            const elementArray = await $$(selector).getElements()
+
+            const result = await executeCommand(elementArray, conditionMultipleElementPass)
+
+            expect(result).toEqual({
+                el: elementArray,
+                success: true,
+                values: ['myValue1', 'myValue2'],
+            })
+        })
+
+        test('Element[]', async () => {
+            const elementArray = await $$(selector)
+            const elements = Array.from(elementArray)
+
+            expect(Array.isArray(elements)).toBe(true)
+
+            const result = await executeCommand(elements, conditionMultipleElementPass)
+
+            expect(result).toEqual({
+                el: elements,
+                success: true,
+                values: ['myValue1', 'myValue2'],
+            })
+        })
+
+        test('pass options to condition', async () => {
+            const options = { wait: 1000, interval: 100 }
+            const elements = await $$(selector).getElements()
+
+            await executeCommand(elements, conditionMultipleElementPass, options)
+
+            expect(conditionMultipleElementPass).toHaveBeenCalledWith(elements, options)
+        })
     })
 
     describe('given not elements', () => {
+        const conditionFail = vi.fn(async (_element: unknown) => {
+            return ({ result: false })
+        })
+
         test('undefined', async () => {
 
             const result = await executeCommand(undefined as any, conditionFail)
 
+            expect(conditionFail).toHaveBeenCalledWith(undefined, {})
             expect(result).toEqual({
                 el: undefined,
                 success: false,
@@ -116,4 +175,5 @@ describe(executeCommand, () => {
             })
         })
     })
+
 })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -2,6 +2,7 @@ import { test, describe, beforeEach, expect } from 'vitest'
 import { printDiffOrStringify } from 'jest-matcher-utils'
 
 import { enhanceError, enhanceErrorBe } from '../../src/util/formatMessage.js'
+import stripAnsi from 'strip-ansi'
 
 describe('formatMessage', () => {
     describe(enhanceError, () => {
@@ -11,14 +12,14 @@ describe('formatMessage', () => {
             const actual = 'Test Actual Value'
 
             beforeEach(() => {
-                actualFailureMessage = enhanceError(
+                actualFailureMessage = stripAnsi(enhanceError(
                     'window',
                     expected,
                     actual,
                     { isNot: false },
                     'have',
                     'title',
-                )
+                ))
             })
 
             test('message', () => {
@@ -30,7 +31,7 @@ Received: "Test Actual Value"`)
             })
 
             test('diff string', () => {
-                const diffString = printDiffOrStringify('Test Expected Value', 'Test Actual Value', 'Expected', 'Received', true)
+                const diffString = stripAnsi(printDiffOrStringify('Test Expected Value', 'Test Actual Value', 'Expected', 'Received', true))
                 expect(diffString).toEqual(`\
 Expected: "Test Expected Value"
 Received: "Test Actual Value"`)
@@ -47,14 +48,14 @@ Received: "Test Actual Value"`)
                 const actual = expected
 
                 beforeEach(() => {
-                    actualFailureMessage = enhanceError(
+                    actualFailureMessage = stripAnsi(enhanceError(
                         'window',
                         expected,
                         actual,
                         { isNot },
                         'have',
                         'title'
-                    )
+                    ))
                 })
 
                 test('message', () => {
@@ -83,7 +84,7 @@ Received      : "Test Same"`
                 const isNot = false
 
                 beforeEach(() => {
-                    actualFailureMessage = enhanceError(
+                    actualFailureMessage = stripAnsi(enhanceError(
                         'window',
                         expected,
                         actual,
@@ -92,7 +93,7 @@ Received      : "Test Same"`
                         'title',
                         '',
                         { message: '', containing: true }
-                    )
+                    ))
                 })
 
                 test('message', () => {
@@ -110,7 +111,7 @@ Received: "Test Actual Value"`)
                 const isNot = true
 
                 beforeEach(() => {
-                    actualFailureMessage = enhanceError(
+                    actualFailureMessage = stripAnsi(enhanceError(
                         'window',
                         expected,
                         actual,
@@ -119,7 +120,7 @@ Received: "Test Actual Value"`)
                         'title',
                         '',
                         { message: '', containing: true }
-                    )
+                    ))
                 })
 
                 test('message', () => {
@@ -137,7 +138,7 @@ Received      : "same value"`)
             const customPrefixMessage = 'Test Message'
 
             beforeEach(() => {
-                actualFailureMessage = enhanceError(
+                actualFailureMessage = stripAnsi(enhanceError(
                     'window',
                     'Test Expected Value',
                     'Test Actual Value',
@@ -146,7 +147,7 @@ Received      : "same value"`)
                     'title',
                     '',
                     { message: customPrefixMessage, containing: false }
-                )
+                ))
             })
 
             test('message', () => {
@@ -169,7 +170,7 @@ Received: "Test Actual Value"`)
                 const isNot = false
 
                 beforeEach(() => {
-                    actualFailureMessage = enhanceError(
+                    actualFailureMessage = stripAnsi(enhanceError(
                         'window',
                         expected,
                         actual,
@@ -177,7 +178,7 @@ Received: "Test Actual Value"`)
                         'have',
                         'property',
                         expectedArg2,
-                    )
+                    ))
                 })
 
                 test('message', () => {
@@ -195,7 +196,7 @@ Received: "Actual Property Value"`)
                 const isNot = true
 
                 beforeEach(() => {
-                    actualFailureMessage = enhanceError(
+                    actualFailureMessage = stripAnsi(enhanceError(
                         'window',
                         expected,
                         actual,
@@ -203,7 +204,7 @@ Received: "Actual Property Value"`)
                         'have',
                         'property',
                         expectedArg2,
-                    )
+                    ))
                 })
 
                 test('message', () => {
@@ -225,7 +226,7 @@ Received      : "Actual Property Value"`)
 
         const isNot = false
         test('when isNot is false', () => {
-            const message = enhanceErrorBe(subject, { isNot, verb, expectation }, options )
+            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options ))
             expect(message).toEqual(`\
 Expect element to be displayed
 
@@ -235,7 +236,7 @@ Received: "not displayed"`)
 
         test('with custom message', () => {
             const customMessage = 'Custom Error Message'
-            const message = enhanceErrorBe(subject, { isNot, verb, expectation }, { ...options, message: customMessage })
+            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, { ...options, message: customMessage }))
             expect(message).toEqual(`\
 Custom Error Message
 Expect element to be displayed
@@ -246,7 +247,7 @@ Received: "not displayed"`)
 
         test('when isNot is true', () => {
             const isNot = true
-            const message = enhanceErrorBe(subject, { isNot, verb, expectation }, options)
+            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options))
             expect(message).toEqual(`\
 Expect element not to be displayed
 

--- a/test/util/refetchElements.test.ts
+++ b/test/util/refetchElements.test.ts
@@ -2,63 +2,52 @@ import { vi, test, describe, beforeEach, expect } from 'vitest'
 import { $$ } from '@wdio/globals'
 
 import { refetchElements } from '../../src/util/refetchElements.js'
+import { browserFactory, chainableElementArrayFactory, elementFactory } from '../__mocks__/@wdio/globals.js'
 
-const createMockElementArray = (length: number): WebdriverIO.ElementArray => {
-    const array = Array.from({ length }, () => ({}))
-    const mockArray = {
-        selector: 'parent',
-        get length() { return array.length },
-        set length(newLength: number) { array.length = newLength },
-        parent: {
-            $: vi.fn(),
-            $$: vi.fn().mockReturnValue(array),
-        },
-        foundWith: '$$',
-        props: [],
-        [Symbol.iterator]: array[Symbol.iterator].bind(array),
-        filter: vi.fn().mockReturnThis(),
-        map: vi.fn().mockReturnThis(),
-        find: vi.fn().mockReturnThis(),
-        forEach: vi.fn(),
-        some: vi.fn(),
-        every: vi.fn(),
-        slice: vi.fn().mockReturnThis(),
-        toArray: vi.fn().mockReturnThis(),
-    }
-    return Object.assign(array, mockArray) as unknown as WebdriverIO.ElementArray
-}
+vi.mock('@wdio/globals')
 
-vi.mock('@wdio/globals', () => ({
-    $$: vi.fn().mockImplementation(() => createMockElementArray(5))
-}))
-
-describe('refetchElements', () => {
+describe(refetchElements, () => {
     describe('given WebdriverIO.ElementArray type', () => {
         let elements: WebdriverIO.ElementArray
 
         beforeEach(async () => {
-            elements = (await $$('parent')) as unknown as WebdriverIO.ElementArray
-            // @ts-ignore
-            elements.parent._length = 5
+            elements = await $$('elements').getElements()
+
+            // Have a different browser instance and $$ implementation to be able to assert calls
+            elements.parent = browserFactory()
+            elements.parent.$$ = vi.fn().mockResolvedValue(
+                chainableElementArrayFactory('elements', 5) as unknown as ChainablePromiseArray & WebdriverIO.MultiRemoteElement[]
+            )
         })
 
-        test('default', async () => {
+        test('default should refresh once', async () => {
+
             const actual = await refetchElements(elements, 5, true)
+
             expect(actual.length).toBe(5)
+            expect(actual).not.toBe(elements)
+            expect(elements.parent.$$).toHaveBeenCalledTimes(1)
         })
 
-        test('wait is 0', async () => {
-            const actual = await refetchElements(elements, 0, true)
+        test('wait is 0 should not refresh', async () => {
+            const wait = 0
+
+            const actual = await refetchElements(elements, wait, true)
+
             expect(actual).toEqual(elements)
+            expect(actual).toHaveLength(2)
+            expect(elements.parent.$$).not.toHaveBeenCalled()
         })
 
         test('should call $$ with all props', async () => {
             elements.props = ['prop1', 'prop2']
+
             await refetchElements(elements, 5, true)
-            expect(elements.parent.$$).toHaveBeenCalledWith('parent', 'prop1', 'prop2')
+
+            expect(elements.parent.$$).toHaveBeenCalledWith('elements', 'prop1', 'prop2')
         })
 
-        test('should call $$ with the proper parent this context', async () => {
+        test('should call $$ with the proper parent "this" context', async () => {
             const parentFoundWith = vi.mocked(elements.parent.$$)
 
             await refetchElements(elements, 5, true)
@@ -68,11 +57,17 @@ describe('refetchElements', () => {
     })
 
     describe('given WebdriverIO.Element[] type', () => {
-        const elements: WebdriverIO.Element[] = [] as unknown as WebdriverIO.Element[]
+        let elements: WebdriverIO.Element[]
 
-        test('default', async () => {
-            const actual = await refetchElements(elements, 0)
-            expect(actual).toEqual([])
+        beforeEach(() => {
+            elements = [elementFactory('element1'), elementFactory('element2')]
+        })
+
+        test('default should not refresh', async () => {
+            const actual = await refetchElements(elements, 5, true)
+
+            expect(actual).toEqual(elements)
+            expect(actual).toHaveLength(2)
         })
     })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,27 @@
-import { describe, test, expect } from 'vitest'
-import { compareObject, compareText, compareTextWithArray, getAsymmetricMatcherValue, isAsymmetricMatcher, isInversedStringContainingMatcher, isStringContainingMatcherLike } from '../src/utils'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { $ } from '@wdio/globals'
+import { compareObject, compareText, compareTextWithArray, executeCommand, executeCommandBe, getAsymmetricMatcherValue, isAsymmetricMatcher, isInversedStringContainingMatcher, isStringContainingMatcherLike, waitUntil } from '../src/utils'
 import { jasmine } from './__mocks__/jasmine'
+import { CommandOptions } from 'expect-webdriverio'
+import stripAnsi from 'strip-ansi'
+import { enhanceErrorBe } from '../src/util/formatMessage'
+
+vi.mock('@wdio/globals')
+
+vi.mock('../src/util/executeCommand', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../src/util/executeCommand')>()
+    return {
+        ...actual,
+        executeCommand: vi.spyOn(actual, 'executeCommand'),
+    }
+})
+vi.mock('../src/util/formatMessage', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../src/util/formatMessage')>()
+    return {
+        ...actual,
+        enhanceErrorBe: vi.spyOn(actual, 'enhanceErrorBe'),
+    }
+})
 
 describe('utils', () => {
     describe(compareText, () => {
@@ -142,6 +163,147 @@ describe('utils', () => {
         test('should fail if the actual value is a number or array', () => {
             expect(compareObject(10, { 'foo': 'bar' }).result).toBe(false)
             expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).result).toBe(false)
+        })
+    })
+
+    describe(executeCommandBe, () => {
+        let context: { isNot: boolean; expectation: string; verb: string }
+        let command: (el: WebdriverIO.Element) => Promise<boolean>
+        let options: CommandOptions
+
+        beforeEach(() => {
+            context = {
+                isNot: false,
+                expectation: 'displayed',
+                verb: 'be'
+            }
+            command = vi.fn().mockResolvedValue(true)
+            options = { wait: 0, interval: 1 }
+        })
+
+        describe('given no elements', () => {
+            test('should fail given undefined', async () => {
+                command = vi.fn().mockResolvedValue(false)
+
+                const result = await executeCommandBe.call(context, undefined as any, command, options)
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect  to be displayed
+
+Expected: "displayed"
+Received: "not displayed"`)
+                expect(waitUntil).toHaveBeenCalled()
+            })
+
+            // TODO Bring back with $$ support
+            test.skip('should fail given empty array', async () => {
+                // @ts-expect-error bring back with $$ support
+                const result = await executeCommandBe.call(context, [], command, options)
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect [] to be displayed
+
+Expected: "at least one result"
+Received: []`)
+                expect(waitUntil).toHaveBeenCalled()
+            })
+        })
+
+        describe('given single element', () => {
+            let received: ChainablePromiseElement
+            let el: WebdriverIO.Element
+
+            beforeEach(async () => {
+                received = $('element1')
+                el = await received.getElement()
+            })
+
+            test('should pass given ChainableElement', async () => {
+                const result = await executeCommandBe.call(context, received, command, options)
+
+                expect(result.pass).toBe(true)
+                expect(executeCommand).toHaveBeenCalledWith(el, expect.any(Function), options)
+                expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), false, options)
+            })
+
+            test('should pass given WebdriverIO.Element', async () => {
+                const result = await executeCommandBe.call(context, received, command, options)
+
+                expect(result.pass).toBe(true)
+                expect(executeCommand).toHaveBeenCalledWith(el, expect.any(Function), options)
+            })
+
+            test('should fail if command returns false', async () => {
+                vi.mocked(command).mockResolvedValue(false)
+
+                const result = await executeCommandBe.call(context, received, command, options)
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`element1\`) to be displayed
+
+Expected: "displayed"
+Received: "not displayed"`)
+                expect(enhanceErrorBe).toHaveBeenCalledWith(
+                    el,
+                    expect.objectContaining({ isNot: false }),
+                    options
+                )
+            })
+
+            describe('given isNot is true', () => {
+                let negatedContext: { isNot: boolean; expectation: string; verb: string }
+
+                beforeEach(() => {
+                    // Success for `.not`
+                    vi.mocked(command).mockResolvedValue(false)
+                    negatedContext = {
+                        expectation: 'displayed',
+                        verb: 'be',
+                        isNot: true
+                    }
+                })
+
+                test('should succeed so pass=false since it is inverted later', async () => {
+                    const result = await executeCommandBe.call(negatedContext, received, command, options)
+
+                    expect(result.pass).toBe(false)
+                    expect(enhanceErrorBe).toHaveBeenCalledWith(
+                        await received,
+                        {
+                            expectation: 'displayed',
+                            isNot: true,
+                            verb: 'be',
+                        },
+                        options
+                    )
+                    expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), true, options)
+                })
+
+                test('should failed so pass=true since it is inverted later', async () => {
+                    vi.mocked(command).mockResolvedValue(true)
+                    const result = await executeCommandBe.call(negatedContext, received, command, options)
+
+                    expect(result.pass).toBe(true)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`element1\`) not to be displayed
+
+Expected: "not displayed"
+Received: "displayed"`)
+                    expect(enhanceErrorBe).toHaveBeenCalledWith(
+                        await received,
+                        {
+                            expectation: 'displayed',
+                            isNot: true,
+                            verb: 'be',
+                        },
+                        options
+                    )
+                    expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), true, options)
+                })
+            })
         })
     })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -212,33 +212,33 @@ Received: []`)
         })
 
         describe('given single element', () => {
-            let received: ChainablePromiseElement
-            let el: WebdriverIO.Element
+            let chainable: ChainablePromiseElement
+            let element: WebdriverIO.Element
 
             beforeEach(async () => {
-                received = $('element1')
-                el = await received.getElement()
+                chainable = $('element1')
+                element = await chainable.getElement()
             })
 
             test('should pass given ChainableElement', async () => {
-                const result = await executeCommandBe.call(context, received, command, options)
+                const result = await executeCommandBe.call(context, chainable, command, options)
 
                 expect(result.pass).toBe(true)
-                expect(executeCommand).toHaveBeenCalledWith(el, expect.any(Function), options)
+                expect(executeCommand).toHaveBeenCalledWith(element, expect.any(Function), options)
                 expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), false, options)
             })
 
             test('should pass given WebdriverIO.Element', async () => {
-                const result = await executeCommandBe.call(context, received, command, options)
+                const result = await executeCommandBe.call(context, element, command, options)
 
                 expect(result.pass).toBe(true)
-                expect(executeCommand).toHaveBeenCalledWith(el, expect.any(Function), options)
+                expect(executeCommand).toHaveBeenCalledWith(element, expect.any(Function), options)
             })
 
             test('should fail if command returns false', async () => {
                 vi.mocked(command).mockResolvedValue(false)
 
-                const result = await executeCommandBe.call(context, received, command, options)
+                const result = await executeCommandBe.call(context, chainable, command, options)
 
                 expect(result.pass).toBe(false)
                 expect(stripAnsi(result.message())).toEqual(`\
@@ -247,7 +247,7 @@ Expect $(\`element1\`) to be displayed
 Expected: "displayed"
 Received: "not displayed"`)
                 expect(enhanceErrorBe).toHaveBeenCalledWith(
-                    el,
+                    element,
                     expect.objectContaining({ isNot: false }),
                     options
                 )
@@ -267,11 +267,11 @@ Received: "not displayed"`)
                 })
 
                 test('should succeed so pass=false since it is inverted later', async () => {
-                    const result = await executeCommandBe.call(negatedContext, received, command, options)
+                    const result = await executeCommandBe.call(negatedContext, chainable, command, options)
 
                     expect(result.pass).toBe(false)
                     expect(enhanceErrorBe).toHaveBeenCalledWith(
-                        await received,
+                        await chainable,
                         {
                             expectation: 'displayed',
                             isNot: true,
@@ -284,7 +284,7 @@ Received: "not displayed"`)
 
                 test('should failed so pass=true since it is inverted later', async () => {
                     vi.mocked(command).mockResolvedValue(true)
-                    const result = await executeCommandBe.call(negatedContext, received, command, options)
+                    const result = await executeCommandBe.call(negatedContext, chainable, command, options)
 
                     expect(result.pass).toBe(true)
                     expect(stripAnsi(result.message())).toEqual(`\
@@ -293,7 +293,7 @@ Expect $(\`element1\`) not to be displayed
 Expected: "not displayed"
 Received: "displayed"`)
                     expect(enhanceErrorBe).toHaveBeenCalledWith(
-                        await received,
+                        await chainable,
                         {
                             expectation: 'displayed',
                             isNot: true,

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -450,7 +450,10 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     /**
      * `WebdriverIO.Element` -> `getAttribute("style")`
      */
-    toHaveStyle: FnWhenElementOrArrayLike<ActualT, (style: { [key: string]: string }, options?: ExpectWebdriverIO.StringOptions) => Promise<void>>
+    toHaveStyle: FnWhenElementOrArrayLike<ActualT, (
+        style: { [key: string]: string },
+        options?: ExpectWebdriverIO.StringOptions
+    ) => Promise<void>>
 }
 
 /**


### PR DESCRIPTION
Bring back more tests' changes done on $$ supports to scope code review