### PR TITLE
chore: Add test simulating element retrieval delay

### DIFF
--- a/test/__mocks__/@wdio/globals.ts
+++ b/test/__mocks__/@wdio/globals.ts
@@ -93,10 +93,8 @@ export const $Factory = (element: WebdriverIO.Element, findDelay = 0): Chainable
 
     // Fake finding time of an element
     if (findDelay > 0) {
-        console.log(`Simulating finding time of ${findDelay}ms for element with selector ${element.selector}`)
         // Wdio framework does return a Promise-wrapped element, so we need to mimic this behavior
         chainablePromiseElement = new Promise<WebdriverIO.Element>((resolve) => {
-            console.log(`Finding element with selector ${element.selector}...`)
             setTimeout(() => resolve(element), findDelay)
         })
     }

--- a/test/__mocks__/@wdio/globals.ts
+++ b/test/__mocks__/@wdio/globals.ts
@@ -87,23 +87,46 @@ export const notFoundElementFactory = (_selector: string, index?: number, parent
     return notFoundElement
 }
 
-const $ = vi.fn((_selector: string) => {
-    const element = elementFactory(_selector)
-
+export const $Factory = (element: WebdriverIO.Element, findDelay = 0): ChainablePromiseElement => {
     // Wdio framework does return a Promise-wrapped element, so we need to mimic this behavior
-    const chainablePromiseElement = Promise.resolve(element) as unknown as ChainablePromiseElement
+    let chainablePromiseElement = Promise.resolve(element)
 
-    // Ensure `'getElement' in chainableElement` is false while allowing to use `await chainableElement.getElement()`
+    // Fake finding time of an element
+    if (findDelay > 0) {
+        console.log(`Simulating finding time of ${findDelay}ms for element with selector ${element.selector}`)
+        // Wdio framework does return a Promise-wrapped element, so we need to mimic this behavior
+        chainablePromiseElement = new Promise<WebdriverIO.Element>((resolve) => {
+            console.log(`Finding element with selector ${element.selector}...`)
+            setTimeout(() => resolve(element), findDelay)
+        })
+    }
+
+    // Ensure `'getElement' in chainableElement` at runtime does not exist while allowing to use `await chainableElement.getElement()`
     const runtimeChainableElement = new Proxy(chainablePromiseElement, {
         get(target, prop) {
             if (prop in element) {
-                return element[prop as keyof WebdriverIO.Element]
+                const originalValue = element[prop as keyof WebdriverIO.Element]
+
+                // 2. Wrap element methods to await the delayed Promise first
+                if (findDelay > 0 && typeof originalValue === 'function') {
+                    return async (...args: any[]) => {
+                        await target // Wait for the delay to finish
+                        return (originalValue as Function).apply(element, args)
+                    }
+                }
+                return originalValue
             }
             const value = Reflect.get(target, prop)
             return typeof value === 'function' ? value.bind(target) : value
         }
     })
-    return runtimeChainableElement
+    return runtimeChainableElement as unknown as ChainablePromiseElement
+}
+
+const $ = vi.fn((_selector: string) => {
+    const element = elementFactory(_selector)
+
+    return $Factory(element)
 })
 
 const $$ = vi.fn((selector: string) => {

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -177,7 +177,7 @@ describe('globals mock', () => {
             expect(await awaitedEl.getText()).toBe(' Valid Text ')
         })
 
-        it("should takes time to await the element's text", async () => {
+        it("should take time to await the element's text", async () => {
             const el = $Factory(elementFactory('foo'), 1000)
 
             expect(el).toBeInstanceOf(Promise)

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -170,10 +170,10 @@ describe('globals mock', () => {
             const start = performance.now()
             const awaitedEl = await el
             const end = performance.now()
+
             expect(end - start).toBeGreaterThanOrEqual(1000)
             expect('getElement' in awaitedEl).toBe(true)
             expect('getText' in awaitedEl).toBe(true)
-
             expect(await awaitedEl.getText()).toBe(' Valid Text ')
         })
 
@@ -187,8 +187,8 @@ describe('globals mock', () => {
             const start = performance.now()
             const text = await el.getText()
             const end = performance.now()
-            expect(end - start).toBeGreaterThanOrEqual(1000)
 
+            expect(end - start).toBeGreaterThanOrEqual(1000)
             expect(text).toBe(' Valid Text ')
         })
     })

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -160,7 +160,7 @@ describe('globals mock', () => {
     })
 
     describe('$Factory', () => {
-        it('should takes time to await the element', async () => {
+        it('should take time to await the element', async () => {
             const el = $Factory(elementFactory('foo'), 1000)
 
             expect(el).toBeInstanceOf(Promise)

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { $, $$ } from '@wdio/globals'
-import { notFoundElementFactory } from './__mocks__/@wdio/globals.js'
+import { $Factory, elementFactory, notFoundElementFactory } from './__mocks__/@wdio/globals.js'
 
 vi.mock('@wdio/globals')
 
@@ -156,6 +156,40 @@ describe('globals mock', () => {
         it('should throw error when awaiting a method call (sync throw)', async () => {
             const el = notFoundElementFactory('not-found')
             expect(() => el.getText()).toThrow("Can't call getText on element with selector not-found because element wasn't found")
+        })
+    })
+
+    describe('$Factory', () => {
+        it('should takes time to await the element', async () => {
+            const el = $Factory(elementFactory('foo'), 1000)
+
+            expect(el).toBeInstanceOf(Promise)
+            expect('getElement' in el).toBe(false)
+            expect('getText' in el).toBe(false)
+
+            const start = performance.now()
+            const awaitedEl = await el
+            const end = performance.now()
+            expect(end - start).toBeGreaterThanOrEqual(1000)
+            expect('getElement' in awaitedEl).toBe(true)
+            expect('getText' in awaitedEl).toBe(true)
+
+            expect(await awaitedEl.getText()).toBe(' Valid Text ')
+        })
+
+        it("should takes time to await the element's text", async () => {
+            const el = $Factory(elementFactory('foo'), 1000)
+
+            expect(el).toBeInstanceOf(Promise)
+            expect('getElement' in el).toBe(false)
+            expect('getText' in el).toBe(false)
+
+            const start = performance.now()
+            const text = await el.getText()
+            const end = performance.now()
+            expect(end - start).toBeGreaterThanOrEqual(1000)
+
+            expect(text).toBe(' Valid Text ')
         })
     })
 })

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -2,7 +2,7 @@ import { $, $$ } from '@wdio/globals'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { toHaveText } from '../../../src/matchers/element/toHaveText.js'
 import type { ChainablePromiseArray } from 'webdriverio'
-import { notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
+import { $Factory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
 
@@ -490,11 +490,29 @@ Expect ${selectorName} to have text
     })
 
     describe('Edge cases', () => {
-        test('should have pass false with proper error message when actual is an empty array of elements', async () => {
-            // @ts-ignore
-            const result = await thisContext.toHaveText([], 'webdriverio')
+        // TODO is this a bug? to fix?
+        test('given exact text but with space in it should work by default', async () => {
+            const element = $('sel')
 
-            expect(result.pass).toBe(true)
+            const result = await thisContext.toHaveText(element, ' Valid Text ')
+
+            expect(result.pass).toBe(false) // should be true?
+        })
+
+        // TODO Fix incoming
+        test.skip.each([
+            { elements: [] satisfies WebdriverIO.Element[], name: 'Element[]' },
+            // { elements: Promise.resolve([]) satisfies Promise<WebdriverIO.Element[]>, name: 'Promise of Element[]' },
+            // { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray' },
+        ])('should fail with proper error message when actual is an empty of $name', async ({ elements }) => {
+            const result = await thisContext.toHaveText(elements, 'webdriverio')
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect ${elements} to have text
+
+Expected: "webdriverio"
+Received: "[]"`)
         })
 
         // TODO view later to handle this case more gracefully
@@ -530,6 +548,69 @@ Expect ${selectorName} to have text
 
 Expected: "webdriverio"
 Received: undefined`)
+        })
+
+        describe('Long promises', () => {
+
+            describe("given element's text takes more time then the configured wait to be retrieved", () => {
+
+                test('given element text takes more time then the configured wait then it should fail', async () => {
+                    const element: ChainablePromiseElement = $('elements')
+                    vi.mocked((await element).getText).mockImplementationOnce(() => new Promise((resolve) => setTimeout(() => resolve('0'), 500)))
+                        .mockImplementationOnce(() => new Promise((resolve) => setTimeout(() => resolve('1'), 500)))
+
+                    const result = await thisContext.toHaveText(element, '1', { wait: 1, interval: 1 })
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect {} to have text
+
+Expected: "1"
+Received: "0"`)
+                })
+            })
+
+            describe('given element itself takes more time then the configured wait to be retrieved', () => {
+
+                test('given element take time to be found, and first getText match then it should work', async () => {
+                    const element: ChainablePromiseElement = $Factory(elementFactory('slowElement'), 500)
+
+                    const result = await thisContext.toHaveText(element, 'Valid Text', { wait: 250, interval: 100 })
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('given element take time to be found, and match only on second getText try then it should fails when using non-awaited version', async () => {
+                    const element = elementFactory('slowElement')
+                    element.getText = vi.fn()
+                        .mockResolvedValueOnce('Invalid Text')
+                        .mockResolvedValueOnce('Valid Text')
+
+                    const nonAwaitedElement: ChainablePromiseElement = $Factory(element, 500)
+
+                    const result = await thisContext.toHaveText(nonAwaitedElement, 'Valid Text', { wait: 250, interval: 100 })
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect {} to have text
+
+Expected: "Valid Text"
+Received: "Invalid Text"`)
+                })
+
+                test('given element take time to be found, but match only on second try then it should succeeds when using awaited version', async () => {
+                    const element = elementFactory('slowElement')
+                    element.getText = vi.fn()
+                        .mockResolvedValueOnce('Invalid Text')
+                        .mockResolvedValueOnce('Valid Text')
+
+                    const awaitedElement: ChainablePromiseElement = await $Factory(element, 500)
+
+                    const result = await thisContext.toHaveText(awaitedElement, 'Valid Text', { wait: 250, interval: 100 })
+
+                    expect(result.pass).toBe(true)
+                })
+            })
         })
     })
 })


### PR DESCRIPTION
Add tests around element retreival before changing the mechanism