### PR TITLE
fix: Have enhanceError support more edge case

### DIFF
--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -3,6 +3,7 @@ import { equals } from '../jasmineUtils.js'
 import type { WdioElements } from '../types.js'
 import { isElementArray } from './elementsUtil.js'
 import { numberMatcherTester } from './numberOptionsUtil.js'
+import { isString, toJsonString } from './stringUtil.js'
 
 // TODO one day use a real asymmetric matcher for number options instead of this custom equality tester
 const CUSTOM_EQUALITY_TESTER = [numberMatcherTester]
@@ -17,6 +18,10 @@ export const getSelector = (el: WebdriverIO.Element | WebdriverIO.ElementArray) 
 }
 
 export const getSelectors = (el: WebdriverIO.Element | WdioElements) => {
+    if (!el || typeof el !== 'object') {
+        return ''
+    }
+
     const selectors = []
     let parent: WebdriverIO.ElementArray['parent'] | undefined
 
@@ -27,7 +32,7 @@ export const getSelectors = (el: WebdriverIO.Element | WdioElements) => {
         parent = el
     }
 
-    while (parent && 'selector' in parent) {
+    while (!!parent && typeof parent === 'object' && 'selector' in parent) {
         const selector = getSelector(parent as WebdriverIO.Element)
         const index = parent.index ? `[${parent.index}]` : ''
         selectors.push(`${parent.index ? '$' : ''}$(\`${selector}\`)${index}`)
@@ -53,7 +58,11 @@ export const enhanceError = (
     } = {}): string => {
     const { isNot, useNotInLabel = true } = context
 
-    subject = typeof subject === 'string' ? subject : getSelectors(subject)
+    let subjectStr = isString(subject) ? subject : getSelectors(subject)
+    if (!subjectStr) {
+        subjectStr = toJsonString(subject)
+    }
+    subjectStr = subjectStr?.slice(0, 100)
 
     let contain = ''
     if (containing) {
@@ -84,7 +93,7 @@ ${label.received}: ${printReceived(actual)}`
     }
 
     const msg = `\
-${message}Expect ${subject} ${not(isNot)}to ${verb}${expectation}${expectedValueArgument2}${contain}
+${message}Expect ${subjectStr} ${not(isNot)}to ${verb}${expectation}${expectedValueArgument2}${contain}
 
 ${diffString}`
 

--- a/src/util/stringUtil.ts
+++ b/src/util/stringUtil.ts
@@ -1,0 +1,12 @@
+export const isString = (value: unknown): value is string => typeof value === 'string'
+
+export const toJsonString = (value: unknown): string => {
+    if (isString(value)) {
+        return value
+    }
+    try {
+        return JSON.stringify(value)
+    } catch {
+        return String(value)
+    }
+}

--- a/src/util/stringUtil.ts
+++ b/src/util/stringUtil.ts
@@ -4,9 +4,13 @@ export const toJsonString = (value: unknown): string => {
     if (isString(value)) {
         return value
     }
+
+    let stringifiedValue: string | undefined = undefined
     try {
-        return JSON.stringify(value)
+        stringifiedValue = JSON.stringify(value)
     } catch {
-        return String(value)
+        stringifiedValue = undefined
     }
+
+    return isString(stringifiedValue) ? stringifiedValue : String(value)
 }

--- a/src/util/stringUtil.ts
+++ b/src/util/stringUtil.ts
@@ -4,13 +4,9 @@ export const toJsonString = (value: unknown): string => {
     if (isString(value)) {
         return value
     }
-
-    let stringifiedValue: string | undefined = undefined
     try {
-        stringifiedValue = JSON.stringify(value)
+        return JSON.stringify(value) ?? String(value)
     } catch {
-        stringifiedValue = undefined
+        return String(value)
     }
-
-    return isString(stringifiedValue) ? stringifiedValue : String(value)
 }

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -111,42 +111,42 @@ describe('Custom Wdio Matchers Integration Tests', async () => {
         const el = await $('selector')
 
         test('toBe matchers', async () => {
-            await expect(() => expectLib(el).not.toBeDisplayed({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeDisplayed()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be displayed
 
 Expected: "not displayed"
 Received: "displayed"`
             )
 
-            await expect(() => expectLib(el).not.toBeExisting({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeExisting()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be existing
 
 Expected: "not existing"
 Received: "existing"`
             )
 
-            await expect(() => expectLib(el).not.toBeEnabled({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeEnabled()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be enabled
 
 Expected: "not enabled"
 Received: "enabled"`
             )
 
-            await expect(() => expectLib(el).not.toBeClickable({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeClickable()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be clickable
 
 Expected: "not clickable"
 Received: "clickable"`
             )
 
-            await expect(() => expectLib(el).not.toBeFocused({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeFocused()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be focused
 
 Expected: "not focused"
 Received: "focused"`
             )
 
-            await expect(() => expectLib(el).not.toBeSelected({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toBeSelected()).rejects.toThrow(`\
 Expect $(\`selector\`) not to be selected
 
 Expected: "not selected"
@@ -162,21 +162,21 @@ Expected [not]: " Valid Text "
 Received      : " Valid Text "`
             )
 
-            await expect(() => expectLib(el).not.toHaveHTML('<Html/>', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveHTML('<Html/>')).rejects.toThrow(`\
 Expect $(\`selector\`) not to have HTML
 
 Expected [not]: "<Html/>"
 Received      : "<Html/>"`
             )
 
-            await expect(() => expectLib(el).not.toHaveComputedLabel('Computed Label', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveComputedLabel('Computed Label')).rejects.toThrow(`\
 Expect $(\`selector\`) not to have computed label
 
 Expected [not]: "Computed Label"
 Received      : "Computed Label"`
             )
 
-            await expect(() => expectLib(el).not.toHaveComputedRole('Computed Role', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveComputedRole('Computed Role')).rejects.toThrow(`\
 Expect $(\`selector\`) not to have computed role
 
 Expected [not]: "Computed Role"
@@ -185,21 +185,21 @@ Received      : "Computed Role"`
         })
 
         test('size matchers', async () => {
-            await expect(() => expectLib(el).not.toHaveSize({ width: 100, height: 50 }, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveSize({ width: 100, height: 50 })).rejects.toThrow(`\
 Expect $(\`selector\`) not to have size
 
 Expected [not]: {"height": 50, "width": 100}
 Received      : {"height": 50, "width": 100}`
             )
 
-            await expect(() => expectLib(el).not.toHaveHeight(50, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveHeight(50)).rejects.toThrow(`\
 Expect $(\`selector\`) not to have height
 
 Expected [not]: 50
 Received      : 50`
             )
 
-            await expect(() => expectLib(el).not.toHaveWidth(100, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).not.toHaveWidth(100)).rejects.toThrow(`\
 Expect $(\`selector\`) not to have width
 
 Expected [not]: 100
@@ -247,43 +247,43 @@ Received      : "1"`
         vi.mocked(el.isSelected).mockResolvedValue(false)
 
         test('Ensure toBe matchers throws and show proper failing message', async () => {
-            await expect(() => expectLib(el).toBeDisplayed({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeDisplayed()).rejects.toThrow(`\
 Expect $(\`selector\`) to be displayed
 
 Expected: "displayed"
 Received: "not displayed"`)
 
-            await expect(() => expectLib(el).toBeExisting({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeExisting()).rejects.toThrow(`\
 Expect $(\`selector\`) to be existing
 
 Expected: "existing"
 Received: "not existing"`)
 
-            await expect(() => expectLib(el).toExist({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toExist()).rejects.toThrow(`\
 Expect $(\`selector\`) to exist
 
 Expected: "exist"
 Received: "not exist"`)
 
-            await expect(() => expectLib(el).toBeEnabled({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeEnabled()).rejects.toThrow(`\
 Expect $(\`selector\`) to be enabled
 
 Expected: "enabled"
 Received: "not enabled"`)
 
-            await expect(() => expectLib(el).toBeClickable({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeClickable()).rejects.toThrow(`\
 Expect $(\`selector\`) to be clickable
 
 Expected: "clickable"
 Received: "not clickable"`)
 
-            await expect(() => expectLib(el).toBeFocused({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeFocused()).rejects.toThrow(`\
 Expect $(\`selector\`) to be focused
 
 Expected: "focused"
 Received: "not focused"`)
 
-            await expect(() => expectLib(el).toBeSelected({ wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toBeSelected()).rejects.toThrow(`\
 Expect $(\`selector\`) to be selected
 
 Expected: "selected"
@@ -292,31 +292,31 @@ Received: "not selected"`)
         })
 
         test('Ensure toHave matchers throws and show proper failing message', async () => {
-            await expect(() => expectLib(el).toHaveText('Some other text', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveText('Some other text')).rejects.toThrow(`\
 Expect $(\`selector\`) to have text
 
 Expected: "Some other text"
 Received: " Valid Text "`)
 
-            await expect(() => expectLib(el).toHaveHTML('<SomeOtherHtml/>', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveHTML('<SomeOtherHtml/>')).rejects.toThrow(`\
 Expect $(\`selector\`) to have HTML
 
 Expected: "<SomeOtherHtml/>"
 Received: "<Html/>"`)
 
-            await expect(() => expectLib(el).toHaveComputedLabel('Some Other Computed Label', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveComputedLabel('Some Other Computed Label')).rejects.toThrow(`\
 Expect $(\`selector\`) to have computed label
 
 Expected: "Some Other Computed Label"
 Received: "Computed Label"`)
 
-            await expect(() => expectLib(el).toHaveComputedRole('Some Other Computed Role', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveComputedRole('Some Other Computed Role')).rejects.toThrow(`\
 Expect $(\`selector\`) to have computed role
 
 Expected: "Some Other Computed Role"
 Received: "Computed Role"`)
 
-            await expect(() => expectLib(el).toHaveElementProperty('someProperty', 'some other value', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveElementProperty('someProperty', 'some other value')).rejects.toThrow(`\
 Expect $(\`selector\`) to have property someProperty
 
 Expected: "some other value"
@@ -325,7 +325,7 @@ Received: "1"`)
         })
 
         test('Ensure toHaveAttribute matchers throw and show proper failing message', async () => {
-            await expect(() => expectLib(el).toHaveAttribute('someAttribute', 'some other attribute', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveAttribute('someAttribute', 'some other attribute')).rejects.toThrow(`\
 Expect $(\`selector\`) to have attribute someAttribute
 
 Expected: "some other attribute"
@@ -337,7 +337,7 @@ Expect $(\`selector\`) to have attribute notExistingAttribute
 
 Expected: "to have a defined value"
 Received: "value null"`)
-            await expect(() => expectLib(el).toHaveAttr('someAttribute', 'some other attribute', { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveAttr('someAttribute', 'some other attribute')).rejects.toThrow(`\
 Expect $(\`selector\`) to have attribute someAttribute
 
 Expected: "some other attribute"
@@ -345,7 +345,7 @@ Received: null`)
         })
 
         test('Ensure toHaveSize, toHaveHeight, toHaveWidth matchers throw and show proper failing message', async () => {
-            await expect(() => expectLib(el).toHaveSize({ width: 200, height: 100 }, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveSize({ width: 200, height: 100 })).rejects.toThrow(`\
 Expect $(\`selector\`) to have size
 
 - Expected  - 2
@@ -357,13 +357,13 @@ Expect $(\`selector\`) to have size
 +   "height": 50,
 +   "width": 100,
   }`)
-            await expect(() => expectLib(el).toHaveHeight(100, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveHeight(100)).rejects.toThrow(`\
 Expect $(\`selector\`) to have height
 
 Expected: 100
 Received: 50`)
 
-            await expect(() => expectLib(el).toHaveWidth(200, { wait: 1 })).rejects.toThrow(`\
+            await expect(() => expectLib(el).toHaveWidth(200)).rejects.toThrow(`\
 Expect $(\`selector\`) to have width
 
 Expected: 200
@@ -382,25 +382,25 @@ Received: 100`)
         vi.mocked(el.isSelected).mockResolvedValue(false)
 
         test('toBe matchers', async () => {
-            await expectLib(el).not.toBeDisplayed({ wait: 1 })
-            await expectLib(el).not.toBeExisting({ wait: 1 })
-            await expectLib(el).not.toBeEnabled({ wait: 1 })
-            await expectLib(el).not.toBeClickable({ wait: 1 })
-            await expectLib(el).not.toBeFocused({ wait: 1 })
-            await expectLib(el).not.toBeSelected({ wait: 1 })
+            await expectLib(el).not.toBeDisplayed()
+            await expectLib(el).not.toBeExisting()
+            await expectLib(el).not.toBeEnabled()
+            await expectLib(el).not.toBeClickable()
+            await expectLib(el).not.toBeFocused()
+            await expectLib(el).not.toBeSelected()
         })
 
         test('toHave matchers', async () => {
-            await expectLib(el).not.toHaveText('Some other text', { wait: 1 })
-            await expectLib(el).not.toHaveHTML('<SomeOtherHtml/>', { wait: 1 })
-            await expectLib(el).not.toHaveComputedLabel('Some Other Computed Label', { wait: 1 })
-            await expectLib(el).not.toHaveComputedRole('Some Other Computed Role', { wait: 1 })
-            await expectLib(el).not.toHaveElementProperty('someProperty', 'some other value', { wait: 1 })
-            await expectLib(el).not.toHaveAttribute('someAttribute', 'some other attribute', { wait: 1 })
-            await expectLib(el).not.toHaveAttr('someAttribute', 'some other attribute', { wait: 1 })
-            await expectLib(el).not.toHaveSize({ width: 200, height: 100 }, { wait: 1 })
-            await expectLib(el).not.toHaveHeight(100, { wait: 1 })
-            await expectLib(el).not.toHaveWidth(200, { wait: 1 })
+            await expectLib(el).not.toHaveText('Some other text')
+            await expectLib(el).not.toHaveHTML('<SomeOtherHtml/>')
+            await expectLib(el).not.toHaveComputedLabel('Some Other Computed Label')
+            await expectLib(el).not.toHaveComputedRole('Some Other Computed Role')
+            await expectLib(el).not.toHaveElementProperty('someProperty', 'some other value')
+            await expectLib(el).not.toHaveAttribute('someAttribute', 'some other attribute')
+            await expectLib(el).not.toHaveAttr('someAttribute', 'some other attribute')
+            await expectLib(el).not.toHaveSize({ width: 200, height: 100 })
+            await expectLib(el).not.toHaveHeight(100)
+            await expectLib(el).not.toHaveWidth(200)
         })
 
     })

--- a/test/matchers/browser/toHaveClipboardText.test.ts
+++ b/test/matchers/browser/toHaveClipboardText.test.ts
@@ -39,7 +39,7 @@ describe(toHaveClipboardText, () => {
     test('failure check with message', async () => {
         vi.mocked(browser.execute).mockResolvedValue('actual text')
 
-        const result = await thisContext.toHaveClipboardText(browser, 'expected text', { wait: 1 })
+        const result = await thisContext.toHaveClipboardText(browser, 'expected text')
 
         expect(result.pass).toBe(false)
         expect(stripAnsi(result.message())).toEqual(`\
@@ -80,7 +80,7 @@ Received: "actual text"`
     test('failure check with message with isNot true', async () => {
         vi.mocked(browser.execute).mockResolvedValue('actual text')
 
-        const result = await thisNotContext.toHaveClipboardText(browser, 'actual text', { wait: 1 })
+        const result = await thisNotContext.toHaveClipboardText(browser, 'actual text')
 
         expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
         expect(stripAnsi(result.message())).toEqual(`\

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -199,7 +199,7 @@ Received: "not displayed"`)
 
             expect(result.pass).toBe(false)
             expect(stripAnsi(result.message())).toEqual(`\
-Expect  to be displayed
+Expect undefined to be displayed
 
 Expected: "displayed"
 Received: "not displayed"`)

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -25,7 +25,7 @@ describe(toHaveText, async () => {
         let el: ChainablePromiseElement | WebdriverIO.Element
 
         let selectorName = '$(`sel`)'
-        if (title.includes('non-awaited')) {selectorName = ''} // Bug to fix
+        if (title.includes('non-awaited')) {selectorName = '{}'} // Bug to fix
 
         beforeEach(async () => {
             el = element
@@ -329,7 +329,7 @@ Received: "This is example text"`
     ])('given a multiple elements when $title', ({ elements, title }) => {
         let els: ChainablePromiseArray | WebdriverIO.ElementArray //| WebdriverIO.Element[] // Bug that will be fixed later with $$ support
 
-        const selectorName = title.includes('WebdriverIO.Element[]') ? '': '$$(`sel`)' // Bug to fix where with Element[] selector name is empty
+        const selectorName = title.includes('WebdriverIO.Element[]') ? '[{"selector":"sel","parent":{},"elementId":"sel"},{"selector":"dev","parent":{},"elementId":"dev"}]': '$$(`sel`)' // Bug to fix where with Element[] selector name is empty
 
         beforeEach(async () => {
             els = elements as ChainablePromiseArray | WebdriverIO.ElementArray // casting, bug that will be fixed later with $$ support

--- a/test/softAssertions.test.ts
+++ b/test/softAssertions.test.ts
@@ -90,7 +90,7 @@ describe('Soft Assertions', () => {
             expect(failures.length).toBe(1)
             expect(failures[0].matcherName).toBe('toHaveText')
             expect(failures[0].error.message).toEqual(`\
-Expect  to have text
+Expect {} to have text
 
 Expected: "Expected Text"
 Received: "Actual Text"`

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -3,6 +3,7 @@ import { printDiffOrStringify } from 'jest-matcher-utils'
 
 import { enhanceError, enhanceErrorBe } from '../../src/util/formatMessage.js'
 import stripAnsi from 'strip-ansi'
+import { elementFactory } from '../__mocks__/@wdio/globals.js'
 
 describe('formatMessage', () => {
     describe(enhanceError, () => {
@@ -216,44 +217,119 @@ Received      : "Actual Property Value"`)
                 })
             })
         })
+
+        test.for([
+            { actual: undefined, selectorName: 'undefined' },
+            { actual: null, selectorName: 'null' },
+            { actual: true, selectorName: 'true' },
+            { actual: 5, selectorName: '5' },
+            { actual: 'test', selectorName: 'test' },
+            { actual: {}, selectorName: '{}' },
+            { actual: ['1', '2'], selectorName: '["1","2"]' },
+        ])('should return failure message for unsupported type $actual when isNot is false', async ({ actual, selectorName }) => {
+            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: false }, 'have', 'text')
+
+            expect(stripAnsi(result)).toEqual(`\
+Expect ${selectorName} to have text
+
+Expected: "webdriverio"
+Received: undefined`)
+        })
+
+        test.for([
+            { actual: undefined, selectorName: 'undefined' },
+            { actual: null, selectorName: 'null' },
+            { actual: true, selectorName: 'true' },
+            { actual: 5, selectorName: '5' },
+            { actual: 'test', selectorName: 'test' },
+            { actual: {}, selectorName: '{}' },
+            { actual: ['1', '2'], selectorName: '["1","2"]' },
+        ])('should return failure message for unsupported type $actual when isNot is true', async ({ actual, selectorName }) => {
+            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: true }, 'have', 'text')
+
+            expect(stripAnsi(result)).toEqual(`\
+Expect ${selectorName} not to have text
+
+Expected [not]: "webdriverio"
+Received      : undefined`)
+        })
     })
 
     describe(enhanceErrorBe, () => {
-        const subject = 'element'
         const verb = 'be'
         const expectation = 'displayed'
         const options = {}
 
-        const isNot = false
-        test('when isNot is false', () => {
-            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options ))
-            expect(message).toEqual(`\
-Expect element to be displayed
+        describe('given a single element', () => {
+            const subject = elementFactory('element')
+
+            const isNot = false
+            test('when isNot is false and failure with result having pass=false', () => {
+                const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options ))
+                expect(message).toEqual(`\
+Expect $(\`element\`) to be displayed
 
 Expected: "displayed"
 Received: "not displayed"`)
-        })
+            })
 
-        test('with custom message', () => {
-            const customMessage = 'Custom Error Message'
-            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, { ...options, message: customMessage }))
-            expect(message).toEqual(`\
+            test('with custom message', () => {
+                const customMessage = 'Custom Error Message'
+                const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, { ...options, message: customMessage }))
+                expect(message).toEqual(`\
 Custom Error Message
-Expect element to be displayed
+Expect $(\`element\`) to be displayed
 
 Expected: "displayed"
 Received: "not displayed"`)
-        })
+            })
 
-        test('when isNot is true', () => {
-            const isNot = true
-            const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options))
-            expect(message).toEqual(`\
-Expect element not to be displayed
+            test('when isNot is true and failure with result having pass=true (inverted later by Jest)', () => {
+                const isNot = true
+                const message = stripAnsi(enhanceErrorBe(subject, { isNot, verb, expectation }, options))
+                expect(message).toEqual(`\
+Expect $(\`element\`) not to be displayed
 
 Expected: "not displayed"
 Received: "displayed"`)
 
+            })
+
+            test.for([
+                { actual: undefined, selectorName: 'undefined' },
+                { actual: null, selectorName: 'null' },
+                { actual: true, selectorName: 'true' },
+                { actual: 5, selectorName: '5' },
+                { actual: 'test', selectorName: 'test' },
+                { actual: {}, selectorName: '{}' },
+                { actual: ['1', '2'], selectorName: '["1","2"]' },
+            ])('should return failure message for unsupported type $actual when isNot is false and not result from element function call', async ({ actual: subject, selectorName }) => {
+                const result = await enhanceErrorBe(subject as any, { isNot, verb, expectation }, options)
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect ${selectorName} to be displayed
+
+Expected: "displayed"
+Received: "not displayed"`)
+            })
+
+            test.for([
+                { actual: undefined, selectorName: 'undefined' },
+                { actual: null, selectorName: 'null' },
+                { actual: true, selectorName: 'true' },
+                { actual: 5, selectorName: '5' },
+                { actual: 'test', selectorName: 'test' },
+                { actual: {}, selectorName: '{}' },
+                { actual: ['1', '2'], selectorName: '["1","2"]' },
+            ])('should return failure message for unsupported type $actual when isNot is true and not result from element function call', async ({ actual: subject, selectorName }) => {
+                const result = await enhanceErrorBe(subject as any, { isNot: true, verb, expectation }, options)
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect ${selectorName} not to be displayed
+
+Expected: "not displayed"
+Received: "displayed"`)
+            })
         })
     })
 })

--- a/test/util/stringUtil.test.ts
+++ b/test/util/stringUtil.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import { isString, toJsonString } from '../../src/util/stringUtil'
+
+describe('stringUtil', () => {
+    describe(isString, () => {
+        test('should return true for a string', () => {
+            expect(isString('hello')).toBe(true)
+            expect(isString('')).toBe(true)
+        })
+
+        test('should return false for non-string values', () => {
+            expect(isString(123)).toBe(false)
+            expect(isString(true)).toBe(false)
+            expect(isString({})).toBe(false)
+            expect(isString(null)).toBe(false)
+            expect(isString(undefined)).toBe(false)
+            expect(isString([])).toBe(false)
+        })
+    })
+
+    describe(toJsonString, () => {
+        test('should return the string as is if input is a string', () => {
+            expect(toJsonString('hello')).toBe('hello')
+        })
+
+        test('should return JSON string if input is a serializable object', () => {
+            const obj = { foo: 'bar', num: 123 }
+            expect(toJsonString(obj)).toBe(JSON.stringify(obj))
+        })
+
+        test('should return string representation if JSON.stringify throws', () => {
+            const circular: any = { foo: 'bar' }
+            circular.self = circular
+
+            expect(toJsonString(circular)).toBe('[object Object]')
+            expect(toJsonString(BigInt(9007199254740991))).toBe('9007199254740991')
+        })
+
+        test('should return string representation for other types', () => {
+            expect(toJsonString(123)).toBe('123')
+            expect(toJsonString(true)).toBe('true')
+            expect(toJsonString(null)).toBe('null')
+        })
+
+        test('should handle undefined correctly', () => {
+            expect(toJsonString(undefined)).toBeUndefined()
+        })
+    })
+})

--- a/test/util/stringUtil.test.ts
+++ b/test/util/stringUtil.test.ts
@@ -43,7 +43,7 @@ describe('stringUtil', () => {
         })
 
         test('should handle undefined correctly', () => {
-            expect(toJsonString(undefined)).toBeUndefined()
+            expect(toJsonString(undefined)).toBe('undefined')
         })
     })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -189,7 +189,7 @@ describe('utils', () => {
 
                 expect(result.pass).toBe(false)
                 expect(stripAnsi(result.message())).toEqual(`\
-Expect  to be displayed
+Expect undefined to be displayed
 
 Expected: "displayed"
 Received: "not displayed"`)


### PR DESCRIPTION
- Fix `enhanceError` not supporting edge cases such as `undefined`
- Bring back more test cases from $$ support, like for errorMesssageBe