### PR TITLE
fix: Align `toHaveChildren` with `toHaveElementProperty`

### DIFF
--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,10 +1,9 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
-import { isStrictlyCommandOptions } from '../../util/commandOptionsUtils.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
-import { validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
+import { isLegacyNumberOptions, validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
     enhanceError,
     waitUntil,
@@ -25,19 +24,20 @@ async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher |
 }
 
 /**
- * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, options)`.
+ * Verifies that the element(s) has children.
+ * Same as `expect(el).toHaveChildren({ gte: 1 })` or `expect(el).toHaveChildren({ gte: 1 }, options)`.
+ */
+export async function toHaveChildren(
+    received: WdioElementOrArrayMaybePromise,
+): Promise<AssertionResult>
+
+/**
+ * @deprecated since 6.0.0, remove in v10.0.0.
+ * Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, { gte: 1 }, options)`.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
     expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
-    options?: ExpectWebdriverIO.CommandOptions
-): Promise<AssertionResult>
-
-/**
- * When called with only configuration options (omitting the expected count) where default is gte 1.
- */
-export async function toHaveChildren(
-    received: WdioElementOrArrayMaybePromise,
     options?: ExpectWebdriverIO.CommandOptions
 ): Promise<AssertionResult>
 
@@ -62,7 +62,9 @@ export async function toHaveChildren(
 ): Promise<AssertionResult>
 
 /**
- * deprecated since 5.7.1, remove in v6.0.0. NumberOptions is no longer supported. Use `toHaveChildren(el, numberMatcher, options)` instead.
+ * @deprecated since 6.0.0, remove in v10.0.0.
+ * NumberOptions is no longer supported. Use `expect(el).toHaveChildren(numberMatcher, options)` instead.
+ * Instead of `expect(el).toHaveChildren({ wait: 1 })` use `expect(el).toHaveChildren({ gte: 1 },  { wait: 1 })`.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
@@ -73,17 +75,15 @@ export async function toHaveChildren(
 export async function toHaveChildren(
     received: WdioElementOrArrayMaybePromise,
     expectedValueOrOptions?: MaybeArray<number | ExpectWebdriverIO.NumberMatcher> | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions,
-    options?: ExpectWebdriverIO.CommandOptions
+    options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'children', verb = 'have', isNot, matcherName = 'toHaveChildren' } = this
 
-    const hasOnlyTwoArgs = options === undefined
+    const paramsCount = arguments.length
     options = options ?? DEFAULT_OPTIONS
 
-    // Properly support new case `toHaveChildren(commandOptions)` where the second argument is the commandOptions and not a number or NumberMatcher for a clearer API instead of `toHaveChildren(undefined, commandOptions)`.
-    if (hasOnlyTwoArgs && isStrictlyCommandOptions(expectedValueOrOptions)) {
-        options = expectedValueOrOptions
-        expectedValueOrOptions = undefined
+    if (paramsCount > 1 && isLegacyNumberOptions(expectedValueOrOptions)) {
+        console.warn('Passing NumberOptions as the second argument to toHaveChildren is deprecated. Use a NumberMatcher instead. For example, `expect(el).toHaveChildren({ gte: 1 }, options)`')
     }
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -83,7 +83,7 @@ export async function toHaveChildren(
     const paramsCount = arguments.length
 
     if (paramsCount > 1 && (expectedValueOrOptions === undefined || isEmptyOrLegacyNumberOptions(expectedValueOrOptions))) {
-        console.warn('Passing NumberOptions as the second argument to toHaveChildren is deprecated. Use a NumberMatcher instead. For example, `expect(el).toHaveChildren({ gte: 1 }, options)`')
+        console.warn('Passing undefined or NumberOptions as the second argument to toHaveChildren is deprecated. Use a NumberMatcher instead. For example, `expect(el).toHaveChildren({ gte: 1 }, options)`')
     }
 
     await options.beforeAssertion?.({

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -33,7 +33,8 @@ export async function toHaveChildren(
 
 /**
  * @deprecated since 6.0.0, remove in v10.0.0.
- * Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(el, { gte: 1 }, options)`.
+ * Passing explicit `undefined` or `{}` as a value is deprecated.
+ * Omit the second argument entirely or use `toHaveChildren(el, { gte: 1 }, options)`.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,
@@ -64,7 +65,7 @@ export async function toHaveChildren(
 /**
  * @deprecated since 6.0.0, remove in v10.0.0.
  * NumberOptions is no longer supported. Use `expect(el).toHaveChildren(numberMatcher, options)` instead.
- * Instead of `expect(el).toHaveChildren({ wait: 1 })` use `expect(el).toHaveChildren({ gte: 1 },  { wait: 1 })`.
+ * Instead of `expect(el).toHaveChildren({ wait: 1 })` use `expect(el).toHaveChildren({ gte: 1 }, { wait: 1 })`.
  */
 export async function toHaveChildren(
     received: WdioElementMaybePromise,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
-import { isLegacyNumberOptions, validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
+import { isEmptyOrLegacyNumberOptions, validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
 import {
     enhanceError,
     waitUntil,
@@ -80,19 +80,18 @@ export async function toHaveChildren(
     const { expectation = 'children', verb = 'have', isNot, matcherName = 'toHaveChildren' } = this
 
     const paramsCount = arguments.length
-    options = options ?? DEFAULT_OPTIONS
 
-    if (paramsCount > 1 && isLegacyNumberOptions(expectedValueOrOptions)) {
+    if (paramsCount > 1 && (expectedValueOrOptions === undefined || isEmptyOrLegacyNumberOptions(expectedValueOrOptions))) {
         console.warn('Passing NumberOptions as the second argument to toHaveChildren is deprecated. Use a NumberMatcher instead. For example, `expect(el).toHaveChildren({ gte: 1 }, options)`')
     }
 
-    const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
-
-    await commandOptions.beforeAssertion?.({
+    await options.beforeAssertion?.({
         matcherName,
-        expectedValue: expectedValueOrOptions, // Send unaltered value to the hook for backward compatibility
+        expectedValue: expectedValueOrOptions,
         options,
     })
+
+    const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
 
     let subject
     let children
@@ -121,7 +120,7 @@ export async function toHaveChildren(
         message: (): string => message
     }
 
-    await commandOptions.afterAssertion?.({
+    await options.afterAssertion?.({
         matcherName,
         expectedValue: expectedValueOrOptions,
         options,

--- a/src/util/commandOptionsUtils.ts
+++ b/src/util/commandOptionsUtils.ts
@@ -1,37 +1,5 @@
-const COMMAND_OPTIONS_ALLOWED_KEY_LIST = new Set([
-    // CommandOptions
-    'message',
-    // DefaultOptions
-    'wait',
-    'interval',
-    'beforeAssertion',
-    'afterAssertion',
-    'featureFlags',
-])
-
-export const isStrictlyCommandOptions = (obj: unknown): obj is ExpectWebdriverIO.CommandOptions => {
-    if (obj === null ||
-        obj === undefined ||
-        typeof obj !== 'object' ||
-        obj instanceof RegExp ||
-        Array.isArray(obj) ||
-        'asymmetricMatch' in obj ||
-        Object.prototype.toString.call(obj) !== '[object Object]' // This instantly filters out null, primitives, Arrays, Dates, RegExps, Maps, Sets, etc.
-    ) {
-        return false
-    }
-
-    const objKeys = Object.keys(obj)
-
-    if (objKeys.length === 0) {
-        return false
-    }
-
-    return objKeys.every(key => COMMAND_OPTIONS_ALLOWED_KEY_LIST.has(key))
-}
-
-export const isDefinedObject = (obj: unknown): obj is object => {
-    if (typeof obj === 'object' && obj !== null) {
+export const isDefinedPlainObject = (obj: unknown): obj is object => {
+    if (typeof obj === 'object' && obj !== null && !Array.isArray(obj)) {
         return true
     }
     return false

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -54,8 +54,7 @@ export function validateNumberArrayAndExtractOptions(
         const allNumbers = expectedValues.map((value) => validateNumberAndExtractOptions(value, commandOptions, { supportDefaultAsGteThen1 }))
         return { numberMatcher: allNumbers.map( ({ numberMatcher }) =>  numberMatcher), commandOptions }
     }
-    const { numberMatcher, commandOptions: numberCommandOptions } = validateNumberAndExtractOptions(expectedValues, commandOptions, { supportDefaultAsGteThen1 })
-    return { numberMatcher: numberMatcher, commandOptions: numberCommandOptions }
+    return validateNumberAndExtractOptions(expectedValues, commandOptions, { supportDefaultAsGteThen1 })
 }
 
 /**
@@ -132,8 +131,8 @@ export class NumberMatcher extends AsymmetricMatcher<number | ExpectWebdriverIO.
     }
 }
 
-export const isLegacyNumberOptions = (value: unknown): value is ExpectWebdriverIO.NumberOptions => {
-    if (!isDefinedObject(value)) {return false}
-    const keys = Object.keys(value ?? {})
-    return keys.some((key) => ['eq', 'gte', 'lte'].includes(key) && keys.length > 1)
+export const isEmptyOrLegacyNumberOptions = (value: unknown): value is ExpectWebdriverIO.NumberOptions => {
+    if (!isDefinedObject(value)) { return false }
+    const keys = Object.keys(value)
+    return keys.length === 0 || keys.filter((key) => !['eq', 'gte', 'lte'].includes(key)).length > 0
 }

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -131,3 +131,9 @@ export class NumberMatcher extends AsymmetricMatcher<number | ExpectWebdriverIO.
         return this.toString()
     }
 }
+
+export const isLegacyNumberOptions = (value: unknown): value is ExpectWebdriverIO.NumberOptions => {
+    if (!isDefinedObject(value)) {return false}
+    const keys = Object.keys(value ?? {})
+    return keys.some((key) => ['eq', 'gte', 'lte'].includes(key) && keys.length > 1)
+}

--- a/src/util/numberOptionsUtil.ts
+++ b/src/util/numberOptionsUtil.ts
@@ -1,5 +1,5 @@
 import { AsymmetricMatcher } from 'expect'
-import { isDefinedObject } from './commandOptionsUtils.js'
+import { isDefinedPlainObject } from './commandOptionsUtils.js'
 
 export const isNumber = (value: unknown): value is number => typeof value === 'number' && !isNaN(value)
 export const isDefinedNotNumber = (value: unknown) => value !== undefined && !isNumber(value)
@@ -21,7 +21,7 @@ export function validateNumberAndExtractOptions(
     { supportDefaultAsGteThen1 }: { supportDefaultAsGteThen1?: boolean } = {}
 ): { numberMatcher: NumberMatcher; commandOptions: ExpectWebdriverIO.CommandOptions } {
     let defaultExpectedValue: NumberMatcher | undefined = undefined
-    if (supportDefaultAsGteThen1 && (expectedValue === undefined || (isDefinedObject(expectedValue) && expectedValue.eq === undefined && expectedValue.gte === undefined && expectedValue.lte === undefined))) {
+    if (supportDefaultAsGteThen1 && (expectedValue === undefined || (isDefinedPlainObject(expectedValue) && expectedValue.eq === undefined && expectedValue.gte === undefined && expectedValue.lte === undefined))) {
         defaultExpectedValue = new NumberMatcher({ gte: 1 })
     } else if (isNumber(expectedValue)) {
         return { numberMatcher: new NumberMatcher({ eq: expectedValue }), commandOptions }
@@ -132,7 +132,7 @@ export class NumberMatcher extends AsymmetricMatcher<number | ExpectWebdriverIO.
 }
 
 export const isEmptyOrLegacyNumberOptions = (value: unknown): value is ExpectWebdriverIO.NumberOptions => {
-    if (!isDefinedObject(value)) { return false }
+    if (!isDefinedPlainObject(value)) { return false }
     const keys = Object.keys(value)
     return keys.length === 0 || keys.filter((key) => !['eq', 'gte', 'lte'].includes(key)).length > 0
 }

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -894,7 +894,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
         describe('toHaveChildren', () => {
             describe('given element', () => {
                 it('should support various signatures', async () => {
-                // Preferred Signatures
+                    // Preferred Signatures
                     expectTypeOf(expect(element).toHaveChildren()).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveChildren(5)).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveChildren(5, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
@@ -917,6 +917,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                     expectTypeOf(expect(element).toHaveChildren({})).toEqualTypeOf<Promise<void>>()
                 })
             })
+
             describe('given elements', () => {
                 it('should support various signatures', async () => {
                     expectTypeOf(expect(elements).toHaveChildren()).toEqualTypeOf<Promise<void>>()

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -892,21 +892,54 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
         })
 
         describe('toHaveChildren', () => {
-            it('should support various signatures', async () => {
+            describe('given element', () => {
+                it('should support various signatures', async () => {
                 // Preferred Signatures
-                expectTypeOf(expect(element).toHaveChildren()).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren({ wait: 1000 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren(5)).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren(5, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren({ eq: 5 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren({ eq: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren()).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren(5)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren(5, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ eq: 5 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ eq: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ gte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ lte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ gte: 1, lte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
 
-                // Deprecated Signatures
-                expectTypeOf(expect(element).toHaveChildren(undefined)).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren(undefined, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(element).toHaveChildren({ eq: 5, wait: 1000 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
-                // Deprecating this is just too hard but let's not support this!
-                expectTypeOf(expect(element).toHaveChildren({})).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren).not.parameter(0).toBeArray()
+                })
+
+                it('should be deprecated', async () => {
+                    expectTypeOf(expect(element).toHaveChildren({ wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren(undefined)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren(undefined, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveChildren({ eq: 5, wait: 1000 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+
+                    // Deprecating this is just too hard but let's not support this!
+                    expectTypeOf(expect(element).toHaveChildren({})).toEqualTypeOf<Promise<void>>()
+                })
+            })
+            describe('given elements', () => {
+                it('should support various signatures', async () => {
+                    expectTypeOf(expect(elements).toHaveChildren()).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren(5)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren(5, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren([5, 5], { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren({ eq: 5 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren({ gte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren({ lte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren({ gte: 1, lte: 5 }, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren([{ gte: 1, lte: 5 }, 1, { eq: 1 }], { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                })
+
+                it('should be deprecated since it was never supported', async () => {
+                    expectTypeOf(expect(elements).toHaveChildren(undefined)).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveChildren(undefined, { wait: 1000 })).toEqualTypeOf<Promise<void>>()
+                })
+
+                it('should have tsc error since it is not supported', async () => {
+                    expectTypeOf(expect(elements).toHaveChildren).not.parameter(0).toEqualTypeOf<{ wait: 1000 }>()
+                    expectTypeOf(expect(elements).toHaveChildren).not.parameter(0).toEqualTypeOf<{ eq: 5, wait: 1000 }>()
+                    expectTypeOf(expect(elements).toHaveChildren).not.parameter(0).toEqualTypeOf<[{ gte: 1, lte: 5, wait: 1 }]>()
+                })
             })
         })
     })

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -526,6 +526,70 @@ Received      : [2, 2]`)
 
                 expect(result.pass).toBe(true) // success, boolean is inverted later because of `.not`
             })
+
+            test('should fails when not enough expected values', async () => {
+                const result = await thisContext.toHaveChildren(elements, [{ eq: 2 }])
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) to have children
+
+- Expected  - 0
++ Received  + 1
+
+  Array [
+    2,
++   2,
+  ]`
+                )
+            })
+
+            test('should fails when more expected values (missing elements)', async () => {
+                const result = await thisContext.toHaveChildren(elements, [{ eq: 2 }])
+
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) to have children
+
+- Expected  - 0
++ Received  + 1
+
+  Array [
+    2,
++   2,
+  ]`
+                )
+            })
+
+            test('not - should fails (pass=true) when not enough expected values', async () => {
+                const result = await thisNotContext.toHaveChildren(elements, [{ eq: 2 }])
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) not to have children
+
+- Expected [not]  - 0
++ Received        + 1
+
+  Array [
+    2,
++   2,
+  ]`
+                )
+
+            })
+
+            test('not - should fails (pass=true) when more expected values (missing elements)', async () => {
+                const result = await thisNotContext.toHaveChildren(elements, [{ eq: 2 }, { eq: 2 }, { eq: 2 }])
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $$(\`sel\`) not to have children
+
+Expected [not]: [2, 2, 2]
+Received      : [2, 2, undefined]`
+                )
+            })
         })
     })
 })

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -28,7 +28,7 @@ describe(toHaveChildren, () => {
                 expect(result.pass).toBe(true)
             })
 
-            test('no value - success - default to gte 1 with options', async () => {
+            test('no value - success - default to gte 1 with options - deprecated', async () => {
                 const beforeAssertion = vi.fn()
                 const afterAssertion = vi.fn()
 
@@ -37,13 +37,13 @@ describe(toHaveChildren, () => {
                 expect(result.pass).toBe(true)
                 expect(beforeAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
-                    expectedValue: undefined,
-                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion }
+                    expectedValue: { gte: 1 },
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion, featureFlags: { useToHaveTextStrictMultiElementsCompareStrategy: false } }
                 })
                 expect(afterAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
-                    expectedValue: undefined,
-                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion },
+                    expectedValue: { gte: 1 },
+                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion, featureFlags: { useToHaveTextStrictMultiElementsCompareStrategy: false } },
                     result
                 })
             })
@@ -243,7 +243,7 @@ Received      : 2`
                 const beforeAssertion = vi.fn()
                 const afterAssertion = vi.fn()
 
-                const result = await thisContext.toHaveChildren(elements, { wait: 0, interval: 5, beforeAssertion, afterAssertion })
+                const result = await thisContext.toHaveChildren(elements, { gte: 1 },  { wait: 0, interval: 5, beforeAssertion, afterAssertion })
 
                 expect(waitUntil).toHaveBeenCalledExactlyOnceWith(expect.any(Function), undefined, { wait: 0, interval: 5 })
 

--- a/test/matchers/element/toHaveChildren.test.ts
+++ b/test/matchers/element/toHaveChildren.test.ts
@@ -28,22 +28,28 @@ describe(toHaveChildren, () => {
                 expect(result.pass).toBe(true)
             })
 
-            test('no value - success - default to gte 1 with options - deprecated', async () => {
+            test('no value - success - with options', async () => {
+                const result = await thisContext.toHaveChildren(el, { gte: 1 }, { wait: 0, interval: 5 })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('no value - success - default to gte 1 with options as NumberOptions  - deprecated', async () => {
                 const beforeAssertion = vi.fn()
                 const afterAssertion = vi.fn()
 
-                const result = await thisContext.toHaveChildren(el, { wait: 0, interval: 5, beforeAssertion, afterAssertion })
+                const result = await thisContext.toHaveChildren(el, { wait: 0, interval: 5 }, { beforeAssertion, afterAssertion })
 
                 expect(result.pass).toBe(true)
                 expect(beforeAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
-                    expectedValue: { gte: 1 },
-                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion, featureFlags: { useToHaveTextStrictMultiElementsCompareStrategy: false } }
+                    expectedValue: { wait: 0, interval: 5 },
+                    options: { beforeAssertion, afterAssertion }
                 })
                 expect(afterAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
-                    expectedValue: { gte: 1 },
-                    options: { wait: 0, interval: 5, beforeAssertion, afterAssertion, featureFlags: { useToHaveTextStrictMultiElementsCompareStrategy: false } },
+                    expectedValue: { wait: 0, interval: 5 },
+                    options: { beforeAssertion, afterAssertion },
                     result
                 })
             })
@@ -250,10 +256,12 @@ Received      : 2`
                 expect(result.pass).toBe(true)
                 expect(beforeAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
+                    expectedValue: { gte: 1 },
                     options: { wait: 0, interval: 5, beforeAssertion, afterAssertion }
                 })
                 expect(afterAssertion).toHaveBeenCalledWith({
                     matcherName: 'toHaveChildren',
+                    expectedValue: { gte: 1 },
                     options: { wait: 0, interval: 5, beforeAssertion, afterAssertion },
                     result
                 })
@@ -290,7 +298,7 @@ Received      : 2`
             test('fails - If no options passed in + children do not exist', async () => {
                 elements[0].$$ = vi.fn(() => chainableElementArrayFactory('./child', 0))
 
-                const result = await thisContext.toHaveChildren(elements, undefined)
+                const result = await thisContext.toHaveChildren(elements)
 
                 expect(result.pass).toBe(false)
                 expect(stripAnsi(result.message())).toEqual(`\

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -222,14 +222,14 @@ Received      : 2`
             vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
             const elements = await $$('elements')
 
-            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 200, interval: 20 })
+            const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 198, interval: 20 })
 
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)
             expect(elements).toBe(elementArrayOf2)
             expect(browser.$$).toHaveBeenCalledTimes(11)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 200, true)
-            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 200, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 198, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 198, true)
         })
 
         // TODO: By awaiting the promise we could update the actual elements array, so should we support that?

--- a/test/util/commandOptionsUtils.test.ts
+++ b/test/util/commandOptionsUtils.test.ts
@@ -1,107 +1,23 @@
-import { describe, it, expect, vi } from 'vitest'
-import { isStrictlyCommandOptions } from '../../src/util/commandOptionsUtils.js'
+import { describe, it, expect } from 'vitest'
+import { isDefinedPlainObject } from '../../src/util/commandOptionsUtils.js'
 
 describe('Command Options Utility Functions', () => {
 
-    describe('isStrictlyCommandOptions Type Guard', () => {
+    it('should return true for defined objects', () => {
+        expect(isDefinedPlainObject({})).toBe(true)
+        expect(isDefinedPlainObject({ a: 1 })).toBe(true)
+    })
 
-        // 1. Testing Requirement: Empty Objects
-        describe('Empty Objects', () => {
-            it('should return false for a completely empty object literal - we do not need any backward compatibility for command options', () => {
-                expect(isStrictlyCommandOptions({})).toBe(false)
-            })
-        })
+    it('should return false for non-objects', () => {
+        expect(isDefinedPlainObject(null)).toBe(false)
+        expect(isDefinedPlainObject(undefined)).toBe(false)
+        expect(isDefinedPlainObject(123)).toBe(false)
+        expect(isDefinedPlainObject('string')).toBe(false)
+        expect(isDefinedPlainObject(true)).toBe(false)
+    })
 
-        // 2. Testing Requirement: CommandOptions & DefaultOptions Properties
-        describe('CommandOptions & DefaultOptions Properties', () => {
-            it('should return true for objects containing valid base command options', () => {
-                expect(isStrictlyCommandOptions({ message: 'Custom Error Message' })).toBe(true)
-                expect(isStrictlyCommandOptions({ wait: 5000 })).toBe(true)
-                expect(isStrictlyCommandOptions({ interval: 200 })).toBe(true)
-                expect(isStrictlyCommandOptions({ beforeAssertion: async () => { } })).toBe(true)
-                expect(isStrictlyCommandOptions({ afterAssertion: async () => { } })).toBe(true)
-            })
-
-            it('should return true for a fully valid mixed base configuration object', () => {
-                const mixedOptions = {
-                    wait: 1000,
-                    message: 'Failed assertion',
-                    interval: 50
-                }
-                expect(isStrictlyCommandOptions(mixedOptions)).toBe(true)
-            })
-        })
-
-        // 3. Testing Requirement: Invalid Configurations & False Positives
-        describe('Invalid Configurations & False Positives', () => {
-            it('should return false for primitive types and null', () => {
-                expect(isStrictlyCommandOptions('some-string-value')).toBe(false)
-                expect(isStrictlyCommandOptions(123)).toBe(false)
-                expect(isStrictlyCommandOptions(true)).toBe(false)
-                expect(isStrictlyCommandOptions(null)).toBe(false)
-                expect(isStrictlyCommandOptions(undefined)).toBe(false)
-            })
-
-            it('should return false for RegExp instances', () => {
-                expect(isStrictlyCommandOptions(/test-regex/i)).toBe(false)
-                expect(isStrictlyCommandOptions(new RegExp('test'))).toBe(false)
-            })
-
-            it('should return false for Asymmetric Matchers', () => {
-                const mockAsymmetricMatcher = {
-                    asymmetricMatch: vi.fn(),
-                    toString: vi.fn()
-                }
-                expect(isStrictlyCommandOptions(mockAsymmetricMatcher)).toBe(false)
-            })
-
-            it('should return false for plain objects with unrelated custom properties', () => {
-                expect(isStrictlyCommandOptions({ customKey: 'not-an-option' })).toBe(false)
-                expect(isStrictlyCommandOptions({ id: 'element-id', class: 'btn' })).toBe(false)
-            })
-
-            it('should return false for arrays and other object-type built-ins', () => {
-                expect(isStrictlyCommandOptions(['wait', 'message'])).toBe(false)
-                expect(isStrictlyCommandOptions(new Date())).toBe(false)
-            })
-
-            it('should return false for extended options (like StringOptions keys)', () => {
-            // String-specific options should fail a strict command-only option check
-                expect(isStrictlyCommandOptions({ trim: true })).toBe(false)
-                expect(isStrictlyCommandOptions({ ignoreCase: false })).toBe(false)
-                expect(isStrictlyCommandOptions({ wait: 2000, trim: true })).toBe(false)
-            })
-
-            it('should return false for objects containing valid options mixed with unrecognized keys', () => {
-                expect(isStrictlyCommandOptions({ wait: 2000, invalidProperty: 'malicious-or-typo' })).toBe(false)
-                expect(isStrictlyCommandOptions({ message: 'error', href: '/path' })).toBe(false)
-                expect(isStrictlyCommandOptions({ waitt: 1000 })).toBe(false) // Misspelled option key
-            })
-        })
-
-        // 4. Exhaustiveness Guard to catch additions/deletions at compile time
-        describe('Interface Exhaustiveness Guard', () => {
-            it('should compile successfully only if all interface keys are covered', () => {
-            // This object maps EVERY allowed key from COMMAND_OPTIONS_ALLOWED_KEY_LIST.
-            // We cast it strictly to require all optional keys from the combined base types.
-                const typeCompletenessCheck: Required<
-                ExpectWebdriverIO.CommandOptions &
-                ExpectWebdriverIO.DefaultOptions
-                > = {
-                    // CommandOptions
-                    message: '',
-
-                    // DefaultOptions
-                    wait: 0,
-                    interval: 0,
-                    beforeAssertion: async () => {},
-                    afterAssertion: async () => {},
-                    featureFlags: {}
-                }
-
-                // Run the runtime check against the fully-populated type asset
-                expect(isStrictlyCommandOptions(typeCompletenessCheck)).toBe(true)
-            })
-        })
+    it('should return false for arrays', () => {
+        expect(isDefinedPlainObject([])).toBe(false)
+        expect(isDefinedPlainObject([1, 2, 3])).toBe(false)
     })
 })

--- a/test/util/numberOptionsUtil.test.ts
+++ b/test/util/numberOptionsUtil.test.ts
@@ -1,5 +1,6 @@
 import { test, describe, expect, vi } from 'vitest'
 import {
+    isEmptyOrLegacyNumberOptions,
     isNumber,
     NumberMatcher,
     validateNumberAndExtractOptions
@@ -245,6 +246,20 @@ describe('numberOptionsUtil', () => {
             expect(result.commandOptions?.afterAssertion?.({} as any)).toBe(2)
             expect(beforeAssertion).toHaveBeenCalledTimes(1)
             expect(afterAssertion).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe(isEmptyOrLegacyNumberOptions, () => {
+        test('should return true for empty or legacy number options', () => {
+            expect(isEmptyOrLegacyNumberOptions({})).toBe(true)
+            expect(isEmptyOrLegacyNumberOptions({ wait: 0 })).toBe(true)
+            expect(isEmptyOrLegacyNumberOptions({ eq: 0, wait: 0 })).toBe(true)
+            expect(isEmptyOrLegacyNumberOptions({ gte: 1, lte: 10, wait: 0 })).toBe(true)
+        })
+
+        test('should return false for non-empty number options', () => {
+            expect(isEmptyOrLegacyNumberOptions({ eq: 5 })).toBe(false)
+            expect(isEmptyOrLegacyNumberOptions({ gte: 1, lte: 10 })).toBe(false)
         })
     })
 })

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -378,24 +378,22 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
 
     /**
      * `WebdriverIO.Element` -> `$$('./*').length`
-     * supports less / greater then or equals to be passed in options
+     * Supports less / greater then or equals to be passed in value as a NumberMatcher.
      */
     toHaveChildren: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         /**
-         * deprecated since 5.7.1, remove in v6.0.0.
-         * Passing explicit `undefined` or `{}` as a value is deprecated.
-         * Omit the second argument entirely or use options with `toHaveChildren({ gte: 1 }, options)`.????
+         * Verifies that the element has children.
+         * Same as `expect(el).toHaveChildren({ gte: 1 })` or `expect(el).toHaveChildren({ gte: 1 }, options)`.
+         */
+        (): Promise<void>;
+        /**
+         * @deprecated since 6.0.0, remove in v10.0.0.
+         * Passing explicit `undefined` or `{ wait : 1 }` (NumberOptions) as a value is deprecated.
+         * Use options with `toHaveChildren({ gte: 1 }, options)`.
          */
         (
             expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
-            options?: ExpectWebdriverIO.CommandOptions
-        ): Promise<void>;
-
-        /**
-         * When called with only configuration options (omitting the expected count) where default is gte 1.
-         */
-        (
             options?: ExpectWebdriverIO.CommandOptions
         ): Promise<void>;
 
@@ -408,7 +406,9 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         ): Promise<void>;
 
         /**
-         * deprecated since 5.7.1, remove in v6.0.0. NumberOptions is no longer supported. Use `toHaveChildren(numberMatcher, options)` instead.
+         * @deprecated since 6.0.0, remove in v10.0.0.
+         * NumberOptions is no longer supported. Use `expect(el).toHaveChildren(numberMatcher, options)` instead.
+         * Instead of `expect(el).toHaveChildren({ wait: 1 })` use `expect(el).toHaveChildren({ gte: 1 }, { wait: 1 })`.
          */
         (
             expectedValue: ExpectWebdriverIO.NumberOptions,
@@ -417,17 +417,18 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }, {
         /** Element $$() API */
         /**
-         * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` or `{}` as a value is deprecated. Omit the second argument entirely or use `toHaveChildren(options)`.
+         * Verifies that the element has children.
+         * Same as `expect(el).toHaveChildren({ gte: 1 })` or `expect(el).toHaveChildren({ gte: 1 }, options)`.
          */
-        (
-            expectedValue: undefined, // {} also deprecated but we cannot use it as a type because it would match any object
-            options?: ExpectWebdriverIO.CommandOptions
-        ): Promise<void>;
+        (): Promise<void>;
 
         /**
-         * When called with only configuration options (omitting the expected count) where default is gte 1.
+         * @deprecated Not supported
+         * NumberOptions is no longer supported. Use `expect(el).toHaveChildren(numberMatcher, options)` instead.
+         * Instead of `expect(el).toHaveChildren({ wait: 1 })` use `expect(el).toHaveChildren({ gte: 1 }, { wait: 1 })`.
          */
         (
+            expectedValue: undefined,
             options?: ExpectWebdriverIO.CommandOptions
         ): Promise<void>;
 


### PR DESCRIPTION
Better deprecation mechanism for NumberOptions while keeping legacy behaviour from v5.7.0, and transforming to the NumberMatcher