### PR TITLE
fix: Centralize awaiting of element(s) to support more type & edge cases (toHaveText)

### DIFF
--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -120,7 +120,6 @@ describe('WebdriverIO Custom Matchers', () => {
                 it('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {
                     const heading = (await $$('h1').getElements()).filter(async (el) => (await el.getText()).includes('Open Source'))
 
-                    // @ts-expect-error TODO support Element[] in toHaveText signature??
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
             })
@@ -136,14 +135,12 @@ describe('WebdriverIO Custom Matchers', () => {
                 it('should verify text with options with non-awaited filtered ChainablePromiseArray', async () => {
                     const heading = $$('h1').filter(async (el) => (await el.getText()).includes('Open Source'))
 
-                    // @ts-expect-error TODO support Element[] in toHaveText signature??
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
 
                 it('should verify text with options with non-awaited getElements ChainablePromiseArray', async () => {
                     const heading = $$('h1').getElements()
 
-                    // @ts-expect-error TODO support Element[] in toHaveText signature??
                     await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
                 })
             })

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -105,13 +105,6 @@ describe('WebdriverIO Custom Matchers', () => {
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
 
-                it('should fails if there is no elements', async () => {
-                    const heading = await $$('h1').filter(async (el) => (await el.getText()).includes('test'))
-
-                    expect(heading.length).toBe(0)
-                    await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
-                })
-
                 it('should verify text with options with awaited getElements ChainablePromiseArray', async () => {
                     const heading = await $$('h1').getElements()
                     await expect(heading).toHaveText(['','Open Source and Open Governed'], { ignoreCase: true, containing: true })
@@ -121,6 +114,23 @@ describe('WebdriverIO Custom Matchers', () => {
                     const heading = (await $$('h1').getElements()).filter(async (el) => (await el.getText()).includes('Open Source'))
 
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+
+
+                describe('Empty elemetns', () => {
+                    it('should fails if there is no elements with Element[]', async () => {
+                        const heading = await $$('h1').filter(async (el) => (await el.getText()).includes('test'))
+
+                        expect(heading.length).toBe(0)
+                        await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
+                    })
+
+                    it('should fails if there is no elements with ElementArray', async () => {
+                        const heading = await $$('h10')
+
+                        expect(heading.length).toBe(0)
+                        await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
+                    })
                 })
             })
 
@@ -142,6 +152,20 @@ describe('WebdriverIO Custom Matchers', () => {
                     const heading = $$('h1').getElements()
 
                     await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
+                })
+
+                describe('Empty elements', () => {
+                    it('should fails if there is no elements with Element[]', async () => {
+                        const heading = $$('h1').filter(async (el) => (await el.getText()).includes('test'))
+
+                        await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
+                    })
+
+                    it('should fails if there is no elements with ElementArray', async () => {
+                        const heading = $$('h10')
+
+                        await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
+                    })
                 })
             })
         })

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -105,11 +105,11 @@ describe('WebdriverIO Custom Matchers', () => {
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
 
-                // TODO fix: When element array is 0 is does match anything and should fail, but it does not
-                it.skip('should fails if there is no elements', async () => {
+                it('should fails if there is no elements', async () => {
                     const heading = await $$('h1').filter(async (el) => (await el.getText()).includes('test'))
+
                     expect(heading.length).toBe(0)
-                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                    await expect(expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })).rejects.toThrow()
                 })
 
                 it('should verify text with options with awaited getElements ChainablePromiseArray', async () => {
@@ -117,8 +117,7 @@ describe('WebdriverIO Custom Matchers', () => {
                     await expect(heading).toHaveText(['','Open Source and Open Governed'], { ignoreCase: true, containing: true })
                 })
 
-                // TODO fix `el.getText is not a function`
-                it.skip('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {
+                it('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {
                     const heading = (await $$('h1').getElements()).filter(async (el) => (await el.getText()).includes('Open Source'))
 
                     // @ts-expect-error TODO support Element[] in toHaveText signature??
@@ -128,27 +127,24 @@ describe('WebdriverIO Custom Matchers', () => {
 
             describe('Non-awaited', () => {
 
-                // TODO fix `Can't call "getText" on element with selector "h1", it is not a function`
-                it.skip('should verify text with options with non-awaited ChainablePromiseArray', async () => {
+                it('should verify text with options with non-awaited ChainablePromiseArray', async () => {
                     const heading = $$('h1')
-                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+
+                    await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
                 })
 
-                // TODO fix `Can't call "getText" on element with selector "h1", it is not a function`
-                it.skip('should verify text with options with non-awaited filtered ChainablePromiseArray', async () => {
+                it('should verify text with options with non-awaited filtered ChainablePromiseArray', async () => {
                     const heading = $$('h1').filter(async (el) => (await el.getText()).includes('Open Source'))
 
-                    console.log('heading', heading)
                     // @ts-expect-error TODO support Element[] in toHaveText signature??
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
 
-                // TODO fix `el.getText is not a function`
-                it.skip('should verify text with options with non-awaited getElements ChainablePromiseArray', async () => {
+                it('should verify text with options with non-awaited getElements ChainablePromiseArray', async () => {
                     const heading = $$('h1').getElements()
 
                     // @ts-expect-error TODO support Element[] in toHaveText signature??
-                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                    await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
                 })
             })
         })

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -81,6 +81,77 @@ describe('WebdriverIO Custom Matchers', () => {
             const heading = await $$('h1')[1]  // Second h1 has text
             await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
         })
+
+        describe('Multiple Elements', () => {
+            describe('Awaited', () => {
+                it('should verify text with array of text & with options with awaited ChainablePromiseArray', async () => {
+                    const heading = await $$('h1')
+                    await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
+                })
+
+                it('should verify text with array of text without exact array match', async () => {
+                    const heading = await $$('h1')
+                    await expect(heading).toHaveText(['Open Source and Open Governed', '', 'no match'])
+                })
+
+                it('should fails verify a single text found in only one element', async () => {
+                    const heading = await $$('h1')
+                    await expect(expect(heading).toHaveText('Open Source and Open Governed', { ignoreCase: true, containing: true, wait: 500 })).rejects.toThrow()
+                })
+
+                it('should verify text with options with awaited filtered ChainablePromiseArray', async () => {
+                    const heading = await $$('h1').filter(async (el) => (await el.getText()).includes('Open Source'))
+                    expect(heading.length).toBe(1)
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+
+                // TODO fix: When element array is 0 is does match anything and should fail, but it does not
+                it.skip('should fails if there is no elements', async () => {
+                    const heading = await $$('h1').filter(async (el) => (await el.getText()).includes('test'))
+                    expect(heading.length).toBe(0)
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+
+                it('should verify text with options with awaited getElements ChainablePromiseArray', async () => {
+                    const heading = await $$('h1').getElements()
+                    await expect(heading).toHaveText(['','Open Source and Open Governed'], { ignoreCase: true, containing: true })
+                })
+
+                // TODO fix `el.getText is not a function`
+                it.skip('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {
+                    const heading = (await $$('h1').getElements()).filter(async (el) => (await el.getText()).includes('Open Source'))
+
+                    // @ts-expect-error TODO support Element[] in toHaveText signature??
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+            })
+
+            describe('Non-awaited', () => {
+
+                // TODO fix `Can't call "getText" on element with selector "h1", it is not a function`
+                it.skip('should verify text with options with non-awaited ChainablePromiseArray', async () => {
+                    const heading = $$('h1')
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+
+                // TODO fix `Can't call "getText" on element with selector "h1", it is not a function`
+                it.skip('should verify text with options with non-awaited filtered ChainablePromiseArray', async () => {
+                    const heading = $$('h1').filter(async (el) => (await el.getText()).includes('Open Source'))
+
+                    console.log('heading', heading)
+                    // @ts-expect-error TODO support Element[] in toHaveText signature??
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+
+                // TODO fix `el.getText is not a function`
+                it.skip('should verify text with options with non-awaited getElements ChainablePromiseArray', async () => {
+                    const heading = $$('h1').getElements()
+
+                    // @ts-expect-error TODO support Element[] in toHaveText signature??
+                    await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+                })
+            })
+        })
     })
 
     describe('Element attribute matchers', () => {

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -7,6 +7,7 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 import type { MaybeArray, WdioElementOrArrayMaybePromise } from '../../types.js'
+import { awaitElementOrArray } from '../../util/elementsUtil.js'
 
 async function condition(el: WebdriverIO.Element, html: MaybeArray<string | RegExp | AsymmetricMatcher<string>>, options: ExpectWebdriverIO.HTMLOptions) {
     const actualHTML = await el.getHTML(options) // TODO: Support for array of elements is coming!
@@ -29,17 +30,18 @@ export async function toHaveHTML(
         options,
     })
 
-    let el = 'getElement' in received
-        ? await received?.getElement()
-        : 'getElements' in received
-            ? await received?.getElements()
-            : received
     let actualHTML
-
+    let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
-            const result = await executeCommand.call(this, el, condition, options, [expectedValue, options])
-            el = result.el as WebdriverIO.Element
+            const { selector, other } = await awaitElementOrArray(received)
+            if (!selector) {
+                actualSubject = other
+                return false
+            }
+
+            const result = await executeCommand.call(this, selector, condition, options, [expectedValue, options])
+            actualSubject = result.el as WebdriverIO.Element
             actualHTML = result.values
 
             return result.success
@@ -48,7 +50,7 @@ export async function toHaveHTML(
         { wait: options.wait, interval: options.interval }
     )
 
-    const message = enhanceError(el, wrapExpectedWithArray(el, actualHTML, expectedValue), actualHTML, this, verb, expectation, '', options)
+    const message = enhanceError(actualSubject, wrapExpectedWithArray(actualSubject, actualHTML, expectedValue), actualHTML, this, verb, expectation, '', options)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -39,7 +39,7 @@ export async function toHaveHTML(
             if (!selector || isEmptyElements) { return false }
 
             const result = await executeCommand.call(this, selector, condition, options, [expectedValue, options])
-            actualSubject = result.el as WebdriverIO.Element
+            actualSubject = result.el
             actualHTML = result.values
 
             return result.success

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -34,9 +34,12 @@ export async function toHaveHTML(
     let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
-            const { selector, other } = await awaitElementOrArray(received)
+            const { selector, elements, other } = await awaitElementOrArray(received)
             if (!selector) {
                 actualSubject = other
+                return false
+            } else if (!!elements && elements.length === 0) {
+                actualSubject = selector
                 return false
             }
 

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -34,14 +34,9 @@ export async function toHaveHTML(
     let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
-            const { selector, elements, other } = await awaitElementOrArray(received)
-            if (!selector) {
-                actualSubject = other
-                return false
-            } else if (!!elements && elements.length === 0) {
-                actualSubject = selector
-                return false
-            }
+            const { selector, other, isEmptyElements } = await awaitElementOrArray(received)
+            actualSubject = selector ?? other
+            if (!selector || isEmptyElements) { return false }
 
             const result = await executeCommand.call(this, selector, condition, options, [expectedValue, options])
             actualSubject = result.el as WebdriverIO.Element

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -7,6 +7,7 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 import type { MaybeArray, WdioElementOrArrayMaybePromise, WdioElements } from '../../types.js'
+import { awaitElementOrArray } from '../../util/elementsUtil.js'
 
 async function condition(el: WebdriverIO.Element | WdioElements, text: MaybeArray<string | RegExp | AsymmetricMatcher<string>>, options: ExpectWebdriverIO.StringOptions) {
     const actualTextArray: string[] = []
@@ -50,26 +51,29 @@ export async function toHaveText(
         options,
     })
 
-    let elements = 'getElement' in received
-        ? await received?.getElement()
-        : 'getElements' in received
-            ? await received?.getElements()
-            : received
+    const { selector, other } = await awaitElementOrArray(received)
     let actualText
+    let pass = false
+    let elements = selector
+    if (elements) {
+        pass = await waitUntil(
+            async () => {
+                if (!elements) {throw new Error('Element(s) not found')} // to satisfy typescript that elements is defined, but should never happen since waitUntil will throw if elements is undefined
 
-    const pass = await waitUntil(
-        async () => {
-            const result = await executeCommand.call(this, elements, condition, options, [expectedValue, options])
-            elements = result.el
-            actualText = result.values
+                const result = await executeCommand.call(this, elements, condition, options, [expectedValue, options])
+                elements = result.el
+                actualText = result.values
 
-            return result.success
-        },
-        isNot,
-        { wait: options.wait, interval: options.interval }
-    )
+                return result.success
+            },
+            isNot,
+            { wait: options.wait, interval: options.interval }
+        )
+    }
 
-    const message = enhanceError(elements, wrapExpectedWithArray(elements, actualText, expectedValue), actualText, this, verb, expectation, '', options)
+    const actualSubject = elements ?? other
+
+    const message = enhanceError(actualSubject, wrapExpectedWithArray(actualSubject, actualText, expectedValue), actualText, this, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -55,6 +55,8 @@ export async function toHaveText(
     let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
+            // Calling `awaitElementOrArray` inside the waitUntil so that in non-awaited cases, it couns in the wait time like before!
+            // However, now we do await inside the loop on each iteration even in awaited cases, so should we optimize this?
             const { selector, other, isEmptyElements } = await awaitElementOrArray(received)
             actualSubject = selector ?? other
             if (!selector || isEmptyElements) { return false }

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -55,14 +55,9 @@ export async function toHaveText(
     let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
-            const { selector, elements, other } = await awaitElementOrArray(received)
-            if (!selector) {
-                actualSubject = other
-                return false
-            } else if (!!elements && elements.length === 0) {
-                actualSubject = selector
-                return false
-            }
+            const { selector, other, isEmptyElements } = await awaitElementOrArray(received)
+            actualSubject = selector ?? other
+            if (!selector || isEmptyElements) { return false }
 
             const result = await executeCommand.call(this, selector, condition, options, [expectedValue, options])
             actualSubject = result.el

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -7,14 +7,14 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 import type { MaybeArray, WdioElementOrArrayMaybePromise, WdioElements } from '../../types.js'
-import { awaitElementOrArray } from '../../util/elementsUtil.js'
+import { awaitElementOrArray, isArray } from '../../util/elementsUtil.js'
 
 async function condition(el: WebdriverIO.Element | WdioElements, text: MaybeArray<string | RegExp | AsymmetricMatcher<string>>, options: ExpectWebdriverIO.StringOptions) {
     const actualTextArray: string[] = []
     const resultArray: boolean[] = []
     let checkAllValuesMatchCondition: boolean
 
-    if (Array.isArray(el)){
+    if (isArray(el)){
         for (const element of el){
             const actualText = await element.getText()
             actualTextArray.push(actualText)
@@ -25,7 +25,7 @@ async function condition(el: WebdriverIO.Element | WdioElements, text: MaybeArra
         }
         checkAllValuesMatchCondition = resultArray.every(Boolean)
     } else {
-        const actualText = await (el as WebdriverIO.Element).getText()
+        const actualText = await el.getText()
         actualTextArray.push(actualText)
         checkAllValuesMatchCondition = Array.isArray(text)
             ? compareTextWithArray(actualText, text, options).result
@@ -55,9 +55,12 @@ export async function toHaveText(
     let actualSubject: unknown = received
     const pass = await waitUntil(
         async () => {
-            const { selector, other } = await awaitElementOrArray(received)
+            const { selector, elements, other } = await awaitElementOrArray(received)
             if (!selector) {
                 actualSubject = other
+                return false
+            } else if (!!elements && elements.length === 0) {
+                actualSubject = selector
                 return false
             }
 

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -51,27 +51,25 @@ export async function toHaveText(
         options,
     })
 
-    const { selector, other } = await awaitElementOrArray(received)
     let actualText
-    let pass = false
-    let elements = selector
-    if (elements) {
-        pass = await waitUntil(
-            async () => {
-                if (!elements) {throw new Error('Element(s) not found')} // to satisfy typescript that elements is defined, but should never happen since waitUntil will throw if elements is undefined
+    let actualSubject: unknown = received
+    const pass = await waitUntil(
+        async () => {
+            const { selector, other } = await awaitElementOrArray(received)
+            if (!selector) {
+                actualSubject = other
+                return false
+            }
 
-                const result = await executeCommand.call(this, elements, condition, options, [expectedValue, options])
-                elements = result.el
-                actualText = result.values
+            const result = await executeCommand.call(this, selector, condition, options, [expectedValue, options])
+            actualSubject = result.el
+            actualText = result.values
 
-                return result.success
-            },
-            isNot,
-            { wait: options.wait, interval: options.interval }
-        )
-    }
-
-    const actualSubject = elements ?? other
+            return result.success
+        },
+        isNot,
+        { wait: options.wait, interval: options.interval }
+    )
 
     const message = enhanceError(actualSubject, wrapExpectedWithArray(actualSubject, actualText, expectedValue), actualText, this, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type WdioElements = WebdriverIO.ElementArray | WebdriverIO.Element[]
 
 export type WdioElementsMaybePromise =
     WdioElements |
-    ChainablePromiseArray
+    ChainablePromiseArray | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
 export type WdioElementOrArrayMaybePromise =
     WdioElementMaybePromise |

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -1,4 +1,4 @@
-import type { WdioElements } from '../types.js'
+import type { WdioElementOrArrayMaybePromise, WdioElements } from '../types.js'
 
 /**
  * if el is an array of elements and actual value is an array
@@ -7,13 +7,86 @@ import type { WdioElements } from '../types.js'
  * @param actual actual result or results array
  * @param expected expected result
  */
-export const wrapExpectedWithArray = (el: WebdriverIO.Element | WdioElements, actual: unknown, expected: unknown) => {
+export const wrapExpectedWithArray = <T>(el: WebdriverIO.Element | WdioElements | unknown, actual: unknown, expected: T): T | T[] => {
     if (Array.isArray(el) && el.length > 1 && Array.isArray(actual)) {
-        expected = [expected]
+        return [expected]
     }
     return expected
 }
 
 export const isElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
     return obj !== null && typeof obj === 'object' && 'selector' in obj && 'foundWith' in obj && 'parent' in obj
+}
+
+export const isSelector = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element => {
+    return !!obj && typeof obj === 'object'
+    && 'selector' in obj
+    && 'parent' in obj // commun with Element
+}
+
+export const isStrictlyElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
+    return isSelector(obj)
+    && Array.isArray(obj)
+    && 'foundWith' in obj // Element does not have foundWith property
+    && 'getElements' in obj // specific to ElementArray
+}
+
+export const isElement = (obj: unknown): obj is WebdriverIO.Element => {
+    // Note elementId is only for found element
+    return isSelector(obj)
+    && !Array.isArray(obj)
+    && 'getElement' in obj // specific to Element
+}
+
+export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] => {
+    return (!!obj && isStrictlyElementArray(obj)) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement))
+}
+
+export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {
+    return !!obj && isElement(obj) || isElementArrayLike(obj)
+}
+
+/**
+ * Universaly await element(s) since depending on the type received, it can become complex.
+ *
+ * Using `$()` or `$$()` return a promise as `ChainablePromiseElement/Array` that needs to be awaited and even if chainable.getElement()/getElements() can be done statically, at runtime `'getElement/getElements` in chainable` is false.
+ * Using `await $()` still return a `ChainablePromiseElement` but underneath it's a `WebdriverIO.Element/ElementArray` and thus `'getElement/getElements' in element` is true and can be checked and done.
+ * With `$$().filter()`, it returns a `Promise<WebdriverIO.Element[]>` that also needs to be awaited.
+ * When passing directly a `WebdriverIO.Element` or `WebdriverIO.ElementArray`, no need to await anything and getElement or getElements can be used on it and runtime also works too.
+ *
+ * @param received
+ * @returns
+ */
+export const awaitElementOrArray = async(
+    received: WdioElementOrArrayMaybePromise | undefined
+): Promise<{ selector?: WdioElements | WebdriverIO.Element, elements?: WdioElements, element?: WebdriverIO.Element, other?: unknown }> => {
+    if (!received || typeof received !== 'object') {
+        return { other: received }
+    }
+
+    let awaitedElements = received
+
+    // For non-awaited `$()` or `$$()`, so ChainablePromiseElement | ChainablePromiseArray.
+    // At some extend it also process non-awaited `$().getElement()`, `$$().getElements()` or `$$().filter()`, but typings does not allow it
+    if (awaitedElements instanceof Promise) {
+        awaitedElements = await awaitedElements
+    }
+
+    if (!isElementOrArrayLike(awaitedElements)) {
+        return { other: awaitedElements }
+    }
+
+    // for `await $()` or `WebdriverIO.Element`
+    if ('getElement' in awaitedElements) {
+        const element = await awaitedElements.getElement()
+        return { selector: element, element }
+    }
+    // for `await $$()` or `WebdriverIO.ElementArray` but not `WebdriverIO.Element[]`
+    if ('getElements' in awaitedElements) {
+        const elements = await awaitedElements.getElements()
+        return { selector: elements, elements }
+    }
+
+    // for `WebdriverIO.Element[]`
+    return { selector: awaitedElements, elements: awaitedElements }
 }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -16,7 +16,7 @@ export const wrapExpectedWithArray = <T>(element: WebdriverIO.Element | WdioElem
 }
 
 /**
- * Utility since Array.isArray() does not recognize WebdriverIO.ElementArray as a typed array, but it is an array-like object.
+ * Make isArray typing recognize WebdriverIO.ElementArray since it already works fine at runtime.
  */
 export const isArray = (obj: unknown): obj is unknown[] | WebdriverIO.ElementArray => {
     return Array.isArray(obj)
@@ -49,6 +49,7 @@ export const isElement = (obj: unknown): obj is WebdriverIO.Element => {
 
 /**
  * ElementArray or Element[]
+ * Warning: Element[] must be non-empty!
  */
 export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] => {
     return !!obj && (isStrictlyElementArray(obj) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement)))
@@ -56,6 +57,7 @@ export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArra
 
 /**
  * Element[]
+ * Warning: Element[] must be non-empty!
  */
 export const isArrayOfElement = (obj: unknown): obj is WebdriverIO.Element[] => {
     return Array.isArray(obj) && obj.length > 0 && obj.every(isElement)
@@ -63,6 +65,7 @@ export const isArrayOfElement = (obj: unknown): obj is WebdriverIO.Element[] => 
 
 /**
  * Element, ElementArray or Element[]
+ * Warning: Element[] must be non-empty!
  */
 export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {
     return !!obj && (isElement(obj) || isElementArrayLike(obj))

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -65,7 +65,7 @@ export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementAr
  * @returns
  */
 export const awaitElementOrArray = async(
-    received: WdioElementOrArrayMaybePromise | undefined
+    received: WdioElementOrArrayMaybePromise | PromiseLike<WebdriverIO.Element> | undefined
 ): Promise<{ selector?: WdioElements | WebdriverIO.Element, elements?: WdioElements, element?: WebdriverIO.Element, other?: unknown }> => {
     if (!received || typeof received !== 'object') {
         return { other: received }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -66,7 +66,7 @@ export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementAr
  */
 export const awaitElementOrArray = async(
     received: WdioElementOrArrayMaybePromise | PromiseLike<WebdriverIO.Element> | undefined
-): Promise<{ selector?: WdioElements | WebdriverIO.Element, elements?: WdioElements, element?: WebdriverIO.Element, other?: unknown }> => {
+): Promise<{ selector?: WdioElements | WebdriverIO.Element, elements?: WdioElements, element?: WebdriverIO.Element, other?: unknown, isEmptyElements?: boolean }> => {
     if (!received || typeof received !== 'object') {
         return { other: received }
     }
@@ -91,9 +91,9 @@ export const awaitElementOrArray = async(
     // for `await $$()` or `WebdriverIO.ElementArray` but not `WebdriverIO.Element[]`
     if ('getElements' in awaitedElements) {
         const elements = await awaitedElements.getElements()
-        return { selector: elements, elements }
+        return { selector: elements, elements, isEmptyElements: elements.length === 0 }
     }
 
     // for `WebdriverIO.Element[]`
-    return { selector: awaitedElements, elements: awaitedElements }
+    return { selector: awaitedElements, elements: awaitedElements, isEmptyElements: awaitedElements.length === 0 }
 }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -1,21 +1,22 @@
 import type { WdioElementOrArrayMaybePromise, WdioElements } from '../types.js'
 
 /**
- * if el is an array of elements and actual value is an array
- * wrap expected value with array
- * @param el element
- * @param actual actual result or results array
- * @param expected expected result
+ * Wraps the expected value in an array if both the target element (`el`) and the `actual` value are arrays.
+ *
+ * @param element - The WebdriverIO element, element array, or unknown target being evaluated.
+ * @param actual - The actual result or results array.
+ * @param expected - The expected result to potentially wrap.
+ * @returns An array containing the expected result if conditions are met, otherwise returns the expected result as-is.
  */
-export const wrapExpectedWithArray = <T>(el: WebdriverIO.Element | WdioElements | unknown, actual: unknown, expected: T): T | T[] => {
-    if (Array.isArray(el) && el.length > 1 && Array.isArray(actual)) {
+export const wrapExpectedWithArray = <T>(element: WebdriverIO.Element | WdioElements | unknown, actual: unknown, expected: T): T | T[] => {
+    if (Array.isArray(element) && element.length > 1 && Array.isArray(actual)) {
         return [expected]
     }
     return expected
 }
 
 /**
- * Utility since Array.isArray() does not regonize WebdriverIO.ElementArray as a a typed array, but it is an array-like object.
+ * Utility since Array.isArray() does not recognize WebdriverIO.ElementArray as a typed array, but it is an array-like object.
  */
 export const isArray = (obj: unknown): obj is unknown[] | WebdriverIO.ElementArray => {
     return Array.isArray(obj)
@@ -54,15 +55,25 @@ export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementAr
 }
 
 /**
- * Universaly await element(s) since depending on the type received, it can become complex.
+ * Universally awaits and resolves WebdriverIO element(s) into a standardized object.
  *
- * Using `$()` or `$$()` return a promise as `ChainablePromiseElement/Array` that needs to be awaited and even if chainable.getElement()/getElements() can be done statically, at runtime `'getElement/getElements` in chainable` is false.
- * Using `await $()` still return a `ChainablePromiseElement` but underneath it's a `WebdriverIO.Element/ElementArray` and thus `'getElement/getElements' in element` is true and can be checked and done.
- * With `$$().filter()`, it returns a `Promise<WebdriverIO.Element[]>` that also needs to be awaited.
- * When passing directly a `WebdriverIO.Element` or `WebdriverIO.ElementArray`, no need to await anything and getElement or getElements can be used on it and runtime also works too.
+ * Element resolution can be complex depending on the type received:
+ * - Using `$()` or `$$()` returns a `ChainablePromiseElement` or `ChainablePromiseArray`. These need to be awaited.
+ *   - Even though methods like `.getElement()` can be called statically, at runtime `'getElement'` / `'getElements'` does not exist on the chainable promise itself.
+ * - Using `await $()` resolves to a `WebdriverIO.Element` or `WebdriverIO.ElementArray`, meaning `'getElement'` or `'getElements'` can be safely checked and evaluated at runtime.
+ * - Native promises are also fully supported and properly awaited, including those returned by methods like:
+ *   - `$().getElement()` which evaluates to `Promise<WebdriverIO.Element>`
+ *   - `$$().getElements()` which evaluates to `Promise<WebdriverIO.ElementArray>`
+ *   - `$$().filter()` which evaluates to `Promise<WebdriverIO.Element[]>`
+ * - Directly passing a `WebdriverIO.Element` or `WebdriverIO.ElementArray` requires no awaiting, and runtime methods work immediately.
  *
- * @param received
- * @returns
+ * @param received - The target to resolve. Can be a single WebdriverIO element, an array of elements, a promise evaluating to elements, or an undefined/primitive value.
+ * @returns A promise resolving to an object detailing the state of the element(s):
+ *  - `selector`: The resolved WebdriverIO element or array of elements.
+ *  - `element`: The resolved single `WebdriverIO.Element` (if a single element was passed).
+ *  - `elements`: The resolved array of elements (if an array or ElementArray was passed).
+ *  - `isEmptyElements`: `true` if the resolved array of elements has a length of 0.
+ *  - `other`: Contains the original value if it was a primitive, `undefined`, or not a recognized element/array.
  */
 export const awaitElementOrArray = async(
     received: WdioElementOrArrayMaybePromise | PromiseLike<WebdriverIO.Element> | undefined

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -14,6 +14,13 @@ export const wrapExpectedWithArray = <T>(el: WebdriverIO.Element | WdioElements 
     return expected
 }
 
+/**
+ * Utility since Array.isArray() does not regonize WebdriverIO.ElementArray as a a typed array, but it is an array-like object.
+ */
+export const isArray = (obj: unknown): obj is unknown[] | WebdriverIO.ElementArray => {
+    return Array.isArray(obj)
+}
+
 export const isElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
     return obj !== null && typeof obj === 'object' && 'selector' in obj && 'foundWith' in obj && 'parent' in obj
 }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -49,23 +49,24 @@ export const isElement = (obj: unknown): obj is WebdriverIO.Element => {
 
 /**
  * ElementArray or Element[]
- * Warning: Element[] must be non-empty!
+ * Warning: empty array is considered as Element[] and will return true.
+ *
  */
 export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] => {
-    return !!obj && (isStrictlyElementArray(obj) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement)))
+    return !!obj && (isStrictlyElementArray(obj) || (Array.isArray(obj) && obj.every(isElement)))
 }
 
 /**
  * Element[]
- * Warning: Element[] must be non-empty!
+ * Warning: empty array is considered as Element[] and will return true.
  */
 export const isArrayOfElement = (obj: unknown): obj is WebdriverIO.Element[] => {
-    return Array.isArray(obj) && obj.length > 0 && obj.every(isElement)
+    return Array.isArray(obj) && obj.every(isElement)
 }
 
 /**
  * Element, ElementArray or Element[]
- * Warning: Element[] must be non-empty!
+ * Warning: empty array is considered as Element[] and will return true.
  */
 export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {
     return !!obj && (isElement(obj) || isElementArrayLike(obj))

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -22,32 +22,33 @@ export const isArray = (obj: unknown): obj is unknown[] | WebdriverIO.ElementArr
     return Array.isArray(obj)
 }
 
-export const isElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
-    return obj !== null && typeof obj === 'object' && 'selector' in obj && 'foundWith' in obj && 'parent' in obj
-}
-
 export const isSelector = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element => {
-    return !!obj && typeof obj === 'object'
+    return !!obj
+    && typeof obj === 'object'
     && 'selector' in obj
     && 'parent' in obj // commun with Element
 }
 
-export const isStrictlyElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
+export const isElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
     return isSelector(obj)
+    && 'foundWith' in obj
+}
+
+export const isStrictlyElementArray = (obj: unknown): obj is WebdriverIO.ElementArray => {
+    return isElementArray(obj)
     && Array.isArray(obj)
-    && 'foundWith' in obj // Element does not have foundWith property
     && 'getElements' in obj // specific to ElementArray
 }
 
 export const isElement = (obj: unknown): obj is WebdriverIO.Element => {
-    // Note elementId is only for found element
+    // Note: elementId is only for found element
     return isSelector(obj)
     && !Array.isArray(obj)
     && 'getElement' in obj // specific to Element
 }
 
 export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] => {
-    return (!!obj && isStrictlyElementArray(obj)) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement))
+    return !!obj && (isStrictlyElementArray(obj) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement)))
 }
 
 export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -47,10 +47,23 @@ export const isElement = (obj: unknown): obj is WebdriverIO.Element => {
     && 'getElement' in obj // specific to Element
 }
 
+/**
+ * ElementArray or Element[]
+ */
 export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] => {
     return !!obj && (isStrictlyElementArray(obj) || (Array.isArray(obj) && obj.length > 0 && obj.every(isElement)))
 }
 
+/**
+ * Element[]
+ */
+export const isArrayOfElement = (obj: unknown): obj is WebdriverIO.Element[] => {
+    return Array.isArray(obj) && obj.length > 0 && obj.every(isElement)
+}
+
+/**
+ * Element, ElementArray or Element[]
+ */
 export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {
     return !!obj && (isElement(obj) || isElementArrayLike(obj))
 }

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -43,7 +43,7 @@ export const isElementArrayLike = (obj: unknown): obj is WebdriverIO.ElementArra
 }
 
 export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Element => {
-    return !!obj && isElement(obj) || isElementArrayLike(obj)
+    return !!obj && (isElement(obj) || isElementArrayLike(obj))
 }
 
 /**

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -67,7 +67,7 @@ export const awaitElementOrArray = async(
     let awaitedElements = received
 
     // For non-awaited `$()` or `$$()`, so ChainablePromiseElement | ChainablePromiseArray.
-    // At some extend it also process non-awaited `$().getElement()`, `$$().getElements()` or `$$().filter()`, but typings does not allow it
+    // Extend also to other valid non-awaited case like `$().getElement()`, `$$().getElements()` or `$$().filter()`.
     if (awaitedElements instanceof Promise) {
         awaitedElements = await awaitedElements
     }

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -1,9 +1,9 @@
 import { printDiffOrStringify, printExpected, printReceived } from 'jest-matcher-utils'
 import { equals } from '../jasmineUtils.js'
 import type { WdioElements } from '../types.js'
-import { isElementArray } from './elementsUtil.js'
+import { isArrayOfElement, isElementArray, isElementOrArrayLike } from './elementsUtil.js'
 import { numberMatcherTester } from './numberOptionsUtil.js'
-import { isString, toJsonString } from './stringUtil.js'
+import { toJsonString } from './stringUtil.js'
 
 // TODO one day use a real asymmetric matcher for number options instead of this custom equality tester
 const CUSTOM_EQUALITY_TESTER = [numberMatcherTester]
@@ -17,7 +17,7 @@ export const getSelector = (el: WebdriverIO.Element | WebdriverIO.ElementArray) 
     return result
 }
 
-export const getSelectors = (el: WebdriverIO.Element | WdioElements ) => {
+export const getSelectors = (el: WebdriverIO.Element | WdioElements): string => {
     if (!el || typeof el !== 'object') {
         return ''
     }
@@ -26,9 +26,14 @@ export const getSelectors = (el: WebdriverIO.Element | WdioElements ) => {
     let parent: WebdriverIO.ElementArray['parent'] | undefined
 
     if (isElementArray(el)) {
+        // Type ElementArray
         selectors.push(`${(el).foundWith}(\`${getSelector(el)}\`)`)
         parent = el.parent
-    } else if (!Array.isArray(el)) {
+    } else if (isArrayOfElement(el)) {
+        // Type Element[]
+        return `[${el.map(getSelectors).join(',')}]`
+    } else {
+        // Type Element
         parent = el
     }
 
@@ -58,11 +63,10 @@ export const enhanceError = (
     } = {}): string => {
     const { isNot, useNotInLabel = true } = context
 
-    let subjectStr = isString(subject) ? subject : getSelectors(subject as WebdriverIO.Element | WdioElements)
-    if (!subjectStr) {
-        subjectStr = toJsonString(subject)
+    let subjectStr = (isElementOrArrayLike(subject) ? getSelectors(subject) : toJsonString(subject))
+    if (subjectStr.length > 100) {
+        subjectStr = `${subjectStr.substring(0, 100)}...`
     }
-    subjectStr = subjectStr?.slice(0, 100)
 
     let contain = ''
     if (containing) {

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -17,7 +17,7 @@ export const getSelector = (el: WebdriverIO.Element | WebdriverIO.ElementArray) 
     return result
 }
 
-export const getSelectors = (el: WebdriverIO.Element | WdioElements) => {
+export const getSelectors = (el: WebdriverIO.Element | WdioElements ) => {
     if (!el || typeof el !== 'object') {
         return ''
     }
@@ -46,7 +46,7 @@ export const getSelectors = (el: WebdriverIO.Element | WdioElements) => {
 const not = (isNot: boolean): string => `${isNot ? 'not ' : ''}`
 
 export const enhanceError = (
-    subject: string | WebdriverIO.Element | WdioElements,
+    subject: string | WebdriverIO.Element | WdioElements | unknown,
     expected: unknown,
     actual: unknown,
     context: { isNot: boolean, useNotInLabel?: boolean },
@@ -58,7 +58,7 @@ export const enhanceError = (
     } = {}): string => {
     const { isNot, useNotInLabel = true } = context
 
-    let subjectStr = isString(subject) ? subject : getSelectors(subject)
+    let subjectStr = isString(subject) ? subject : getSelectors(subject as WebdriverIO.Element | WdioElements)
     if (!subjectStr) {
         subjectStr = toJsonString(subject)
     }

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -161,6 +161,14 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(Promise.resolve('text')).toHaveText).toBeNever()
                 expectTypeOf(expect(Promise.resolve('text')).toHaveText).toBeNever()
             })
+
+            it('support edge types case like Promises of ElementArray & Element[]', async () => {
+                const elementArrayPromise: Promise<WebdriverIO.ElementArray> = Promise.resolve([] as unknown as WebdriverIO.ElementArray)
+                const elementsPromise: Promise<WebdriverIO.Element[]> = Promise.resolve([] as unknown as WebdriverIO.Element[])
+
+                expectTypeOf(expect(elementArrayPromise).toHaveText('text')).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(elementsPromise).toHaveText('text')).toEqualTypeOf<Promise<void>>()
+            })
         })
 
         describe('toHaveHeight', () => {

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -171,7 +171,7 @@ describe('globals mock', () => {
             const awaitedEl = await el
             const end = performance.now()
 
-            expect(end - start).toBeGreaterThanOrEqual(1000)
+            expect(Math.round(end - start)).toBeGreaterThanOrEqual(1000)
             expect('getElement' in awaitedEl).toBe(true)
             expect('getText' in awaitedEl).toBe(true)
             expect(await awaitedEl.getText()).toBe(' Valid Text ')

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -499,45 +499,19 @@ Expect ${selectorName} to have text
             expect(result.pass).toBe(false) // should be true?
         })
 
-        test('should fails with proper error message when actual is an empty Element[]', async () => {
-            const result = await thisContext.toHaveText([], 'webdriverio')
-
-            expect(result.pass).toBe(false)
-            expect(stripAnsi(result.message())).toEqual(`\
-Expect [] to have text
-
-Expected: "webdriverio"
-Received: undefined`
-            )
-        })
-
-        test('should fails with proper error message when actual is an empty ElementArray', async () => {
-            const elements = elementArrayFactory('EmptyElementArray', 0)
-
+        test.each([
+            { elements: [] as unknown as WebdriverIO.Element[], name: 'Element[]', selectorName: '[]' },
+            { elements: Promise.resolve([] as WebdriverIO.Element[]), name: 'Promise of Element[]', selectorName: '[]' },
+            { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray', selectorName: '$$(`EmptyElementArray`)' },
+        ])('should fail with proper error message when actual is an empty of $name', async ({ elements, selectorName }) => {
             const result = await thisContext.toHaveText(elements, 'webdriverio')
 
             expect(result.pass).toBe(false)
             expect(stripAnsi(result.message())).toEqual(`\
-Expect $$(\`EmptyElementArray\`) to have text
+Expect ${selectorName} to have text
 
 Expected: "webdriverio"
-Received: undefined`
-            )
-        })
-
-        test.skip.each([
-            { elements: [] as unknown as WebdriverIO.Element[], name: 'Element[]' },
-            { elements: Promise.resolve([] as WebdriverIO.Element[]), name: 'Promise of Element[]' },
-            { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray' },
-        ])('should fail with proper error message when actual is an empty of $name', async ({ elements }) => {
-            const result = await thisContext.toHaveText(elements, 'webdriverio')
-
-            expect(result.pass).toBe(false)
-            expect(stripAnsi(result.message())).toEqual(`\
-Expect ${elements} to have text
-
-Expected: "webdriverio"
-Received: "[]"`)
+Received: undefined`)
         })
 
         // TODO view later to handle this case more gracefully
@@ -555,7 +529,7 @@ Received: "[]"`)
         })
 
         // Throws with wierd and differrent error message!
-        test.skip.for([
+        test.each([
             { actual: undefined, selectorName: 'undefined' },
             { actual: null, selectorName: 'null' },
             { actual: true, selectorName: 'true' },

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -507,6 +507,7 @@ Expect [] to have text
 Expected: "webdriverio"
 Received: undefined`
             )
+        })
 
         // TODO Fix incoming
         test.skip.each([

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -2,7 +2,7 @@ import { $, $$ } from '@wdio/globals'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { toHaveText } from '../../../src/matchers/element/toHaveText.js'
 import type { ChainablePromiseArray } from 'webdriverio'
-import { $Factory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
+import { $Factory, elementArrayFactory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
 
@@ -323,14 +323,15 @@ Received: "This is example text"`
         { elements: await $$('sel').getElements(), title: 'awaited getElements of ChainablePromiseArray (e.g. WebdriverIO.ElementArray)' },
         { elements: await $$('sel').filter((t) => t.isEnabled()), title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])' },
         { elements: $$('sel'), title: 'non-awaited of ChainablePromiseArray' },
+        { elements: $$('sel').getElements(), title: 'non-awaited getElements of ChainablePromiseArray' },
         { elements: $$('sel').filter((t) => t.isEnabled()), title: 'non-awaited filtered ChainablePromiseArray (e.g. Promise<WebdriverIO.Element[]>)' },
     ])('given a multiple elements when $title', ({ elements, title }) => {
-        let els: ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] // | Promise<WebdriverIO.Element[]> TODO fix types to include Promise<WebdriverIO.Element[]> ??
+        let els: ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
         const selectorName = title.includes('WebdriverIO.Element[]') ? '[{"selector":"sel","parent":{},"elementId":"sel"},{"selector":"dev","parent":{},"elementId":"dev"}]': '$$(`sel`)' // Bug to fix where with Element[] selector name is empty
 
         beforeEach(async () => {
-            els = elements as ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] // | Promise<WebdriverIO.Element[]> TODO fix types to include Promise<WebdriverIO.Element[]> ??
+            els = elements as ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
             const awaitedEls = await els
             awaitedEls[0] = await $('sel')
@@ -509,11 +510,10 @@ Received: undefined`
             )
         })
 
-        // TODO Fix incoming
         test.skip.each([
-            { elements: [] satisfies WebdriverIO.Element[], name: 'Element[]' },
-            // { elements: Promise.resolve([]) satisfies Promise<WebdriverIO.Element[]>, name: 'Promise of Element[]' },
-            // { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray' },
+            { elements: [] as unknown as WebdriverIO.Element[], name: 'Element[]' },
+            { elements: Promise.resolve([] as WebdriverIO.Element[]), name: 'Promise of Element[]' },
+            { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray' },
         ])('should fail with proper error message when actual is an empty of $name', async ({ elements }) => {
             const result = await thisContext.toHaveText(elements, 'webdriverio')
 
@@ -573,7 +573,7 @@ Received: undefined`)
 
                     expect(result.pass).toBe(false)
                     expect(stripAnsi(result.message())).toEqual(`\
-Expect {} to have text
+Expect $(\`elements\`) to have text
 
 Expected: "1"
 Received: "0"`)
@@ -602,7 +602,7 @@ Received: "0"`)
 
                     expect(result.pass).toBe(false)
                     expect(stripAnsi(result.message())).toEqual(`\
-Expect {} to have text
+Expect $(\`slowElement\`) to have text
 
 Expected: "Valid Text"
 Received: "Invalid Text"`)

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -328,7 +328,7 @@ Received: "This is example text"`
     ])('given a multiple elements when $title', ({ elements, title }) => {
         let els: ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
-        const selectorName = title.includes('WebdriverIO.Element[]') ? '[{"selector":"sel","parent":{},"elementId":"sel"},{"selector":"dev","parent":{},"elementId":"dev"}]': '$$(`sel`)' // Bug to fix where with Element[] selector name is empty
+        const selectorName = title.includes('WebdriverIO.Element[]') ? '[$(`sel`),$(`dev`)]': '$$(`sel`)'
 
         beforeEach(async () => {
             els = elements as ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -499,11 +499,26 @@ Expect ${selectorName} to have text
             expect(result.pass).toBe(false) // should be true?
         })
 
-        test('should have pass false with proper error message when actual is an empty array of elements', async () => {
+        test('should fails with proper error message when actual is an empty Element[]', async () => {
             const result = await thisContext.toHaveText([], 'webdriverio')
+
             expect(result.pass).toBe(false)
             expect(stripAnsi(result.message())).toEqual(`\
 Expect [] to have text
+
+Expected: "webdriverio"
+Received: undefined`
+            )
+        })
+
+        test('should fails with proper error message when actual is an empty ElementArray', async () => {
+            const elements = elementArrayFactory('EmptyElementArray', 0)
+
+            const result = await thisContext.toHaveText(elements, 'webdriverio')
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`EmptyElementArray\`) to have text
 
 Expected: "webdriverio"
 Received: undefined`

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -21,11 +21,10 @@ describe(toHaveText, async () => {
         { element: await $('sel'), title: 'awaited ChainablePromiseElement' },
         { element: await $('sel').getElement(), title: 'awaited getElement of ChainablePromiseElement (e.g. WebdriverIO.Element)' },
         { element: $('sel'), title: 'non-awaited of ChainablePromiseElement' }
-    ])('given a single element when $title', ({ element, title }) => {
+    ])('given a single element when $title', ({ element }) => {
         let el: ChainablePromiseElement | WebdriverIO.Element
 
-        let selectorName = '$(`sel`)'
-        if (title.includes('non-awaited')) {selectorName = '{}'} // Bug to fix
+        const selectorName = '$(`sel`)'
 
         beforeEach(async () => {
             el = element
@@ -323,18 +322,15 @@ Received: "This is example text"`
         { elements: await $$('sel'), title: 'awaited ChainablePromiseArray' },
         { elements: await $$('sel').getElements(), title: 'awaited getElements of ChainablePromiseArray (e.g. WebdriverIO.ElementArray)' },
         { elements: await $$('sel').filter((t) => t.isEnabled()), title: 'awaited filtered ChainablePromiseArray (e.g. WebdriverIO.Element[])' },
-
-        // Bug that will be fixed later with $$ support. Throws `Error: Can't call "getText" on element with selector "label", it is not a function`
-        // { elements: $$('sel'), title: 'non-awaited of ChainablePromiseArray' }
-        // { elements: $$('sel').filter((t) => t.isEnabled()), title: 'non-awaited filtered ChainablePromiseArray' },
-
+        { elements: $$('sel'), title: 'non-awaited of ChainablePromiseArray' },
+        { elements: $$('sel').filter((t) => t.isEnabled()), title: 'non-awaited filtered ChainablePromiseArray (e.g. Promise<WebdriverIO.Element[]>)' },
     ])('given a multiple elements when $title', ({ elements, title }) => {
-        let els: ChainablePromiseArray | WebdriverIO.ElementArray //| WebdriverIO.Element[] // Bug that will be fixed later with $$ support
+        let els: ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] // | Promise<WebdriverIO.Element[]> TODO fix types to include Promise<WebdriverIO.Element[]> ??
 
         const selectorName = title.includes('WebdriverIO.Element[]') ? '[{"selector":"sel","parent":{},"elementId":"sel"},{"selector":"dev","parent":{},"elementId":"dev"}]': '$$(`sel`)' // Bug to fix where with Element[] selector name is empty
 
         beforeEach(async () => {
-            els = elements as ChainablePromiseArray | WebdriverIO.ElementArray // casting, bug that will be fixed later with $$ support
+            els = elements as ChainablePromiseArray | WebdriverIO.ElementArray | WebdriverIO.Element[] // | Promise<WebdriverIO.Element[]> TODO fix types to include Promise<WebdriverIO.Element[]> ??
 
             const awaitedEls = await els
             awaitedEls[0] = await $('sel')
@@ -492,6 +488,7 @@ Expect ${selectorName} to have text
     })
 
     describe('Edge cases', () => {
+
         // TODO is this a bug? to fix?
         test('given exact text but with space in it should work by default', async () => {
             const element = $('sel')
@@ -500,6 +497,16 @@ Expect ${selectorName} to have text
 
             expect(result.pass).toBe(false) // should be true?
         })
+
+        test('should have pass false with proper error message when actual is an empty array of elements', async () => {
+            const result = await thisContext.toHaveText([], 'webdriverio')
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect [] to have text
+
+Expected: "webdriverio"
+Received: undefined`
+            )
 
         // TODO Fix incoming
         test.skip.each([

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -326,6 +326,8 @@ Received: "This is example text"`
 
         // Bug that will be fixed later with $$ support. Throws `Error: Can't call "getText" on element with selector "label", it is not a function`
         // { elements: $$('sel'), title: 'non-awaited of ChainablePromiseArray' }
+        // { elements: $$('sel').filter((t) => t.isEnabled()), title: 'non-awaited filtered ChainablePromiseArray' },
+
     ])('given a multiple elements when $title', ({ elements, title }) => {
         let els: ChainablePromiseArray | WebdriverIO.ElementArray //| WebdriverIO.Element[] // Bug that will be fixed later with $$ support
 

--- a/test/softAssertions.test.ts
+++ b/test/softAssertions.test.ts
@@ -90,7 +90,7 @@ describe('Soft Assertions', () => {
             expect(failures.length).toBe(1)
             expect(failures[0].matcherName).toBe('toHaveText')
             expect(failures[0].error.message).toEqual(`\
-Expect {} to have text
+Expect $(\`sel\`) to have text
 
 Expected: "Expected Text"
 Received: "Actual Text"`

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -48,7 +48,11 @@ describe('elementsUtil', () => {
                 const awaitedElements = await awaitElementOrArray(undefined)
 
                 expect(awaitedElements).toEqual({
-                    other: undefined
+                    element: undefined,
+                    elements: undefined,
+                    selector: undefined,
+                    other: undefined,
+                    isEmptyElements: undefined
                 })
             })
 
@@ -56,7 +60,11 @@ describe('elementsUtil', () => {
                 const awaitedElements = await awaitElementOrArray(Promise.resolve(undefined) as any)
 
                 expect(awaitedElements).toEqual({
-                    other: undefined
+                    element: undefined,
+                    elements: undefined,
+                    selector: undefined,
+                    other: undefined,
+                    isEmptyElements: undefined
                 })
             })
 
@@ -67,6 +75,8 @@ describe('elementsUtil', () => {
                 expect(awaitedElements.element).toBeDefined()
                 expect(awaitedElements.element).not.toBeInstanceOf(Promise)
                 expect(awaitedElements.element?.elementId).toEqual('element1')
+                expect(awaitedElements.isEmptyElements).toBe(undefined)
+                expect(awaitedElements.selector).toBeDefined()
             })
 
             test('should return single element when received is an awaited ChainableElement', async () => {
@@ -76,6 +86,8 @@ describe('elementsUtil', () => {
                 expect(awaitedElements.element).toBeDefined()
                 expect(awaitedElements.element).not.toBeInstanceOf(Promise)
                 expect(awaitedElements.element?.elementId).toEqual('element1')
+                expect(awaitedElements.isEmptyElements).toBe(undefined)
+                expect(awaitedElements.selector).toBeDefined()
             })
 
             test('should return single element when received is getElement of non awaited ChainableElement (typing not supported)', async () => {
@@ -85,6 +97,9 @@ describe('elementsUtil', () => {
                 expect(awaitedElements.element).toBeDefined()
                 expect(awaitedElements.element).not.toBeInstanceOf(Promise)
                 expect(awaitedElements.element?.elementId).toEqual('element1')
+                expect(awaitedElements.isEmptyElements).toBe(undefined)
+                expect(awaitedElements.selector).toBeDefined()
+
             })
 
             test('should return single element when received is getElement of an awaited ChainableElement', async () => {
@@ -94,6 +109,8 @@ describe('elementsUtil', () => {
                 expect(awaitedElements.element).toBeDefined()
                 expect(awaitedElements.element).not.toBeInstanceOf(Promise)
                 expect(awaitedElements.element?.elementId).toEqual('element1')
+                expect(awaitedElements.isEmptyElements).toBe(undefined)
+                expect(awaitedElements.selector).toBeDefined()
             })
 
             test('should return single element when received is WebdriverIO.Element', async () => {
@@ -103,18 +120,11 @@ describe('elementsUtil', () => {
                 expect(awaitedElements.element).not.toBeInstanceOf(Promise)
                 expect(awaitedElements.element?.elementId).toEqual('element1')
                 expect(awaitedElements.elements).toBeUndefined()
+                expect(awaitedElements.isEmptyElements).toBe(undefined)
+                expect(awaitedElements.selector).toBeDefined()
+
             })
 
-            test('should return multiple elements when received is WebdriverIO.Element[]', async () => {
-                const elementArray = [elementFactory('element1'), elementFactory('element2')]
-
-                const awaitedElements = await awaitElementOrArray(elementArray)
-
-                expect(awaitedElements.elements).toHaveLength(2)
-                expect(awaitedElements.elements?.[0].selector).toEqual(elementArray[0].selector)
-                expect(awaitedElements.elements?.[1].selector).toEqual(elementArray[1].selector)
-                expect(awaitedElements.element).toBeUndefined()
-            })
         })
 
         describe('given multiple elements', () => {
@@ -132,7 +142,7 @@ describe('elementsUtil', () => {
             })
 
             test('should return multiple elements when received is a non-awaited ChainableElementArray', async () => {
-                const { elements, element } = await awaitElementOrArray(chainableElementArray)
+                const { elements, element, other, isEmptyElements, selector } = await awaitElementOrArray(chainableElementArray)
 
                 expect(elements).toHaveLength(2)
                 expect(elements).toEqual(expect.objectContaining([
@@ -140,10 +150,14 @@ describe('elementsUtil', () => {
                     expect.objectContaining({ selector: element1.selector })
                 ]))
                 expect(element).toBeUndefined()
+                expect(elements).not.toBeInstanceOf(Promise)
+                expect(isEmptyElements).toBe(false)
+                expect(selector).toBeDefined()
+                expect(other).toBeUndefined()
             })
 
             test('should return multiple elements when received is an awaited ChainableElementArray', async () => {
-                const { elements, element } = await awaitElementOrArray(await chainableElementArray)
+                const { elements, element, other, isEmptyElements, selector } = await awaitElementOrArray(await chainableElementArray)
 
                 expect(elements).toHaveLength(2)
                 expect(elements).toEqual(expect.objectContaining([
@@ -151,10 +165,13 @@ describe('elementsUtil', () => {
                     expect.objectContaining({ selector: element1.selector })
                 ]))
                 expect(element).toBeUndefined()
+                expect(isEmptyElements).toBe(false)
+                expect(selector).toBeDefined()
+                expect(other).toBeUndefined()
             })
 
             test('should return multiple elements when received is getElements of non awaited ChainableElement (typing not supported)', async () => {
-                const { elements, element } = await awaitElementOrArray(chainableElementArray.getElements() as any)
+                const { elements, element, other, isEmptyElements, selector } = await awaitElementOrArray(chainableElementArray.getElements() as any)
 
                 expect(elements).toHaveLength(2)
                 expect(elements).toEqual(expect.objectContaining([
@@ -162,35 +179,51 @@ describe('elementsUtil', () => {
                     expect.objectContaining({ selector: element1.selector })
                 ]))
                 expect(element).toBeUndefined()
+                expect(isEmptyElements).toBe(false)
+                expect(selector).toBeDefined()
+                expect(other).toBeUndefined()
             })
 
             test('should return multiple elements when received is getElements of an awaited ChainableElementArray', async () => {
-                const { elements, element } = await awaitElementOrArray(await chainableElementArray.getElements())
+                const { elements, element, other, isEmptyElements, selector } = await awaitElementOrArray(await chainableElementArray.getElements())
+
                 expect(elements).toHaveLength(2)
                 expect(elements).toEqual(expect.objectContaining([
                     expect.objectContaining({ selector: element1.selector }),
                     expect.objectContaining({ selector: element1.selector })
                 ]))
                 expect(element).toBeUndefined()
+                expect(isEmptyElements).toBe(false)
+                expect(selector).toBeDefined()
+                expect(other).toBeUndefined()
+
             })
 
             test('should return multiple elements when received is WebdriverIO.Element[]', async () => {
-                const { elements, element } = await awaitElementOrArray(elementArray)
+                const { elements, element, other, isEmptyElements, selector } = await awaitElementOrArray(elementArray)
                 expect(elements).toHaveLength(2)
                 expect(elements).toEqual(expect.objectContaining([
                     expect.objectContaining({ selector: element1.selector }),
                     expect.objectContaining({ selector: element2.selector })
                 ]))
                 expect(element).toBeUndefined()
+                expect(isEmptyElements).toBe(false)
+                expect(selector).toBeDefined()
+                expect(other).toBeUndefined()
             })
         })
 
         test('should return the same object when not any type related to Elements', async () => {
             const anyOjbect = { foo: 'bar' }
 
-            const { other } = await awaitElementOrArray(anyOjbect as any)
+            const { other, element, elements, isEmptyElements, selector } = await awaitElementOrArray(anyOjbect as any)
 
             expect(other).toBe(anyOjbect)
+            expect(element).toBeUndefined()
+            expect(elements).toBeUndefined()
+            expect(isEmptyElements).toBe(undefined)
+            expect(selector).toBeUndefined()
+
         })
 
     })

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -1,7 +1,7 @@
 import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $, $$ } from '@wdio/globals'
 
-import { awaitElementOrArray, isElement, isElementArrayLike, isElementOrArrayLike, isStrictlyElementArray, wrapExpectedWithArray } from '../../src/util/elementsUtil.js'
+import { awaitElementOrArray, isArray, isElement, isElementArrayLike, isElementOrArrayLike, isStrictlyElementArray, wrapExpectedWithArray } from '../../src/util/elementsUtil.js'
 import { elementFactory, elementArrayFactory, chainableElementArrayFactory, notFoundElementFactory } from '../__mocks__/@wdio/globals.js'
 
 vi.mock('@wdio/globals')
@@ -18,6 +18,17 @@ describe('elementsUtil', () => {
             const els = (await $$('sel')) as unknown as WebdriverIO.ElementArray
             const actual = wrapExpectedWithArray(els, ['Test Actual', 'Test Actual'], 'Test Expected')
             expect(actual).toEqual(['Test Expected'])
+        })
+    })
+
+    describe(isArray, async () => {
+        test.each([
+            { array: [elementFactory('element')], title: 'array of WebdriverIO.Element' },
+            { array: await elementArrayFactory('elements', 0), title: 'array of WebdriverIO.ElementArray' }
+        ])('should return true for $title', (input) => {
+            const result = isArray(input.array)
+
+            expect(result).toBe(true)
         })
     })
 

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -32,8 +32,7 @@ describe('elementsUtil', () => {
         })
     })
 
-    // TODO dprevot to review
-    describe.skip(awaitElementOrArray, () => {
+    describe(awaitElementOrArray, () => {
 
         describe('given single element', () => {
 
@@ -64,45 +63,45 @@ describe('elementsUtil', () => {
             test('should return single element when received is a non-awaited ChainableElement', async () => {
                 const awaitedElements = await awaitElementOrArray(chainableElement)
 
-                expect(awaitedElements).toEqual({
-                    element: expect.objectContaining({ selector: element.selector })
-                })
                 expect(awaitedElements.elements).toBeUndefined()
+                expect(awaitedElements.element).toBeDefined()
+                expect(awaitedElements.element).not.toBeInstanceOf(Promise)
+                expect(awaitedElements.element?.elementId).toEqual('element1')
             })
 
             test('should return single element when received is an awaited ChainableElement', async () => {
                 const awaitedElements = await awaitElementOrArray(await chainableElement)
 
-                expect(awaitedElements).toEqual({
-                    element: expect.objectContaining({ selector: element.selector })
-                })
                 expect(awaitedElements.elements).toBeUndefined()
+                expect(awaitedElements.element).toBeDefined()
+                expect(awaitedElements.element).not.toBeInstanceOf(Promise)
+                expect(awaitedElements.element?.elementId).toEqual('element1')
             })
 
             test('should return single element when received is getElement of non awaited ChainableElement (typing not supported)', async () => {
-                const awaitedElements = await awaitElementOrArray(chainableElement.getElement() as any)
+                const awaitedElements = await awaitElementOrArray(chainableElement.getElement())
 
-                expect(awaitedElements).toEqual({
-                    element: expect.objectContaining({ selector: element.selector })
-                })
                 expect(awaitedElements.elements).toBeUndefined()
+                expect(awaitedElements.element).toBeDefined()
+                expect(awaitedElements.element).not.toBeInstanceOf(Promise)
+                expect(awaitedElements.element?.elementId).toEqual('element1')
             })
 
             test('should return single element when received is getElement of an awaited ChainableElement', async () => {
                 const awaitedElements = await awaitElementOrArray(await chainableElement.getElement())
 
-                expect(awaitedElements).toEqual({
-                    element: expect.objectContaining({ selector: element.selector })
-                })
                 expect(awaitedElements.elements).toBeUndefined()
+                expect(awaitedElements.element).toBeDefined()
+                expect(awaitedElements.element).not.toBeInstanceOf(Promise)
+                expect(awaitedElements.element?.elementId).toEqual('element1')
             })
 
             test('should return single element when received is WebdriverIO.Element', async () => {
                 const awaitedElements = await awaitElementOrArray(element)
 
-                expect(awaitedElements).toEqual({
-                    element: expect.objectContaining({ selector: element.selector })
-                })
+                expect(awaitedElements.element).toBeDefined()
+                expect(awaitedElements.element).not.toBeInstanceOf(Promise)
+                expect(awaitedElements.element?.elementId).toEqual('element1')
                 expect(awaitedElements.elements).toBeUndefined()
             })
 
@@ -111,12 +110,6 @@ describe('elementsUtil', () => {
 
                 const awaitedElements = await awaitElementOrArray(elementArray)
 
-                expect(awaitedElements.elements).toHaveLength(2)
-                expect(awaitedElements).toEqual({
-                    elements: expect.arrayContaining([
-                        expect.objectContaining({ selector: elementArray[0].selector }), expect.objectContaining({ selector: elementArray[1].selector })
-                    ])
-                })
                 expect(awaitedElements.elements).toHaveLength(2)
                 expect(awaitedElements.elements?.[0].selector).toEqual(elementArray[0].selector)
                 expect(awaitedElements.elements?.[1].selector).toEqual(elementArray[1].selector)

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -7,7 +7,7 @@ import { elementFactory, elementArrayFactory, chainableElementArrayFactory, notF
 vi.mock('@wdio/globals')
 
 describe('elementsUtil', () => {
-    describe('wrapExpectedWithArray', () => {
+    describe(wrapExpectedWithArray, () => {
         test('is not array ', async () => {
             const el = (await $('sel')) as unknown as WebdriverIO.Element
             const actual = wrapExpectedWithArray(el, 'Test Actual', 'Test Expected')
@@ -226,6 +226,15 @@ describe('elementsUtil', () => {
 
         })
 
+        test('should return empty array as empty array of Element[]', async () => {
+            const { other, element, elements, isEmptyElements, selector } = await awaitElementOrArray([])
+
+            expect(elements).toEqual([])
+            expect(element).toBeUndefined()
+            expect(other).toBeUndefined()
+            expect(isEmptyElements).toBe(true)
+            expect(selector).toEqual([])
+        })
     })
 
     describe(isStrictlyElementArray, async () => {
@@ -298,7 +307,8 @@ describe('elementsUtil', () => {
             await $$('elements'),
             elementArrayFactory('elements'),
             await chainableElementArrayFactory('elements', 3),
-            [elementFactory('element1'), elementFactory('element2')]
+            [elementFactory('element1'), elementFactory('element2')],
+            []
         ])('should return true for ElementArray or Element[] %s', async (elements) => {
             const isElementArrayResult = isElementArrayLike(elements)
 
@@ -319,7 +329,6 @@ describe('elementsUtil', () => {
             [$('elements')],
             [$$('elements')],
             [await $$('elements')],
-            []
         ])('should return false for non-ElementArray or non-Element[]: %s', async (elements) => {
             const isElementArrayResult = isElementArrayLike(elements)
 
@@ -337,6 +346,7 @@ describe('elementsUtil', () => {
             elementArrayFactory('elements'),
             await chainableElementArrayFactory('elements', 3),
             [elementFactory('element1'), elementFactory('element2')],
+            []
         ])('should return true for Element or ElementArray or Element[]: %s', async (element) => {
             const result = isElementOrArrayLike(element)
 
@@ -357,7 +367,6 @@ describe('elementsUtil', () => {
             [$('elements')],
             [$$('elements')],
             [await $$('elements')],
-            []
         ])('should return false for non-Element and non-ElementArray and non-Element[]: %s', async (element) => {
             const result = isElementOrArrayLike(element)
 

--- a/test/util/elementsUtil.test.ts
+++ b/test/util/elementsUtil.test.ts
@@ -1,7 +1,8 @@
-import { vi, test, describe, expect } from 'vitest'
+import { vi, test, describe, expect, beforeEach } from 'vitest'
 import { $, $$ } from '@wdio/globals'
 
-import { wrapExpectedWithArray } from '../../src/util/elementsUtil.js'
+import { awaitElementOrArray, isElement, isElementArrayLike, isElementOrArrayLike, isStrictlyElementArray, wrapExpectedWithArray } from '../../src/util/elementsUtil.js'
+import { elementFactory, elementArrayFactory, chainableElementArrayFactory, notFoundElementFactory } from '../__mocks__/@wdio/globals.js'
 
 vi.mock('@wdio/globals')
 
@@ -17,6 +18,313 @@ describe('elementsUtil', () => {
             const els = (await $$('sel')) as unknown as WebdriverIO.ElementArray
             const actual = wrapExpectedWithArray(els, ['Test Actual', 'Test Actual'], 'Test Expected')
             expect(actual).toEqual(['Test Expected'])
+        })
+    })
+
+    // TODO dprevot to review
+    describe.skip(awaitElementOrArray, () => {
+
+        describe('given single element', () => {
+
+            let element: WebdriverIO.Element
+            let chainableElement: ChainablePromiseElement
+
+            beforeEach(() => {
+                element = elementFactory('element1')
+                chainableElement = $('element1')
+            })
+
+            test('should return undefined when received is undefined', async () => {
+                const awaitedElements = await awaitElementOrArray(undefined)
+
+                expect(awaitedElements).toEqual({
+                    other: undefined
+                })
+            })
+
+            test('should return undefined when received is Promise of undefined (typing not supported)', async () => {
+                const awaitedElements = await awaitElementOrArray(Promise.resolve(undefined) as any)
+
+                expect(awaitedElements).toEqual({
+                    other: undefined
+                })
+            })
+
+            test('should return single element when received is a non-awaited ChainableElement', async () => {
+                const awaitedElements = await awaitElementOrArray(chainableElement)
+
+                expect(awaitedElements).toEqual({
+                    element: expect.objectContaining({ selector: element.selector })
+                })
+                expect(awaitedElements.elements).toBeUndefined()
+            })
+
+            test('should return single element when received is an awaited ChainableElement', async () => {
+                const awaitedElements = await awaitElementOrArray(await chainableElement)
+
+                expect(awaitedElements).toEqual({
+                    element: expect.objectContaining({ selector: element.selector })
+                })
+                expect(awaitedElements.elements).toBeUndefined()
+            })
+
+            test('should return single element when received is getElement of non awaited ChainableElement (typing not supported)', async () => {
+                const awaitedElements = await awaitElementOrArray(chainableElement.getElement() as any)
+
+                expect(awaitedElements).toEqual({
+                    element: expect.objectContaining({ selector: element.selector })
+                })
+                expect(awaitedElements.elements).toBeUndefined()
+            })
+
+            test('should return single element when received is getElement of an awaited ChainableElement', async () => {
+                const awaitedElements = await awaitElementOrArray(await chainableElement.getElement())
+
+                expect(awaitedElements).toEqual({
+                    element: expect.objectContaining({ selector: element.selector })
+                })
+                expect(awaitedElements.elements).toBeUndefined()
+            })
+
+            test('should return single element when received is WebdriverIO.Element', async () => {
+                const awaitedElements = await awaitElementOrArray(element)
+
+                expect(awaitedElements).toEqual({
+                    element: expect.objectContaining({ selector: element.selector })
+                })
+                expect(awaitedElements.elements).toBeUndefined()
+            })
+
+            test('should return multiple elements when received is WebdriverIO.Element[]', async () => {
+                const elementArray = [elementFactory('element1'), elementFactory('element2')]
+
+                const awaitedElements = await awaitElementOrArray(elementArray)
+
+                expect(awaitedElements.elements).toHaveLength(2)
+                expect(awaitedElements).toEqual({
+                    elements: expect.arrayContaining([
+                        expect.objectContaining({ selector: elementArray[0].selector }), expect.objectContaining({ selector: elementArray[1].selector })
+                    ])
+                })
+                expect(awaitedElements.elements).toHaveLength(2)
+                expect(awaitedElements.elements?.[0].selector).toEqual(elementArray[0].selector)
+                expect(awaitedElements.elements?.[1].selector).toEqual(elementArray[1].selector)
+                expect(awaitedElements.element).toBeUndefined()
+            })
+        })
+
+        describe('given multiple elements', () => {
+
+            let element1: WebdriverIO.Element
+            let element2: WebdriverIO.Element
+            let elementArray: WebdriverIO.Element[]
+            let chainableElementArray: ChainablePromiseArray
+
+            beforeEach(() => {
+                element1 = elementFactory('element1')
+                element2 = elementFactory('element2')
+                elementArray = [element1, element2]
+                chainableElementArray = $$('element1')
+            })
+
+            test('should return multiple elements when received is a non-awaited ChainableElementArray', async () => {
+                const { elements, element } = await awaitElementOrArray(chainableElementArray)
+
+                expect(elements).toHaveLength(2)
+                expect(elements).toEqual(expect.objectContaining([
+                    expect.objectContaining({ selector: element1.selector }),
+                    expect.objectContaining({ selector: element1.selector })
+                ]))
+                expect(element).toBeUndefined()
+            })
+
+            test('should return multiple elements when received is an awaited ChainableElementArray', async () => {
+                const { elements, element } = await awaitElementOrArray(await chainableElementArray)
+
+                expect(elements).toHaveLength(2)
+                expect(elements).toEqual(expect.objectContaining([
+                    expect.objectContaining({ selector: element1.selector }),
+                    expect.objectContaining({ selector: element1.selector })
+                ]))
+                expect(element).toBeUndefined()
+            })
+
+            test('should return multiple elements when received is getElements of non awaited ChainableElement (typing not supported)', async () => {
+                const { elements, element } = await awaitElementOrArray(chainableElementArray.getElements() as any)
+
+                expect(elements).toHaveLength(2)
+                expect(elements).toEqual(expect.objectContaining([
+                    expect.objectContaining({ selector: element1.selector }),
+                    expect.objectContaining({ selector: element1.selector })
+                ]))
+                expect(element).toBeUndefined()
+            })
+
+            test('should return multiple elements when received is getElements of an awaited ChainableElementArray', async () => {
+                const { elements, element } = await awaitElementOrArray(await chainableElementArray.getElements())
+                expect(elements).toHaveLength(2)
+                expect(elements).toEqual(expect.objectContaining([
+                    expect.objectContaining({ selector: element1.selector }),
+                    expect.objectContaining({ selector: element1.selector })
+                ]))
+                expect(element).toBeUndefined()
+            })
+
+            test('should return multiple elements when received is WebdriverIO.Element[]', async () => {
+                const { elements, element } = await awaitElementOrArray(elementArray)
+                expect(elements).toHaveLength(2)
+                expect(elements).toEqual(expect.objectContaining([
+                    expect.objectContaining({ selector: element1.selector }),
+                    expect.objectContaining({ selector: element2.selector })
+                ]))
+                expect(element).toBeUndefined()
+            })
+        })
+
+        test('should return the same object when not any type related to Elements', async () => {
+            const anyOjbect = { foo: 'bar' }
+
+            const { other } = await awaitElementOrArray(anyOjbect as any)
+
+            expect(other).toBe(anyOjbect)
+        })
+
+    })
+
+    describe(isStrictlyElementArray, async () => {
+        test.for([
+            await $$('elements').getElements(),
+            await $$('elements'),
+            elementArrayFactory('elements'),
+            await chainableElementArrayFactory('elements', 3),
+        ])('should return true for ElementArray: %s', async (elements) => {
+            const isElementArrayResult = isStrictlyElementArray(elements)
+
+            expect(elements).toBeDefined()
+            expect(typeof elements).toBe('object')
+            expect(isElementArrayResult).toBe(true)
+        })
+
+        test.for([
+            await $('elements'),
+            await $('elements').getElement(),
+            $$('elements'),
+            $$('elements').getElements(),
+            elementFactory('element'),
+            [elementFactory('element1'), elementFactory('element2')],
+            undefined,
+            null,
+            42,
+            'string',
+            {},
+            Promise.resolve(true),
+            []
+        ])('should return false for non-ElementArray: %s', async (elements) => {
+            const isElementArrayResult = isStrictlyElementArray(elements)
+
+            expect(isElementArrayResult).toBe(false)
+        })
+    })
+
+    describe(isElement, async () => {
+        test.for([
+            await $('element').getElement(),
+            await $('element'),
+            elementFactory('element'),
+            notFoundElementFactory('notFoundElement')
+        ])('should return true for Element: %s', async (element) => {
+            const isElementResult = isElement(element)
+
+            expect(isElementResult).toBe(true)
+        })
+
+        test.for([
+            $$('elements'),
+            $$('elements').getElements(),
+            [elementFactory('element1'), elementFactory('element2')],
+            undefined,
+            null,
+            42,
+            'string',
+            {},
+            Promise.resolve(true)
+        ])('should return false for non-Element: %s', async (element) => {
+            const isElementResult = isElement(element)
+
+            expect(isElementResult).toBe(false)
+        })
+    })
+
+    describe(isElementArrayLike, async () => {
+        test.for([
+            await $$('elements').getElements(),
+            await $$('elements'),
+            elementArrayFactory('elements'),
+            await chainableElementArrayFactory('elements', 3),
+            [elementFactory('element1'), elementFactory('element2')]
+        ])('should return true for ElementArray or Element[] %s', async (elements) => {
+            const isElementArrayResult = isElementArrayLike(elements)
+
+            expect(isElementArrayResult).toBe(true)
+        })
+
+        test.for([
+            await $('elements'),
+            await $('elements').getElement(),
+            $$('elements'),
+            $$('elements').getElements(),
+            undefined,
+            null,
+            42,
+            'string',
+            {},
+            Promise.resolve(true),
+            [$('elements')],
+            [$$('elements')],
+            [await $$('elements')],
+            []
+        ])('should return false for non-ElementArray or non-Element[]: %s', async (elements) => {
+            const isElementArrayResult = isElementArrayLike(elements)
+
+            expect(isElementArrayResult).toBe(false)
+        })
+    })
+
+    describe(isElementOrArrayLike, async () => {
+        test.for([
+            await $('element').getElement(),
+            await $('element'),
+            elementFactory('element'),
+            await $$('elements').getElements(),
+            await $$('elements'),
+            elementArrayFactory('elements'),
+            await chainableElementArrayFactory('elements', 3),
+            [elementFactory('element1'), elementFactory('element2')],
+        ])('should return true for Element or ElementArray or Element[]: %s', async (element) => {
+            const result = isElementOrArrayLike(element)
+
+            expect(result).toBe(true)
+        })
+
+        test.for([
+            $$('elements'),
+            $$('elements').getElements(),
+            $('element'),
+            $('element').getElement(),
+            undefined,
+            null,
+            42,
+            'string',
+            {},
+            Promise.resolve(true),
+            [$('elements')],
+            [$$('elements')],
+            [await $$('elements')],
+            []
+        ])('should return false for non-Element and non-ElementArray and non-Element[]: %s', async (element) => {
+            const result = isElementOrArrayLike(element)
+
+            expect(result).toBe(false)
         })
     })
 })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -498,5 +498,227 @@ Expected: "not displayed"
 Received: "displayed"`)
             })
         })
+
+        describe('given multiple elements', () => {
+            const elements = elementArrayFactory('elements', 2)
+            const elementName = '$$(`elements`)'
+
+            describe('elements when isNot is false', () => {
+                const isNot = false
+                test('all elements failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Actual Value 1', 'Test Actual Value 2']
+
+                    const actualFailureMessage = stripAnsi(enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    ))
+
+                    expect(actualFailureMessage).toEqual(`\
+Expect ${elementName} to have text
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "Test Expected Value 1",
+-   "Test Expected Value 2",
++   "Test Actual Value 1",
++   "Test Actual Value 2",
+  ]`)
+                })
+
+                test('First elements failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Actual Value 1', 'Test Expected Value 2']
+
+                    const actualFailureMessage = stripAnsi(enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    ))
+
+                    expect(actualFailureMessage).toEqual(`\
+Expect ${elementName} to have text
+
+- Expected  - 1
++ Received  + 1
+
+  Array [
+-   "Test Expected Value 1",
++   "Test Actual Value 1",
+    "Test Expected Value 2",
+  ]`)
+                })
+
+                test('Seconds elements failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Expected Value 1', 'Test Actual Value 2']
+
+                    const actualFailureMessage = stripAnsi(enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    ))
+
+                    expect(actualFailureMessage).toEqual(`\
+Expect ${elementName} to have text
+
+- Expected  - 1
++ Received  + 1
+
+  Array [
+    "Test Expected Value 1",
+-   "Test Expected Value 2",
++   "Test Actual Value 2",
+  ]`)
+                })
+            })
+
+            describe('elements when isNot is true', () => {
+                const isNot = true
+                test('all elements failure then all values are highlighted as failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Expected Value 1', 'Test Expected Value 2']
+
+                    const actualFailureMessage = stripAnsi(enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    ))
+
+                    expect(actualFailureMessage).toEqual(`\
+Expect ${elementName} not to have text
+
+Expected [not]: ["Test Expected Value 1", "Test Expected Value 2"]
+Received      : ["Test Expected Value 1", "Test Expected Value 2"]`
+                    )
+                })
+
+                test('First elements failure then only first values are highlighted as failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Expected Value 1', 'Test Actual Value 2']
+
+                    const actualFailureMessage = stripAnsi(enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    ))
+
+                    expect(actualFailureMessage).toEqual(`\
+Expect ${elementName} not to have text
+
+- Expected [not]  - 1
++ Received        + 1
+
+  Array [
+    "Test Expected Value 1",
+-   "Test Expected Value 2",
++   "Test Actual Value 2",
+  ]`
+                    )
+                })
+
+                test('Second elements failure then only second values are highlighted as failure', () => {
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Actual Value 1', 'Test Expected Value 2']
+
+                    const actualFailureMessage = enhanceError(
+                        elements,
+                        expected,
+                        actual,
+                        { isNot },
+                        'have',
+                        'text',
+                    )
+
+                    expect(stripAnsi(actualFailureMessage)).toEqual(`\
+Expect ${elementName} not to have text
+
+- Expected [not]  - 1
++ Received        + 1
+
+  Array [
+-   "Test Expected Value 1",
++   "Test Actual Value 1",
+    "Test Expected Value 2",
+  ]`
+                    )
+
+                })
+            })
+
+            describe('given subject is Element[]', () => {
+                test('should return element selector name inside the array', async () => {
+                    const arrayOfElements = [elementFactory('element1'), elementFactory('element2')]
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Actual Value 1', 'Test Expected Value 2']
+
+                    const actualFailureMessage = enhanceError(
+                        arrayOfElements,
+                        expected,
+                        actual,
+                        { isNot: false },
+                        'have',
+                        'text',
+                    )
+                    expect(stripAnsi(actualFailureMessage)).toEqual(`\
+Expect [$(\`element1\`),$(\`element2\`)] to have text
+
+- Expected  - 1
++ Received  + 1
+
+  Array [
+-   "Test Expected Value 1",
++   "Test Actual Value 1",
+    "Test Expected Value 2",
+  ]`
+                    )
+                })
+
+                test('should return element selector name truncated when array of elements is too long', async () => {
+                    const arrayOfElements = Array(100).fill(null).map((_, index) => elementFactory(`element${index + 1}`))
+                    const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                    const actual = ['Test Actual Value 1', 'Test Expected Value 2']
+
+                    const actualFailureMessage = enhanceError(
+                        arrayOfElements,
+                        expected,
+                        actual,
+                        { isNot: false },
+                        'have',
+                        'text',
+                    )
+                    expect(stripAnsi(actualFailureMessage)).toEqual(`\
+Expect [$(\`element1\`),$(\`element2\`),$(\`element3\`),$(\`element4\`),$(\`element5\`),$(\`element6\`),$(\`element7\`),$... to have text
+
+- Expected  - 1
++ Received  + 1
+
+  Array [
+-   "Test Expected Value 1",
++   "Test Actual Value 1",
+    "Test Expected Value 2",
+  ]`
+                    )
+                })
+            })
+        })
     })
 })

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -37,19 +37,10 @@ type WdioPromiseLike<T = unknown> = PromiseLike<T> | ChainablePromiseElement | C
 type WdioElementOrPromiseLike<T = unknown> = WdioPromiseLike<T> | WebdriverIO.Element
 type ElementPromise = Promise<WebdriverIO.Element>
 type ElementArrayPromise = Promise<WebdriverIO.ElementArray>
+type ArrayOfElementsPromise = Promise<WebdriverIO.Element[]>
 
 /**
- * Only Wdio real promise
- */
-type WdioOnlyPromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray
-
-/**
- * Only wdio real promise or potential promise usage on element or element array or browser
- */
-type WdioOnlyMaybePromiseLike = ElementPromise | ElementArrayPromise | ChainablePromiseElement | ChainablePromiseArray | WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.ElementArray
-
-/**
- * Note we are defining Matchers outside of the namespace as done in jest library until we can make every typing work correctly.
+ * Note we are defining types outside of the namespace as done in jest library until we can make every typing work correctly.
  * Once we have all types working, we could check to bring those back into the `ExpectWebdriverIO` namespace.
  */
 
@@ -58,7 +49,7 @@ type WdioOnlyMaybePromiseLike = ElementPromise | ElementArrayPromise | Chainable
  */
 type ElementOrArrayLike = ElementLike | ElementArrayLike
 type ElementLike = WebdriverIO.Element | ChainablePromiseElement
-type ElementArrayLike = WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[]
+type ElementArrayLike = WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise
 type MockPromise = Promise<WebdriverIO.Mock>
 
 /**


### PR DESCRIPTION
In all matchers, awaiting elements is a flaw in multiple cases. With this centralized function that covers all possible cases, we can be sure which type we are dealing with and thus be more flexible with user input.
- Applied to `toHaveText` matcher
- Extended to `toHaveHTML`, but the bug that $ $ does not support $$ properly is not fixed in this PR.

Already supported:
```ts
// awaited ChainablePromiseArray
const elements: ChainablePromiseArray = await $$('sel')

// awaited getElements of ChainablePromiseArray (e.g. ElementArray):
const elements: WebdriverIO.ElementArray = await $$('sel')

// awaited filtered ChainablePromiseArray (e.g. Element[])
const elements: WebdriverIO.Element[] = await $$('sel').filter((t) => t.isEnabled())
```

Fixed:
```ts
// non-awaited of ChainablePromiseArray
const elements: ChainablePromiseArray = $$('sel')

// non-awaited filtered elements (e.g. Promise<Element[]>):
const elements: Promise<WebdriverIO.Element[]> = $$('sel').filter((t) => t.isEnabled())

// non-awaited getElements (e.g. Promise<ElementArray>):
const elements: Promise<WebdriverIO.Element[]> = $$('sel').getElements()
```

Types were also adjusted to support `Promise<Element[]>` & `Promise<ElementArray>`
