### PR TITLE
feat: Use clear asymmetrics any & anything for existence checks on `toHaveElementProperty`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -402,6 +402,8 @@ const elem = await $('#elem')
 await expect(elem).toHaveElementProperty('height')
 // Does not have height property
 await expect(elem).not.toHaveElementProperty('height')
+// With options
+await expect(elem).not.toHaveElementProperty('height', expect.anything(), { wait : 1 })
 ```
 
 ### toHaveValue

--- a/docs/API.md
+++ b/docs/API.md
@@ -400,6 +400,9 @@ Checks if an element has a certain property.
 ```js
 const elem = await $('#elem')
 await expect(elem).toHaveElementProperty('height')
+// With options
+await expect(elem).toHaveElementProperty('height', expect.anything(), { wait : 1 })
+
 // Does not have height property
 await expect(elem).not.toHaveElementProperty('height')
 // With options

--- a/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/expect-wdioImport/wdio-matchers.test.ts
@@ -115,6 +115,25 @@ describe('WebdriverIO Custom Matchers', () => {
         it('should verify element property', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementProperty('type', 'button')
+            await expect(searchButton).toHaveElementProperty('type')
+        })
+
+        it('should verify element property does not exists', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', 'button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent')
+        })
+
+        it('should verify element property with anything', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).toHaveElementProperty('type', jasmine.anything(),  { wait : 0 })
+            await expect(searchButton).toHaveElementProperty('type', jasmine.anything(),  { wait : 0 })
+        })
+
+        it('should verify element property does not exists with wait option', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', 'button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', jasmine.anything(),  { wait : 0 })
         })
     })
 

--- a/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
@@ -109,6 +109,25 @@ describe('WebdriverIO Custom Matchers', () => {
         it('should verify element property', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toHaveElementProperty('type', 'button')
+            await expect(searchButton).toHaveElementProperty('type')
+        })
+
+        it('should verify element property does not exists', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', 'button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent')
+        })
+
+        it('should verify element property with anything', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).toHaveElementProperty('type', jasmine.anything(),  { wait : 0 })
+            await expect(searchButton).toHaveElementProperty('type', jasmine.anything(),  { wait : 0 })
+        })
+
+        it('should verify element property does not exists with wait option', async () => {
+            const searchButton = await $('.DocSearch-Button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', 'button')
+            await expect(searchButton).not.toHaveElementProperty('non-existent', jasmine.anything(),  { wait : 0 })
         })
     })
 

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -390,7 +390,7 @@ describe('WebdriverIO Custom Matchers', () => {
 
         it('should verify that element property exists immediately', async () => {
             const searchButton = await $('.DocSearch-Button')
-            await expect(searchButton).toHaveElementProperty('type', { wait: 0 })
+            await expect(searchButton).toHaveElementProperty('type', expect.anything(), { wait: 0 })
         })
 
         it('should verify that element property does not exist', async () => {
@@ -400,7 +400,7 @@ describe('WebdriverIO Custom Matchers', () => {
 
         it('should verify that element property does not exist immediately', async () => {
             const searchButton = await $('.DocSearch-Button')
-            await expect(searchButton).not.toHaveElementProperty('doesNNotExist', { wait: 0 })
+            await expect(searchButton).not.toHaveElementProperty('doesNNotExist', expect.anything(), { wait: 0 })
         })
     })
 

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -2,7 +2,7 @@ import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { MaybeArray, WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
-import { isStringOptions } from '../../util/commandOptionsUtils.js'
+import { expect } from 'expect'
 import {
     compareText,
     enhanceError,
@@ -26,11 +26,6 @@ async function condition(
         return { result: false, value: propertyValue }
     }
 
-    // As specified in the w3c spec, cases where property simply exists
-    if (expectedValue === null || expectedValue === undefined) {
-        return { result: true, value: propertyValue }
-    }
-
     if (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString) {
         return { result: propertyValue === expectedValue, value: propertyValue }
     }
@@ -40,22 +35,24 @@ async function condition(
 }
 
 /**
- * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveElementProperty(el, property, options)`.
- */
-export async function toHaveElementProperty(
-    received: WdioElementMaybePromise,
-    property: string,
-    value: undefined | null,
-    options?: ExpectWebdriverIO.StringOptions
-): Promise<AssertionResult>
-
-/**
- * Element or Elements
- * When called with only the property name (and optional configuration options) on a single element or collection.
+ * Elements $() or elements $$()
+ * When called with an expected property name to verify if the property exists on a collection of elements.
+ * Same as `toHaveElementProperty(el, property, expect.anything())`.
  */
 export async function toHaveElementProperty(
     received: WdioElementOrArrayMaybePromise,
     property: string,
+): Promise<AssertionResult>
+
+/**
+ * @deprecated since 6.0.0, remove in v10.0.0.
+ * Passing explicit `undefined` or `null` as a value is deprecated.
+ * Omit the third argument entirely or use `toHaveElementProperty(el, property, object.anything(), options)`.
+ */
+export async function toHaveElementProperty(
+    received: WdioElementOrArrayMaybePromise,
+    property: string,
+    value: undefined | null,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -66,7 +63,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementsMaybePromise,
     property: string,
-    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string>>,
+    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -77,7 +74,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value: string | number | RegExp | AsymmetricMatcher<string>,
+    value: string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -85,18 +82,19 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementOrArrayMaybePromise,
     property: string,
-    valueOrOptions?: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | null> | ExpectWebdriverIO.StringOptions,
+    value?: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | null | undefined,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'property', verb = 'have', isNot, matcherName = 'toHaveElementProperty' } = this
-    let value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | null> | undefined
 
-    // Determine if the third argument is actually options or the expected value
-    if (isStringOptions(valueOrOptions)) {
-        options = valueOrOptions
-        value = undefined
-    } else {
-        value = valueOrOptions
+    const paramsCount = arguments.length
+
+    if (value === undefined || value === null) {
+        if (paramsCount > 2) {
+            // User have passed an explicit undefined or null value, which is deprecated. We will log a warning to inform the user about this deprecation.
+            console.log('Using undefined or null as value for toHaveElementProperty is deprecated and will be removed in v6.0.0. Please omit the third argument entirely or use toHaveElementProperty(el, property, object.anything(), options).')
+        }
+        value = expect.anything()
     }
 
     await options.beforeAssertion?.({

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -10,7 +10,6 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
-import { fillSingleExpectedForElementArray } from '../../util/elementsUtil.js'
 
 async function condition(
     el: WebdriverIO.Element,
@@ -22,12 +21,7 @@ async function condition(
 
     const propertyValue = await el.getProperty(property)
 
-    // As specified in the w3c spec, cases where property does not exist so returning false
-    if (propertyValue === null || propertyValue === undefined) {
-        return { result: false, value: propertyValue }
-    }
-
-    if (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString) {
+    if (propertyValue === null || propertyValue === undefined || (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString)) {
         if (isAsymmetricMatcher(expectedValue)) {
             return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
         }
@@ -67,7 +61,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementsMaybePromise,
     property: string,
-    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
+    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null | undefined>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -131,16 +125,8 @@ export async function toHaveElementProperty(
         { wait: options.wait, interval: options.interval }
     )
 
-    let message: string
-    // TODO: review to handle null/undefined inside array of expected values, for now we will just handle the case where the expected value is undefined or null
-    if (value === undefined) {
-        const expected = fillSingleExpectedForElementArray(elements, '`a defined value`')
-        const actual = actualProppertyValue
-        message = enhanceError(elements, expected, actual, this, verb, expectation, property, options)
-    } else {
-        const expected = wrapExpectedWithArray(elements, actualProppertyValue, value)
-        message = enhanceError(elements, expected, actualProppertyValue, this, verb, expectation, property, options)
-    }
+    const expected = wrapExpectedWithArray(elements, actualProppertyValue, value)
+    const message = enhanceError(elements, expected, actualProppertyValue, this, verb, expectation, property, options)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -2,7 +2,7 @@ import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { MaybeArray, WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
-import { expect } from 'expect'
+import { expect as wdioExpect } from '../../index.js'
 import {
     compareText,
     enhanceError,
@@ -92,7 +92,7 @@ export async function toHaveElementProperty(
             // User have passed an explicit undefined or null value, which is deprecated. We will log a warning to inform the user about this deprecation.
             console.log('Using undefined or null as value for toHaveElementProperty is deprecated and will be removed in v6.0.0. Please omit the third argument entirely or use toHaveElementProperty(el, property, object.anything(), options).')
         }
-        value = expect.anything()
+        value = wdioExpect.anything()
     }
 
     await options.beforeAssertion?.({

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -29,7 +29,7 @@ async function condition(
     }
 
     // To review the cast to be more type safe but for now let's keep the existing behavior to ensure no regression
-    return compareText(propertyValue.toString(), expectedValue as string | RegExp | AsymmetricMatcher<string>, options)
+    return compareText(propertyValue.toString(), expectedValue as string | RegExp | AsymmetricMatcher<string> | null | undefined, options)
 }
 
 /**

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -6,6 +6,7 @@ import { expect } from 'expect'
 import {
     compareText,
     enhanceError,
+    isAsymmetricMatcher,
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
@@ -21,12 +22,15 @@ async function condition(
 
     const propertyValue = await el.getProperty(property)
 
-    // As specified in the w3c spec, cases where property does not exist
+    // As specified in the w3c spec, cases where property does not exist so returning false
     if (propertyValue === null || propertyValue === undefined) {
         return { result: false, value: propertyValue }
     }
 
     if (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString) {
+        if (isAsymmetricMatcher(expectedValue)) {
+            return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
+        }
         return { result: propertyValue === expectedValue, value: propertyValue }
     }
 

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -4,6 +4,7 @@ import type { WdioElements } from '../types.js'
 import { isArrayOfElement, isElementArrayLike, isElementOrArrayLike, isStrictlyElementArray } from './elementsUtil.js'
 import { numberMatcherTester } from './numberOptionsUtil.js'
 import { toJsonString } from './stringUtil.js'
+import { isJasmineStringAsymmetricMatcher } from '../utils.js'
 
 // TODO one day use a real asymmetric matcher for number options instead of this custom equality tester
 const CUSTOM_EQUALITY_TESTER = [numberMatcherTester]
@@ -86,6 +87,13 @@ export const enhanceError = (
     }
 
     let diffString = ''
+
+    if (isJasmineStringAsymmetricMatcher(expected)) {
+        // With Jest's expect asymetric matcher, it uses a pretty-format plugin for asymetric matcher, but Jasmine's asymmetric matcher doesn't have that!
+        expected = expected.jasmineToString()
+    } else if (isElementOrArrayLike(subject) && Array.isArray(expected)) {
+        expected = expected.map(item => isJasmineStringAsymmetricMatcher(item) ? item.jasmineToString() : item)
+    }
 
     // Special formatting for .not with arrays to highlight what matched
     if (isNotInLabel && isElementOrArrayLike(subject) && Array.isArray(expected) && Array.isArray(actual) && expected.length === actual.length) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ import { waitUntil } from './util/waitUntil.js'
 import { DEFAULT_FEATURE_FLAGS } from './constants.js'
 
 export function isJasmineStringAsymmetricMatcher<T>(expected: unknown): expected is JasmineAsymmetricMatcher<T> {
-    return isAsymmetricMatcher(expected) && 'expected' in expected
+    return isAsymmetricMatcher(expected) && 'jasmineToString' in expected && typeof expected.jasmineToString === 'function'
 }
 
 export function isAsymmetricMatcher<T>(expected: unknown): expected is WdioAsymmetricMatcher<T> | JasmineAsymmetricMatcher<T> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export const compareTextOrArray = (
 
 export const compareText = (
     actual: string,
-    expected: string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string>,
+    expected: string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string> | null | undefined,
     {
         ignoreCase = false,
         trim = true,
@@ -164,7 +164,7 @@ export const compareText = (
         replace,
     }: ExpectWebdriverIO.StringOptions
 ): CompareResult<string> => {
-    if (typeof actual !== 'string') {
+    if (typeof actual !== 'string' || expected === null || expected === undefined) {
         return {
             value: actual,
             result: false,
@@ -206,28 +206,28 @@ export const compareText = (
     if (containing) {
         return {
             value: actual,
-            result: actual.includes(expected),
+            result: actual.includes(expected.toString()),
         }
     }
 
     if (atStart) {
         return {
             value: actual,
-            result: actual.startsWith(expected),
+            result: actual.startsWith(expected.toString()),
         }
     }
 
     if (atEnd) {
         return {
             value: actual,
-            result: actual.endsWith(expected),
+            result: actual.endsWith(expected.toString()),
         }
     }
 
     if (atIndex) {
         return {
             value: actual,
-            result: actual.substring(atIndex, actual.length).startsWith(expected),
+            result: actual.substring(atIndex, actual.length).startsWith(expected.toString()),
         }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -206,28 +206,28 @@ export const compareText = (
     if (containing) {
         return {
             value: actual,
-            result: actual.includes(expected.toString()),
+            result: actual.includes(expected),
         }
     }
 
     if (atStart) {
         return {
             value: actual,
-            result: actual.startsWith(expected.toString()),
+            result: actual.startsWith(expected),
         }
     }
 
     if (atEnd) {
         return {
             value: actual,
-            result: actual.endsWith(expected.toString()),
+            result: actual.endsWith(expected),
         }
     }
 
     if (atIndex) {
         return {
             value: actual,
-            result: actual.substring(atIndex, actual.length).startsWith(expected.toString()),
+            result: actual.substring(atIndex, actual.length).startsWith(expected),
         }
     }
 

--- a/test-types/jasmine-global-expect-async/jasmine-expect-global.test-d.ts
+++ b/test-types/jasmine-global-expect-async/jasmine-expect-global.test-d.ts
@@ -8,6 +8,7 @@ describe('Jasmine global type augmentations under `wdio/jasmine-framework`', () 
     const element: WebdriverIO.Element = {} as unknown as WebdriverIO.Element
     const elementArray: WebdriverIO.ElementArray = [] as unknown as WebdriverIO.ElementArray
     const browser: WebdriverIO.Browser = {} as unknown as WebdriverIO.Browser
+    const elements: WebdriverIO.Element[] = [] as unknown as WebdriverIO.Element[]
 
     const networkMock: WebdriverIO.Mock = {} as unknown as WebdriverIO.Mock
 
@@ -68,7 +69,7 @@ describe('Jasmine global type augmentations under `wdio/jasmine-framework`', () 
             })
         })
 
-        describe('element', () => {
+        describe('element or elements', () => {
 
             describe('toBeDisabled', () => {
                 it('should return Promise<void>', async () => {
@@ -232,6 +233,64 @@ describe('Jasmine global type augmentations under `wdio/jasmine-framework`', () 
                 it('should not work when actual is not chainableArray', async () => {
                     expectTypeOf(expect(chainableElement).toBeElementsArrayOfSize).toBeNever()
                     expectTypeOf(expect(true).toBeElementsArrayOfSize).toBeNever()
+                })
+            })
+
+            describe('toHaveElementProperty', () => {
+                describe('given element', () => {
+                    it('should return Promise<void> with element', async () => {
+                        expectTypeOf(expect(element).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
+
+                        expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).not.toHaveElementProperty('prop', 'val')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).not.toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                    })
+
+                    it('should be deprecated', async () => {
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                    })
+
+                    it('should have ts errors but to support one day???', async () => {
+                    // @ts-expect-error
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', ['test'])).toEqualTypeOf<Promise<void>>()
+                        // @ts-expect-error
+                        expectTypeOf(expect(element).toHaveElementProperty('prop', {})).toEqualTypeOf<Promise<void>>()
+                    })
+                })
+
+                describe('given elements', () => {
+                    it('should return Promise<void> with elements', async () => {
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
+
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', ['val'])).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.anything(), expect.any(Number), 'value', expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                    })
+
+                    it('should not be supported (never)', async () => {
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                    })
+
+                    it('should have ts errors but to support one day???', async () => {
+                    // @ts-expect-error
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', [[]])).toEqualTypeOf<Promise<void>>()
+                        // @ts-expect-error
+                        expectTypeOf(expect(elements).toHaveElementProperty('prop', [{}])).toEqualTypeOf<Promise<void>>()
+                    })
                 })
             })
         })

--- a/test-types/jasmine/jasmine.test-d.ts
+++ b/test-types/jasmine/jasmine.test-d.ts
@@ -8,6 +8,7 @@ describe('Jasmine type agumentations', () => {
 
     const element: WebdriverIO.Element = {} as unknown as WebdriverIO.Element
     const elementArray: WebdriverIO.ElementArray = [] as unknown as WebdriverIO.ElementArray
+    const elements: WebdriverIO.Element[] = [] as unknown as WebdriverIO.Element[]
     const browser: WebdriverIO.Browser = {} as unknown as WebdriverIO.Browser
 
     const networkMock: WebdriverIO.Mock = {} as unknown as WebdriverIO.Mock
@@ -69,7 +70,7 @@ describe('Jasmine type agumentations', () => {
             })
         })
 
-        describe('element', () => {
+        describe('element or elements', () => {
 
             describe('toBeDisabled', () => {
                 it('should return Promise<void>', async () => {
@@ -233,6 +234,50 @@ describe('Jasmine type agumentations', () => {
                 it('should not work when actual is not chainableArray', async () => {
                     expectTypeOf(expectAsync(chainableElement).toBeElementsArrayOfSize).toBeNever()
                     expectTypeOf(expectAsync(true).toBeElementsArrayOfSize).toBeNever()
+                })
+            })
+
+            describe('toHaveElementProperty', () => {
+                describe('given element', () => {
+                    it('should return Promise<void> with element', async () => {
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', jasmine.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', jasmine.anything())).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', jasmine.any(Number))).toEqualTypeOf<Promise<void>>()
+
+                        expectTypeOf(expectAsync(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).not.toHaveElementProperty('prop', 'val')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).not.toHaveElementProperty('prop', jasmine.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                    })
+
+                    it('should be deprecated', async () => {
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                    })
+                })
+
+                describe('given elements', () => {
+                    it('should return Promise<void> with elements', async () => {
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', jasmine.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', jasmine.anything())).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', jasmine.any(Number))).toEqualTypeOf<Promise<void>>()
+
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', ['val'])).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', [jasmine.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', [jasmine.anything(), jasmine.any(Number), 'value', jasmine.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                    })
+
+                    it('should not be supported (never)', async () => {
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                        expectTypeOf(expectAsync(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                    })
                 })
             })
         })

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -753,19 +753,61 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             })
         })
 
-        describe('Property Matchers', () => {
-            it('should return Promise<void>', async () => {
-                expectTypeOf(expect(element).toHaveValue('val')).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveValue(expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+        describe('toHaveElementProperty', () => {
+            describe('given element', () => {
+                it('should return Promise<void> with element', async () => {
+                    expectTypeOf(expect(element).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
 
-                expectTypeOf(expect(element).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveElementProperty('prop', 'val')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).not.toHaveElementProperty('prop', 'val')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).not.toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                })
 
-                expectTypeOf(expect(element).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                it('should be deprecated', async () => {
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                })
 
-                // Deprecated matchers
-                expectTypeOf(expect(element).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<void>>()
+                it('should have ts errors but to support one day???', async () => {
+                    // @ts-expect-error
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', ['test'])).toEqualTypeOf<Promise<void>>()
+                    // @ts-expect-error
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', {})).toEqualTypeOf<Promise<void>>()
+                })
+            })
+
+            describe('given elements', () => {
+                it('should return Promise<void> with elements', async () => {
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
+
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', ['val'])).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.anything(), expect.any(Number), 'value', expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
+                })
+
+                it('should not be supported (never)', async () => {
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', null)).toEqualTypeOf<Promise<never>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined)).toEqualTypeOf<Promise<never>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', undefined, { wait: 1 })).toEqualTypeOf<Promise<never>>()
+                })
+
+                it('should have ts errors but to support one day???', async () => {
+                    // @ts-expect-error
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', [[]])).toEqualTypeOf<Promise<void>>()
+                    // @ts-expect-error
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', [{}])).toEqualTypeOf<Promise<void>>()
+                })
             })
         })
 

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -535,12 +535,19 @@ Received: "not displayed"`)
             await expectLib(elements).not.toBeElementsArrayOfSize(3)
         })
 
-        // TODO: Should work on non-existing parameters...
-        test.skip('toHave existence of attribute and property matchers work with .not', async () => {
-            await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute')
+        test('toHave existence of attribute and property matchers work with .not', async () => {
+            const elements = await $$('selector')
+
+            elements.forEach((el) => {
+                vi.mocked(el.getProperty).mockResolvedValue(null)
+            })
+
             await expectLib(elements).not.toHaveElementProperty('someNonExistingAttribute')
-            await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute', expectLib.anything(), { wait: 2 })
             await expectLib(elements).not.toHaveElementProperty('someNonExistingAttribute', expectLib.anything(), { wait: 2 })
+
+            // TODO bring back toHaveAttribute when it is fixed to not throw when attribute does not exist, see
+            // await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute')
+            // await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute', expectLib.anything(), { wait: 2 })
         })
 
         test('toHave existence of attribute and property matchers work with options', async () => {

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -535,6 +535,23 @@ Received: "not displayed"`)
             await expectLib(elements).not.toBeElementsArrayOfSize(3)
         })
 
+        // TODO: Should work on non-existing parameters...
+        test.skip('toHave existence of attribute and property matchers work with .not', async () => {
+            await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute')
+            await expectLib(elements).not.toHaveElementProperty('someNonExistingAttribute')
+            await expectLib(elements).not.toHaveAttribute('someNonExistingAttribute', expectLib.anything(), { wait: 2 })
+            await expectLib(elements).not.toHaveElementProperty('someNonExistingAttribute', expectLib.anything(), { wait: 2 })
+        })
+
+        test('toHave existence of attribute and property matchers work with options', async () => {
+            await expectLib(elements).toHaveAttribute('someOtherAttribute')
+            await expectLib(elements).toHaveElementProperty('someOtherProperty')
+            await expectLib(elements).toHaveAttribute('someOtherAttribute', expectLib.anything())
+            await expectLib(elements).toHaveElementProperty('someOtherProperty', expectLib.anything())
+            await expectLib(elements).toHaveAttribute('someOtherAttribute', expectLib.anything(), { wait: 2 })
+            await expectLib(elements).toHaveElementProperty('someOtherProperty', expectLib.anything(), { wait: 2 })
+        })
+
         test('toHave works with stringContaining asymmetric matcher', async () => {
             await expectLib(elements).toHaveText([expectLib.stringContaining('Valid'), expectLib.stringContaining('Valid')])
             await expectLib(elements).not.toHaveText([expectLib.stringContaining('Test'), expectLib.stringContaining('Test')])

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -187,14 +187,13 @@ Expected: Any<Number>
 Received: "iphone"`)
         })
 
-        // TODO: Not working to fix oen day.
         test('should return be true when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
             vi.mocked(el.getProperty).mockResolvedValue(5)
 
             const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
 
             expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
-            expect(result.pass).toBe(false) // TODO: Not working should be true to fix one day.
+            expect(result.pass).toBe(true)
         })
 
         test.for([

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -652,6 +652,15 @@ Expect $$(\`sel\`) to have property property
                 expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })
 
+            test('not - success - should return false if actual value are not expected', async () => {
+                vi.mocked(els[0].getProperty).mockResolvedValue('no1')
+                vi.mocked(els[1].getProperty).mockResolvedValue('no2')
+
+                const result = await thisIsNotContext.toHaveElementProperty(els, 'property', ['yo1', 'yo2'])
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+            })
+
             test('should return false if actual value is non-string and expected is string', async () => {
                 els.forEach(el =>
                     vi.mocked(el.getProperty).mockResolvedValue(5)

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -161,39 +161,63 @@ Received      : "iphone"`)
             expect(result.pass).toBe(true)
         })
 
-        test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+        describe('when using any/anything asymmetric matchers', () => {
+            test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
 
-            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
-            expect(result.pass).toBe(true)
-        })
+                expect(result.pass).toBe(true)
+            })
 
-        test('should return true when property does exist by passing the any(String) asymmetric matcher', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(String), { wait: 0 })
+            test.for([
+                { actualValue: null },
+                { actualValue: undefined }
+            ]
+            )('should return false when property does not exist by passing the anything() asymmetric matcher', async ({ actualValue }) => {
+                vi.mocked(el.getProperty).mockResolvedValue(actualValue)
 
-            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
-            expect(result.pass).toBe(true)
-        })
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
 
-        test('should return be false when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
 
-            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
-            expect(result.pass).toBe(false)
-            expect(stripAnsi(result.message())).toEqual(`\
+Expected: Anything
+Received: ${actualValue}`
+                )
+            })
+
+            test('should return true when property does exist by passing the any(String) asymmetric matcher', async () => {
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(String), { wait: 0 })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('should return be false when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have property myPropertyName
 
 Expected: Any<Number>
 Received: "iphone"`)
-        })
+            })
 
-        test('should return be true when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
-            vi.mocked(el.getProperty).mockResolvedValue(5)
+            test('should return be true when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+                vi.mocked(el.getProperty).mockResolvedValue(5)
 
-            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
 
-            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
-            expect(result.pass).toBe(true)
+                expect(result.pass).toBe(true)
+            })
+
+            test('not - should succeed (pass=false) when property does not exists and using .not', async () => {
+                vi.mocked(el.getProperty).mockResolvedValue(null)
+
+                const result = await thisIsNotContext.toHaveElementProperty(el, 'myPropertyName')
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+            })
         })
 
         test.for([
@@ -439,6 +463,71 @@ Expect $$(\`sel\`) to have property property
   ]`)
                 })
             })
+
+            describe('when using any/anything asymmetric matchers', () => {
+                test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('should return false when property does not exist by passing the anything() asymmetric matcher', async () => {
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) to have property myPropertyName
+
+- Expected  - 1
++ Received  + 1
+
+  Array [
+    Anything,
+-   Anything,
++   null,
+  ]`
+                    )
+                })
+
+                test('should return true when property does exist by passing the any(String) asymmetric matcher', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.any(String), { wait: 0 })
+
+                    expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+                    expect(result.pass).toBe(true)
+                })
+
+                test('should return be false when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+
+                    expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) to have property myPropertyName
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   Any<Number>,
+-   Any<Number>,
++   "iphone",
++   "iphone",
+  ]`)
+                })
+
+                test('should return be true when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+                    els.forEach(el =>
+                        vi.mocked(el.getProperty).mockResolvedValue(5)
+                    )
+
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+
+                    expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+                    expect(result.pass).toBe(true)
+                })
+            })
         })
 
         describe('given a multiple expected values', () => {
@@ -553,41 +642,6 @@ Expect $$(\`sel\`) to have property property
                 expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })
 
-            // TODO: This test raise the question of either supporting null (non-existence) for arrays or have an assymetric matcher for null!
-            test.skip('should succeed if we have both null and non-null values and expecting so', async () => {
-                vi.mocked(els[0].getProperty).mockResolvedValue(null)
-                vi.mocked(els[1].getProperty).mockResolvedValue('iphone')
-
-                // @ts-expect-error -- null is not supported for now, to support later
-                const result = await thisContext.toHaveElementProperty(els, 'property', [null, 'iphone'])
-
-                expect(result.pass).toBe(true)
-            })
-
-            // TODO: To fix one day, error message should clearly state the last item is epxected to be non-existing.
-            test.skip('should fails if we have null & non-null but asserting the reverse order', async () => {
-                vi.mocked(els[0].getProperty).mockResolvedValue(null)
-                vi.mocked(els[1].getProperty).mockResolvedValue('iphone')
-
-                // @ts-expect-error -- null is not supported for now, to support later
-                const result = await thisContext.toHaveElementProperty(els, 'property', ['iphone', null])
-
-                expect(result.pass).toBe(false)
-                expect(stripAnsi(result.message())).toContain(`\
-Expect $$(\`sel\`) to have property property
-
-- Expected  - 2
-+ Received  + 2
-
-  Array [
--   "iphone",
--   null,
-+   null,
-+   "iphone",
-  ]`
-                )
-            })
-
             test('not - success - should return false if actual value is null and expected is not null', async () => {
                 els.forEach(el =>
                     vi.mocked(el.getProperty).mockResolvedValue(null)
@@ -673,6 +727,54 @@ Expect $$(\`sel\`) to have property property
 -   "iphone",
 +   undefined,
   ]`)
+                })
+            })
+
+            describe('when using any/anything asymmetric matchers', () => {
+                test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', [wdioExpect.anything(), wdioExpect.any(String)], { wait: 0 })
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('should return false when property does not exist by passing the anything() asymmetric matcher', async () => {
+                    vi.mocked(els[0].getProperty).mockResolvedValue(undefined)
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', [wdioExpect.anything(), wdioExpect.any(String)], { wait: 0 })
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) to have property myPropertyName
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   Anything,
+-   Any<String>,
++   undefined,
++   null,
+  ]`
+                    )
+                })
+
+                test('should return true when one property exists but not the other', async () => {
+                    vi.mocked(els[0].getProperty).mockResolvedValue('iphone')
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', ['iphone', null], { wait: 0 })
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('not - should succeed (pass=false) when property does not exist by using not', async () => {
+                    vi.mocked(els[0].getProperty).mockResolvedValue(undefined)
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisIsNotContext.toHaveElementProperty(els, 'myPropertyName')
+
+                    expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
                 })
             })
         })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -168,6 +168,25 @@ Received      : "iphone"`)
                 expect(result.pass).toBe(true)
             })
 
+            test('should return true when property does exist by passing the jasmine anything() asymmetric matcher', async () => {
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', jasmine.anything(), { wait: 0 })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('should return false when property does not exist by passing the jasmine anything() asymmetric matcher', async () => {
+                vi.mocked(el.getProperty).mockResolvedValue(null)
+                const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', jasmine.anything(), { wait: 0 })
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
+
+Expected: "<jasmine.anything>"
+Received: null`
+                )
+            })
+
             test.for([
                 { actualValue: null },
                 { actualValue: undefined }
@@ -817,6 +836,19 @@ Expect $$(\`sel\`) to have property myPropertyName
 Expect $$(\`sel\`) not to have property myPropertyName
 
 Expected [not]: [Anything, Anything]
+Received      : ["iphone", null]`)
+                })
+
+                test('not - should fails (pass=true) when property does exist by using not but with options and jasmine.anything()', async () => {
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisIsNotContext.toHaveElementProperty(els, 'myPropertyName', jasmine.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) not to have property myPropertyName
+
+Expected [not]: ["<jasmine.anything>", "<jasmine.anything>"]
 Received      : ["iphone", null]`)
                 })
             })

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -5,6 +5,7 @@ import { toHaveElementProperty } from '../../../src/matchers/element/toHaveEleme
 import stripAnsi from 'strip-ansi'
 import { jasmine } from '../../__mocks__/jasmine.js'
 import { waitUntil } from '../../../src/utils.js'
+import { expect as wdioExpect } from '../../../src/index.js'
 
 vi.mock('@wdio/globals')
 
@@ -160,11 +161,40 @@ Received      : "iphone"`)
             expect(result.pass).toBe(true)
         })
 
-        test('should return true when property does exist by passing an not defined expected value with options', async () => {
-            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', { wait: 0 })
+        test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
 
             expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
             expect(result.pass).toBe(true)
+        })
+
+        test('should return true when property does exist by passing the any(String) asymmetric matcher', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(String), { wait: 0 })
+
+            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+            expect(result.pass).toBe(true)
+        })
+
+        test('should return be false when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+
+            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have property myPropertyName
+
+Expected: Any<Number>
+Received: "iphone"`)
+        })
+
+        // TODO: Not working to fix oen day.
+        test('should return be true when property does exist but not a number and by passing the any(Number) asymmetric matcher', async () => {
+            vi.mocked(el.getProperty).mockResolvedValue(5)
+
+            const result = await thisContext.toHaveElementProperty(el, 'myPropertyName', wdioExpect.any(Number), { wait: 0 })
+
+            expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), undefined, { wait: 0, interval: undefined })
+            expect(result.pass).toBe(false) // TODO: Not working should be true to fix one day.
         })
 
         test.for([
@@ -196,7 +226,7 @@ Received      : "iphone"`)
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) to have property myPropertyName
 
-Expected: "\`a defined value\`"
+Expected: Anything
 Received: ${propertyValue}`
             )
         })
@@ -208,7 +238,7 @@ Received: ${propertyValue}`
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $(\`sel\`) not to have property myPropertyName
 
-Expected [not]: "\`a defined value\`"
+Expected [not]: Anything
 Received      : "iphone"`)
         })
 
@@ -506,8 +536,8 @@ Expect $$(\`sel\`) to have property property
 + Received  + 2
 
   Array [
--   "\`a defined value\`",
--   "\`a defined value\`",
+-   Anything,
+-   Anything,
 +   null,
 +   null,
   ]`

--- a/test/matchers/element/toHaveElementProperty.test.ts
+++ b/test/matchers/element/toHaveElementProperty.test.ts
@@ -731,6 +731,18 @@ Expect $$(\`sel\`) to have property property
             })
 
             describe('when using any/anything asymmetric matchers', () => {
+                test('should return true when property does exist by passing the anything() asymmetric matcher with options', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('should return true when property does exist by passing nothing', async () => {
+                    const result = await thisContext.toHaveElementProperty(els, 'myPropertyName')
+
+                    expect(result.pass).toBe(true)
+                })
+
                 test('should return true when property does exist by passing the anything() asymmetric matcher', async () => {
                     const result = await thisContext.toHaveElementProperty(els, 'myPropertyName', [wdioExpect.anything(), wdioExpect.any(String)], { wait: 0 })
 
@@ -775,6 +787,28 @@ Expect $$(\`sel\`) to have property myPropertyName
                     const result = await thisIsNotContext.toHaveElementProperty(els, 'myPropertyName')
 
                     expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+                })
+
+                test('not - should succeed (pass=false) when property does not exist by using not but with options', async () => {
+                    vi.mocked(els[0].getProperty).mockResolvedValue(undefined)
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisIsNotContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+                })
+
+                test('not - should fails (pass=true) when property does exist by using not but with options', async () => {
+                    vi.mocked(els[1].getProperty).mockResolvedValue(null)
+
+                    const result = await thisIsNotContext.toHaveElementProperty(els, 'myPropertyName', wdioExpect.anything(), { wait: 0 })
+
+                    expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) not to have property myPropertyName
+
+Expected [not]: [Anything, Anything]
+Received      : ["iphone", null]`)
                 })
             })
         })

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -3,6 +3,7 @@ import { INVERTED_COLOR, printDiffOrStringify } from 'jest-matcher-utils'
 import { enhanceError, enhanceErrorBe } from '../../src/util/formatMessage.js'
 import stripAnsi from 'strip-ansi'
 import { elementArrayFactory, elementFactory } from '../__mocks__/@wdio/globals.js'
+import { jasmine } from '../__mocks__/jasmine.js'
 
 vi.mock('jest-matcher-utils', async (importActual) => {
     const actual = await importActual<typeof import('jest-matcher-utils')>()
@@ -421,6 +422,88 @@ Received      : ["Test Actual Value 1", "Test Expected Value 2"]`
                     expect(INVERTED_COLOR).toHaveBeenNthCalledWith(1, '"Test Expected Value 2"')
                     expect(INVERTED_COLOR).toHaveBeenNthCalledWith(2, '"Test Expected Value 2"')
                 })
+            })
+        })
+
+        describe('given jasmine asymmetric matchers', () => {
+            test('should return failure message for jasmine.any', async () => {
+                const subject = elementFactory('element')
+                const expected = jasmine.any(String)
+                const actual = 'Test Actual Value'
+
+                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect $(\`element\`) to have text
+
+Expected: "<jasmine.any(String)>"
+Received: "Test Actual Value"`)
+            })
+
+            test('should return failure message for jasmine.any when given an array of elements', async () => {
+                const subject = elementArrayFactory('element', 2)
+                const expected = [jasmine.any(String), jasmine.any(Number)]
+                const actual = [null, 'Test Actual Value 2']
+
+                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect $$(\`element\`) to have text
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "<jasmine.any(String)>",
+-   "<jasmine.any(Number)>",
++   null,
++   "Test Actual Value 2",
+  ]`
+                )
+            })
+
+            test('should return failure message for jasmine.any with isNot', async () => {
+                const subject = elementFactory('element')
+                const expected = jasmine.any(String)
+                const actual = 'Test Actual Value'
+
+                const result = await enhanceError(subject, expected, actual, { isNot: true }, 'have', 'text')
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect $(\`element\`) not to have text
+
+Expected [not]: "<jasmine.any(String)>"
+Received      : "Test Actual Value"`)
+            })
+
+            test('should return failure message for jasmine.any with isNot when given an array of elements', async () => {
+                const subject = elementArrayFactory('element', 2)
+                const expected = [jasmine.any(String), jasmine.any(Number)]
+                const actual = ['Test Actual Value 2', 1]
+
+                const result = await enhanceError(subject, expected, actual, { isNot: true }, 'have', 'text')
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect $$(\`element\`) not to have text
+
+Expected [not]: ["<jasmine.any(String)>", "<jasmine.any(Number)>"]
+Received      : ["Test Actual Value 2", 1]`)
+            })
+        })
+
+        describe('given expect asymmetric matchers', () => {
+            test('should return failure message for expect.stringContaining', async () => {
+                const subject = elementFactory('element')
+                const expected = expect.any(String)
+                const actual = 'Test Actual Value'
+
+                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+
+                expect(stripAnsi(result)).toEqual(`\
+Expect $(\`element\`) to have text
+
+Expected: Any<String>
+Received: "Test Actual Value"`)
             })
         })
     })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -85,6 +85,11 @@ describe('utils', () => {
         test('should support jasmine.stringMatching matchers', () => {
             expect(compareText(' FOO ', jasmine.stringMatching(/.*foo.*/i), {}).result).toBe(true)
         })
+
+        test('should support undefined/null expected value', () => {
+            expect(compareText(' FOO ', undefined, {}).result).toBe(false)
+            expect(compareText(' FOO ', null, {}).result).toBe(false)
+        })
     })
 
     describe(compareTextWithArray, () => {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -354,7 +354,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string>> | ExpectWebdriverIO.PartialMatcherAnything,
+            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | null | undefined>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -21,6 +21,7 @@ type ExpectLibAsyncExpectationResult = import('expect').AsyncExpectationResult
 type ExpectLibExpectationResult = import('expect').ExpectationResult
 type ExpectLibMatcherContext = import('expect').MatcherContext
 type MatchersObject = Parameters<typeof import('expect').expect.extend>[0]
+type ExpectLibAnything = ReturnType<typeof expect.any> | ReturnType<typeof expect.anything>
 
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
@@ -221,7 +222,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both attribute name AND a specific expected value */
         (
             attribute: string,
-            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }, {
@@ -307,38 +308,53 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveElementProperty: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         /**
-         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the second argument entirely or pass options instead: `toHaveElementProperty(property, options)`.
+         * Allow to check ONLY for the presence of the property
+         * Use `toHaveElementProperty(property, expect.anything(), options)` to check for the presence of the property with options.
          */
         (
             property: string,
-            value: undefined | null,
-            options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
 
-        /** Check ONLY for the presence of the property (and optional configuration options) */
+        /**
+         * @deprecated since v6.0.0, removed in v10.0.0. Passing explicit `undefined` or `null` as a value is deprecated.
+         * Omit the second argument entirely or use expect.anything() with options: `toHaveElementProperty(property, expect.anything(), options)`.
+         */
         (
             property: string,
+            value: undefined | null, // Use expect.any(type) or expect.anything() instead of undefined or null
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
 
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }, {
         /** Elements $$() API */
-        /** Check ONLY for the presence of the property (and optional configuration options) */
+        /**
+         * Allow to check ONLY for the presence of the property
+         * Use `toHaveElementProperty(property, expect.anything(), options)` to check for the presence of the property with options.
+         */
         (
             property: string,
-            options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
+
+        /**
+         * @deprecated Not supported
+         * Use `expect.anything()` or `[expect.anything()] as value` to check for the presence of the property with options.
+         */
+        (
+            property: string,
+            propertyValue: undefined | null, // Use expect.any(type) or expect.anything() instead of undefined or null
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<never>;
 
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string>> | ExpectWebdriverIO.PartialMatcherAnything,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>
@@ -369,7 +385,9 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveChildren: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         /**
-         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(options)`.
+         * deprecated since 5.7.1, remove in v6.0.0.
+         * Passing explicit `undefined` or `{}` as a value is deprecated.
+         * Omit the second argument entirely or use options with `toHaveChildren({ gte: 1 }, options)`.????
          */
         (
             expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
@@ -820,7 +838,11 @@ type JasmineStringMatchingAsymmetricMatcher<R extends string | RegExp> = Jasmine
 
 type JasmineStringAsymmetricMatcher<R extends string | RegExp> = JasmineStringContainingAsymmetricMatcher<R> | JasmineStringMatchingAsymmetricMatcher<R>
 
+type JasmineAnythingAsymmetricMatcher = JasmineBaseAsymmetricMatcher & {}
+
 type AsymmetricMatcher<R> = WdioAsymmetricMatcher<R> | JasmineStringContainingAsymmetricMatcher<R> | (R extends string | RegExp ? JasmineStringMatchingAsymmetricMatcher<R> : never) | JasmineAsymmetricMatcher<R>
+
+type WdioAnythingAsymmetricMatcher = ExpectLibAnything | JasmineAnythingAsymmetricMatcher
 
 declare namespace ExpectWebdriverIO {
     /**
@@ -1191,6 +1213,11 @@ declare namespace ExpectWebdriverIO {
      * Some properties are omitted for the type check to work correctly.
      */
     type PartialMatcher<T> = Omit<ExpectLibAsymmetricMatcher<T>, 'sample' | 'inverse' | '$$typeof'>
+
+    /**
+     * Allow to match any defined value or any defined value of a given type and simply validate a value exists.
+     */
+    type PartialMatcherAnything = ExpectLibAnything | JasmineAnythingAsymmetricMatcher
 }
 
 declare module 'expect-webdriverio' {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1108,7 +1108,7 @@ declare namespace ExpectWebdriverIO {
         replace?: [string | RegExp, string | Function] | Array<[string | RegExp, string | Function]>
 
         /**
-         * might be helpful to force converting property value to string
+         * convert element's property value to string
          */
         asString?: boolean
     }


### PR DESCRIPTION
In https://github.com/webdriverio/expect-webdriverio/pull/2128, we attempt to clarify the API by omitting the second parameter `undefined/null` value to validate the existence of values and allow passing options.
However, this brought complexity, and a better approach is to use `expect.anything()` instead, which is also reusable for the support of `$$()`

So instead of the ambiguous
```ts
await expect(elem).toHaveElementProperty('height', null, { wait: 0 })
```
We now use
```ts
await expect(elem).toHaveElementProperty('height', expect.anything(), { wait: 0 })
```

And no longer support second parameters as command options, which never got released anyway

Now with `$$()` we can both validate if a value is present or not
```ts
// assert 'height' presence with expect.anything() on first element and not present on second element with null
await expect($$('elements')).toHaveElementProperty('height', [expect.anything(), null])

// Assert `height` is not present
await expect($$('elements')).not.toHaveElementProperty('height')

// Assert `height` is present
await expect($$('elements')).toHaveElementProperty('height')
// Assert `height` is present with option
await expect($$('elements')).toHaveElementProperty('height', expect.anything(), { wait:0 })

// Assert `height` not present with option
await expect($$('elements')).not.toHaveElementProperty('height', expect.anything(), { wait:0 })
```


