### PR TITLE
feat: Expand support of oneOf to all places supporting strings

### DIFF
--- a/src/matchers/asymmetrics/asymmetricsUtils.ts
+++ b/src/matchers/asymmetrics/asymmetricsUtils.ts
@@ -5,17 +5,17 @@ import { isAsymmetricMatcher } from '../../utils.js'
  * Build asymmetric matchers with options for WebdriverIO.
  * Requires new instance of asymmetric matcher to not have multiple assertions mutating the same instance with different options.
  */
-export const buildWdioAsymmetricMatchersWithOptions = <T>(expectedValue: T, options: ExpectWebdriverIO.StringOptions | undefined) => {
+export const buildWdioAsymmetricMatchersWithOptions = <T>(expectedValue: T, options: ExpectWebdriverIO.StringOptions | undefined): T => {
     if (options) {
         if (Array.isArray(expectedValue)) {
-            return expectedValue.map((value) => buildOneAsymmetricMatcherWithOptions(value, options))
+            return expectedValue.map((value) => buildOneAsymmetricMatcherWithOptions(value, options)) as unknown as T
         }
         return buildOneAsymmetricMatcherWithOptions(expectedValue, options)
     }
     return expectedValue
 }
 
-const buildOneAsymmetricMatcherWithOptions = <T>(expectedValue: T, options: ExpectWebdriverIO.StringOptions | undefined) => {
+const buildOneAsymmetricMatcherWithOptions = <T>(expectedValue: T, options: ExpectWebdriverIO.StringOptions | undefined): T => {
     if (options) {
         if (isAsymmetricMatcher(expectedValue) && 'withOptions' in expectedValue && typeof expectedValue.withOptions === 'function') {
             return expectedValue.withOptions(options)

--- a/src/matchers/asymmetrics/oneOf.ts
+++ b/src/matchers/asymmetrics/oneOf.ts
@@ -1,4 +1,4 @@
-import type { StringOptions } from 'expect-webdriverio'
+import type { HTMLOptions, StringOptions } from 'expect-webdriverio'
 import { compareTextWithArray } from '../../utils.js'
 import { WdioAsymmetricMatchers } from './asymmetricsUtils.js'
 
@@ -9,7 +9,7 @@ import { WdioAsymmetricMatchers } from './asymmetricsUtils.js'
  */
 export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp | AsymmetricMatcher<string>>> {
     // TODO support HTML options
-    public options: StringOptions = {}
+    public options: StringOptions | HTMLOptions = {}
 
     constructor(...sample: Array<string | RegExp | AsymmetricMatcher<string>>) {
         super(sample)

--- a/src/matchers/asymmetrics/oneOf.ts
+++ b/src/matchers/asymmetrics/oneOf.ts
@@ -7,11 +7,11 @@ import { WdioAsymmetricMatchers } from './asymmetricsUtils.js'
  * StringOptions is injected by the matcher for customization of the matching behavior.
  * @see oneOfWithContextMatcher
  */
-export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp | AsymmetricMatcher<string>>> {
+export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp | AsymmetricMatcher<string> | null>> {
     // TODO support HTML options
     public options: StringOptions | HTMLOptions = {}
 
-    constructor(...sample: Array<string | RegExp | AsymmetricMatcher<string>>) {
+    constructor(...sample: Array<string | RegExp | AsymmetricMatcher<string> | null>) {
         super(sample)
     }
 
@@ -21,10 +21,13 @@ export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp |
     }
 
     public asymmetricMatch(actual: unknown): boolean {
-        if (typeof actual !== 'string') {
+        if (actual === null) {
+            return this.sample.includes(null)
+        } else if (typeof actual !== 'string') {
             return false
         }
-        return compareTextWithArray(actual, this.sample, this.options).result
+
+        return compareTextWithArray(actual, this.sample.filter(s => s !== null), this.options).result
     }
 
     public withOptions(options: StringOptions): OneOfMatcher {

--- a/src/matchers/asymmetrics/oneOf.ts
+++ b/src/matchers/asymmetrics/oneOf.ts
@@ -69,6 +69,6 @@ export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp |
     }
 }
 
-export function oneOf(...sample: Array<string | RegExp | AsymmetricMatcher<string>>): OneOfMatcher {
+export function oneOf(...sample: Array<string | RegExp | AsymmetricMatcher<string> | null>): OneOfMatcher {
     return new OneOfMatcher(...sample)
 }

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -10,8 +10,10 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 import { expect as wdioExpect } from '../../index.js'
+import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
+import { OneOfMatcher } from '../asymmetrics/oneOf.js'
 
-async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: string | RegExp | AsymmetricMatcher<string> | undefined, options: ExpectWebdriverIO.StringOptions) {
+async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.StringOptions) {
     const attributeValue = await el.getAttribute(attribute)
 
     if (typeof attributeValue !== 'string' || expectedValue === undefined || expectedValue === null) {
@@ -19,13 +21,18 @@ async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element,
             return { result: expectedValue.asymmetricMatch(attributeValue), value: attributeValue }
         }
         return { result: attributeValue === expectedValue, value: attributeValue }
+    } else if ( expectedValue instanceof OneOfMatcher) {
+        return { result: expectedValue.asymmetricMatch(attributeValue), value: attributeValue }
     }
 
-    return compareText(attributeValue, expectedValue, options)
+    // TODO fix OneOfMatcher typing to not require casting here!
+    return compareText(attributeValue, expectedValue as string | RegExp | AsymmetricMatcher<string> | undefined, options)
 }
 
-export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybePromise, attribute: string, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
+export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybePromise, attribute: string, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
     const { expectation = 'attribute', verb = 'have', isNot } = this
+
+    expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     let el
     let attr
@@ -83,7 +90,7 @@ export async function toHaveAttribute(
 export async function toHaveAttribute(
     received: WdioElementMaybePromise,
     attribute: string,
-    value: string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher,
+    value: MaybeOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -93,14 +100,14 @@ export async function toHaveAttribute(
 export async function toHaveAttribute(
     received: WdioElementsMaybePromise,
     attribute: string,
-    value: MaybeArray<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
+    value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
 export async function toHaveAttribute(
     received: WdioElementOrArrayMaybePromise,
     attribute: string,
-    value?: MaybeArray<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
+    value?: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const matcherName = 'toHaveAttribute'

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -7,10 +7,11 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
+import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
 
 async function singleElementCompare(
     element: WebdriverIO.Element,
-    label: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined,
+    label: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined,
     options: ExpectWebdriverIO.StringOptions
 ) {
     const actualLabel = await element.getComputedLabel()
@@ -31,6 +32,8 @@ export async function toHaveComputedLabel(
         options,
     })
 
+    expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
+
     let el
     let actualLabel
 
@@ -39,7 +42,7 @@ export async function toHaveComputedLabel(
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
-                singleElementCompare: (element, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
+                singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -7,10 +7,11 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
+import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
 
 async function singleElementCompare(
     element: WebdriverIO.Element,
-    role: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined,
+    role: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined,
     options: ExpectWebdriverIO.StringOptions
 ) {
     const actualRole = await element.getComputedRole()
@@ -30,6 +31,8 @@ export async function toHaveComputedRole(
         options,
     })
 
+    expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
+
     let el
     let actualRole
 
@@ -38,7 +41,7 @@ export async function toHaveComputedRole(
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
-                singleElementCompare: (element, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
+                singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -65,7 +65,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementsMaybePromise,
     property: string,
-    value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | MaybeArray<number> | null | undefined,
+    value: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null> | undefined,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -84,7 +84,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementOrArrayMaybePromise,
     property: string,
-    value?: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | MaybeArray<number> | null | undefined,
+    value?: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null>  | undefined,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'property', verb = 'have', isNot, matcherName = 'toHaveElementProperty' } = this

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -65,7 +65,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementsMaybePromise,
     property: string,
-    value: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null | undefined>,
+    value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | MaybeArray<number> | null | undefined,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -76,7 +76,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
+    value: MaybeOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | number,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -84,7 +84,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementOrArrayMaybePromise,
     property: string,
-    value?: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | null | undefined,
+    value?: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | MaybeArray<number> | null | undefined,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'property', verb = 'have', isNot, matcherName = 'toHaveElementProperty' } = this

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,6 +1,6 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { MaybeArray, WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { expect as wdioExpect } from '../../index.js'
 import {
@@ -10,11 +10,13 @@ import {
     waitUntil,
     wrapExpectedWithArray
 } from '../../utils.js'
+import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
+import { OneOfMatcher } from '../asymmetrics/oneOf.js'
 
 async function condition(
     el: WebdriverIO.Element,
     property: string,
-    expectedValue: string | number | RegExp | AsymmetricMatcher<string> | null | undefined, // TODO: review if an array of expected values should be supported for this matcher similarly as other matchers
+    expectedValue: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string>> | null | undefined, // TODO: review if an array of expected values should be supported for this matcher similarly as other matchers
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ) {
     const { asString = false } = options
@@ -26,6 +28,8 @@ async function condition(
             return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
         }
         return { result: propertyValue === expectedValue, value: propertyValue }
+    } else if ( expectedValue instanceof OneOfMatcher) {
+        return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
     }
 
     // To review the cast to be more type safe but for now let's keep the existing behavior to ensure no regression
@@ -61,7 +65,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementsMaybePromise,
     property: string,
-    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null | undefined>,
+    value: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null | undefined>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -72,7 +76,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementMaybePromise,
     property: string,
-    value: string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher,
+    value: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -80,7 +84,7 @@ export async function toHaveElementProperty(
 export async function toHaveElementProperty(
     received: WdioElementOrArrayMaybePromise,
     property: string,
-    value?: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | null | undefined,
+    value?: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher> | null | undefined,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'property', verb = 'have', isNot, matcherName = 'toHaveElementProperty' } = this
@@ -100,6 +104,8 @@ export async function toHaveElementProperty(
         options,
     })
 
+    value = buildWdioAsymmetricMatchersWithOptions(value, options)
+
     let elements
     let actualProppertyValue: unknown
 
@@ -108,7 +114,7 @@ export async function toHaveElementProperty(
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: value,
-                singleElementCompare: (element, expectedValue: string | number | RegExp | AsymmetricMatcher<string> | null | undefined) => {
+                singleElementCompare: (element, expectedValue: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string>> | null | undefined) => {
                     return condition(element, property, expectedValue, options)
                 },
                 isNot,

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -7,20 +7,23 @@ import {
 } from '../../utils.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
-import type { MaybeArray, WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { WdioElementOrArrayMaybePromise } from '../../types.js'
 import type { AssertionResult } from 'expect-webdriverio'
+import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
 
-async function singleElementCompare(el: WebdriverIO.Element, html: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.HTMLOptions): Promise<CompareResult<string>> {
+async function singleElementCompare(el: WebdriverIO.Element, html: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.HTMLOptions): Promise<CompareResult<string>> {
     const actualHTML = await el.getHTML(options)
     return compareTextOrArray(actualHTML, html, options)
 }
 
 export async function toHaveHTML(
     received: WdioElementOrArrayMaybePromise,
-    expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
+    expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.HTMLOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
     const { expectation = 'HTML', verb = 'have', isNot, matcherName = 'toHaveHTML' } = this
+
+    expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     await options.beforeAssertion?.({
         matcherName,
@@ -35,7 +38,7 @@ export async function toHaveHTML(
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
-                singleElementCompare: (element, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
+                singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements

--- a/src/matchers/element/toHaveHref.ts
+++ b/src/matchers/element/toHaveHref.ts
@@ -8,7 +8,7 @@ import type { AssertionResult } from 'expect-webdriverio'
  */
 export async function toHaveHref(
     el: WdioElementMaybePromise,
-    expectedValue: string | RegExp | WdioAsymmetricMatcher<string>,
+    expectedValue: MaybeOneOf<string | RegExp | WdioAsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -17,13 +17,13 @@ export async function toHaveHref(
  */
 export async function toHaveHref(
     el: WdioElementsMaybePromise,
-    expectedValue: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string>>,
+    expectedValue: MaybeArrayOrOneOf<string | RegExp | WdioAsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
 export async function toHaveHref(
     el: WdioElementOrArrayMaybePromise,
-    expectedValue: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string>>,
+    expectedValue: MaybeArrayOrOneOf<string | RegExp | WdioAsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
 

--- a/src/matchers/element/toHaveId.ts
+++ b/src/matchers/element/toHaveId.ts
@@ -8,7 +8,7 @@ import type { AssertionResult } from 'expect-webdriverio'
  */
 export async function toHaveId(
     el: WdioElementMaybePromise,
-    expectedValue: string | RegExp | AsymmetricMatcher<string>,
+    expectedValue: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -17,13 +17,13 @@ export async function toHaveId(
  */
 export async function toHaveId(
     el: WdioElementsMaybePromise,
-    expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
+    expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
 export async function toHaveId(
     el: WdioElementOrArrayMaybePromise,
-    expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
+    expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
 

--- a/src/matchers/element/toHaveValue.ts
+++ b/src/matchers/element/toHaveValue.ts
@@ -8,7 +8,7 @@ import type { AssertionResult } from 'expect-webdriverio'
  */
 export function toHaveValue(
     el: WdioElementMaybePromise,
-    value: string | RegExp | AsymmetricMatcher<string>,
+    value: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
@@ -17,13 +17,13 @@ export function toHaveValue(
  */
 export function toHaveValue(
     el: WdioElementsMaybePromise,
-    value: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
+    value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options?: ExpectWebdriverIO.StringOptions
 ): Promise<AssertionResult>
 
 export function toHaveValue(
     el: WdioElementOrArrayMaybePromise,
-    value: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
+    value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult>{
     return (toHaveElementProperty as ToHaveElementPropertyFn).call(this, el, 'value', value, options)
@@ -33,6 +33,6 @@ export function toHaveValue(
 type ToHaveElementPropertyFn = (
     received: WdioElementOrArrayMaybePromise,
     property: string,
-    value: MaybeArray<string | number | RegExp | AsymmetricMatcher<string> | null> | ExpectWebdriverIO.StringOptions | undefined,
+    value: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | null> | ExpectWebdriverIO.StringOptions | undefined,
     options?: ExpectWebdriverIO.StringOptions
 ) => Promise<AssertionResult>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ const compareNumbers = (actual: number, options: ExpectWebdriverIO.NumberOptions
 
 export const compareTextOrArray = (
     actualText: string,
-    expectedTexts: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string> | ExpectWebdriverIO.OneOfPartialMatcher<string>> | undefined,
+    expectedTexts: MaybeArrayOrOneOf<string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string>> | undefined,
     options: ExpectWebdriverIO.StringOptions
 ): CompareResult<string> => {
     const unchangedActualText = actualText
@@ -153,10 +153,9 @@ export const compareTextOrArray = (
         if (expectedTexts.some((expected): expected is OneOfMatcher => expected instanceof OneOfMatcher)) {
             throw new Error('OneOf is not supported in array under legacy behavior. Please enable `useToHaveTextStrictMultiElementsCompareStrategy` feature flag to use the new strict index based matching strategy with `expect.oneOf()`.')
         } else {
-
-            // Casting since typeScript cannot scale down the type and remove OneOfMatcher.
-            const compareResults = compareTextWithArray(actualText, expectedTexts as Array<string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string>>, options)
-            return { result: compareResults.result, value: unchangedActualText }
+            console.warn('Array of expected values is deprecated. Please use `expect.oneOf()` asymmetric matcher to compare against multiple expected values. This will be removed in v10.0.0.')
+            // TODO one day consolidate typing and internal of oneOf so we do not need the below casting!
+            expectedTexts = new OneOfMatcher(...expectedTexts as Array<string | RegExp | AsymmetricMatcher<string>>).withOptions(options)
         }
     }
 
@@ -171,6 +170,7 @@ export const compareTextOrArray = (
 
 }
 
+// TODO one day turn this into at least a asymetrics class to better report in failure messages the string case we are in (containing, atStart, atEnd, atIndex, etc) and the expected value(s)
 export const compareText = (
     actual: string,
     expected: string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string> | null | undefined,

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -206,10 +206,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
 
                 expectTypeOf(expect(chainableElement).toHaveHTML('text')).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(chainableElement).toHaveHTML(/text/)).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(chainableElement).toHaveHTML(['text1', 'text2'])).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(chainableElement).toHaveHTML([expect.stringContaining('text1'), expect.stringContaining('text2')])).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(chainableElement).toHaveHTML([/text1/, /text2/])).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(chainableElement).toHaveHTML(['text1', /text1/, expect.stringContaining('text3')])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML(expect.oneOf('text1', 'text2'))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML(expect.oneOf(expect.stringContaining('text1'), expect.stringContaining('text2')))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(chainableElement).not.toHaveHTML('text')).toEqualTypeOf<Promise<void>>()
 
@@ -221,6 +221,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(elementArray).toHaveHTML([expect.stringContaining('text1'), expect.stringContaining('text2')])).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(elementArray).toHaveHTML([/text1/, /text2/])).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(elementArray).toHaveHTML(['text1', /text1/, expect.stringContaining('text3')])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(elementArray).toHaveHTML(['text1', expect.oneOf('text1', /text1/, expect.stringContaining('text3'))])).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(elementArray).not.toHaveHTML('text')).toEqualTypeOf<Promise<void>>()
 
@@ -238,6 +239,13 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(chainableArray).toHaveHTML).parameter(0).extract<number>().toBeNever()
 
                 expectTypeOf(expect(browser).toHaveHTML).toBeNever()
+            })
+
+            it('should be deprecated', async () => {
+                expectTypeOf(expect(chainableElement).toHaveHTML(['text1', 'text2'])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML([expect.stringContaining('text1'), expect.stringContaining('text2')])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML([/text1/, /text2/])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(chainableElement).toHaveHTML(['text1', /text1/, expect.stringContaining('text3')])).toEqualTypeOf<Promise<void>>()
             })
 
             it('should have ts errors when actual is not an element', async () => {

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -812,6 +812,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.oneOf('val1', 'val2'))).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.oneOf('val1', null))).toEqualTypeOf<Promise<void>>()
+
+                    //@ts-expect-error: TODO one day support oneOf with number
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.oneOf(1, 'val2'))).toEqualTypeOf<Promise<void>>()
 
                     expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
@@ -842,7 +846,9 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                     expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
 
                     expectTypeOf(expect(elements).toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', expect.oneOf(null, 'val', expect.stringContaining('val')))).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(elements).toHaveElementProperty('prop', ['val'])).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(elements).toHaveElementProperty('prop', [null])).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(elements).toHaveElementProperty('prop', [expect.anything(), expect.any(Number), 'value', expect.stringContaining('val')])).toEqualTypeOf<Promise<void>>()
                 })

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -811,6 +811,7 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.stringContaining('val'))).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.anything())).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).toHaveElementProperty('prop', expect.any(Number))).toEqualTypeOf<Promise<void>>()
+                    expectTypeOf(expect(element).toHaveElementProperty('prop', expect.oneOf('val1', 'val2'))).toEqualTypeOf<Promise<void>>()
 
                     expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()
                     expectTypeOf(expect(element).not.toHaveElementProperty('prop')).toEqualTypeOf<Promise<void>>()

--- a/test/matchers/asymmetrics/oneOf.test.ts
+++ b/test/matchers/asymmetrics/oneOf.test.ts
@@ -13,9 +13,17 @@ describe('OneOfMatcher', () => {
         it('should return false if the actual value is not a string', () => {
             const matcher = new OneOfMatcher('apple', 'banana')
 
-            expect(matcher.asymmetricMatch(123 as any)).toBe(false)
-            expect(matcher.asymmetricMatch(null as any)).toBe(false)
-            expect(matcher.asymmetricMatch(undefined as any)).toBe(false)
+            expect(matcher.asymmetricMatch(123)).toBe(false)
+            expect(matcher.asymmetricMatch(null)).toBe(false)
+            expect(matcher.asymmetricMatch(undefined)).toBe(false)
+        })
+
+        it('should support null', () => {
+            const matcher = new OneOfMatcher('apple', 'banana', null)
+
+            expect(matcher.asymmetricMatch(123)).toBe(false)
+            expect(matcher.asymmetricMatch(null)).toBe(true)
+            expect(matcher.asymmetricMatch(undefined)).toBe(false)
         })
     })
 

--- a/test/matchers/element/toHaveHTML.test.ts
+++ b/test/matchers/element/toHaveHTML.test.ts
@@ -4,6 +4,7 @@ import { toHaveHTML } from '../../../src/matchers/element/toHaveHTML.js'
 import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
+import { expect as wdioExpect } from 'expect-webdriverio'
 
 describe(toHaveHTML, () => {
 
@@ -237,7 +238,7 @@ Received: ""`)
                 expect(result.pass).toBe(true)
             })
 
-            test('success if array matches with html', async () => {
+            test('success if array matches with html - deprecated', async () => {
                 const result = await thisContext.toHaveHTML(element, ['This is example HTML', /Webdriver/i])
                 expect(result.pass).toBe(true)
             })
@@ -248,6 +249,33 @@ Received: ""`)
                     ignoreCase: true,
                 })
                 expect(result.pass).toBe(true)
+            })
+
+            test('success if matches one of the html', async () => {
+                const result = await thisContext.toHaveHTML(element, wdioExpect.oneOf('This is example HTML', /Webdriver/i))
+                expect(result.pass).toBe(true)
+            })
+
+            test('success if matches one of the html with ignoreCase', async () => {
+                const result = await thisContext.toHaveHTML(element, wdioExpect.oneOf('ThIs Is ExAmPlE HTML', /Webdriver/i), {
+                    wait: 1,
+                    ignoreCase: true,
+                })
+                expect(result.pass).toBe(true)
+            })
+
+            test('fails if does not match one of the html with ignoreCase', async () => {
+                const result = await thisContext.toHaveHTML(element, wdioExpect.oneOf('ThIs Is ExAmPlE', /Webdriv/i), {
+                    wait: 1,
+                    ignoreCase: true,
+                })
+                expect(result.pass).toBe(false)
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect $(\`sel\`) to have HTML
+
+Expected: oneOf<"ThIs Is ExAmPlE", /Webdriv/i>
+Received: "This is example HTML"`
+                )
             })
 
             test('failure if no match', async () => {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -29,7 +29,22 @@ type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherCont
     (this: Context, actual: any, ...expected: Array<any>): ExpectLibExpectationResult;
 }
 
+/**
+ * Indicates that a value can be either one T or an array of T.
+ */
 type MaybeArray<T> = T | T[]
+
+/**
+ * Indicates that a value can be either one T, an array of T with oneOf of T, or a oneOf matcher of T.
+ * For oneOf anything is excluded since it does not make any sense to have a oneOf with Anything matcher.
+ */
+type MaybeArrayOrOneOf<T> = T | (T | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything>>)[] | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything>>
+
+/**
+ * Indicates that a value can be either one T, or oneOf matchers of T.
+ * For oneOf anything is excluded since it does not make any sense to have a oneOf with Anything matcher.
+ */
+type MaybeOneOf<T> = T | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything>>
 
 /**
  * Real Promise and wdio chainable promise types.
@@ -225,7 +240,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both attribute name AND a specific expected value */
         (
             attribute: string,
-            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
+            value: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>> | ExpectWebdriverIO.PartialMatcherAnything,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }, {
@@ -247,7 +262,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both attribute name AND a specific expected value */
         (
             attribute: string,
-            value: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything>,
+            value: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }
@@ -294,7 +309,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
             className: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
             options?: ExpectWebdriverIO.StringOptions
         ) :Promise<void>
-        /** soon deprecated to replace by oneOf() or anyOf() when available */
+        /** @deprecated use `expect.oneOf()` instead of an array */
         (
             className: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
@@ -330,7 +345,8 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
+            // TODO support `oneOf` for number!
+            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }, {
@@ -356,7 +372,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | null | undefined>,
+            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>
@@ -368,14 +384,14 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Element $() API */
         (
 
-            value: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            value: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) => Promise<void>,
 
         /** Elements $$() API */
         (
 
-            value: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            value: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) => Promise<void>
     >
@@ -451,13 +467,13 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveHref: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            href: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }, {
         /** Elements $$() API */
         (
-            href: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            href: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }>
@@ -468,13 +484,13 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveLink: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            href: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            href: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }, {
         /** Elements $$() API */
         (
-            href: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            href: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }>
@@ -485,13 +501,13 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveId: FnWhenElementOrArrayLike<ActualT,
         /** Element $() API */
         (
-            id: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            id: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) => Promise<void>,
 
         /** Elements $$() API */
         (
-            id: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            id: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) => Promise<void>
     >
@@ -518,7 +534,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveText: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            text: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.OneOfPartialMatcher<string>,
+            text: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
         /** @deprecated Use `expect.oneOf()` instead. */
@@ -529,7 +545,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }, {
         /** Elements $$() API */
         (
-            text: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>> | ExpectWebdriverIO.OneOfPartialMatcher<string>,
+            text: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }>
@@ -541,10 +557,10 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveHTML: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            text: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            text: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.HTMLOptions
         ) : Promise<void>
-        /** soon deprecated to replace by oneOf() or anyOf() when available */
+        /** @deprecated to replace by oneOf() or anyOf() when available */
         (
             text: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.HTMLOptions
@@ -552,7 +568,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }, {
         /** Elements $$() API */
         (
-            text: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            text: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>>,
             options?: ExpectWebdriverIO.HTMLOptions
         ): Promise<void>
     }>
@@ -564,11 +580,11 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveComputedLabel: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            computedLabel: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            computedLabel: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
 
-        /** soon deprecated to replace by oneOf() or anyOf() when available */
+        /** @deprecated use `expect.oneOf()` instead of an array */
         (
             computedLabel: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
@@ -576,7 +592,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }, {
         /** Elements $$() API */
         (
-            computedLabel: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            computedLabel: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }>
@@ -588,11 +604,11 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     toHaveComputedRole: FnWhenElementOrArrayLike<ActualT, {
         /** Element $() API */
         (
-            computedRole: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
+            computedRole: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
 
-        /** soon deprecated to replace by oneOf() or anyOf() when available */
+        /** @deprecated use `expect.oneOf()` instead of an array */
         (
             computedRole: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
@@ -600,7 +616,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
     }, {
         /** Elements $$() API */
         (
-            computedRole: MaybeArray<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            computedRole: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
             options?: ExpectWebdriverIO.StringOptions
         ) : Promise<void>
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -37,8 +37,9 @@ type MaybeArray<T> = T | T[]
 /**
  * Indicates that a value can be either one T, an array of T with oneOf of T, or a oneOf matcher of T.
  * For oneOf anything is excluded since it does not make any sense to have a oneOf with Anything matcher.
+ * TODO support number in oneOf until then we exclude it from the type to avoid confusion.
  */
-type MaybeArrayOrOneOf<T> = T | (T | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything>>)[] | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything>>
+type MaybeArrayOrOneOf<T> = T | (T | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything | number>>)[] | ExpectWebdriverIO.OneOfPartialMatcher<Exclude<T, ExpectWebdriverIO.PartialMatcherAnything | number>>
 
 /**
  * Indicates that a value can be either one T, or oneOf matchers of T.
@@ -372,7 +373,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything> | MaybeArray<number>,
+            value: MaybeArrayOrOneOf<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | null>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -346,7 +346,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         (
             property: string,
             // TODO support `oneOf` for number!
-            value: string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>,
+            value: MaybeOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything> | number,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }, {
@@ -372,7 +372,7 @@ interface WdioElementOrArrayMatchers<_R, ActualT = unknown> {
         /** Assert both property name AND a specific expected value */
         (
             property: string,
-            value: MaybeArray<string | number | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>>,
+            value: MaybeArrayOrOneOf<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything> | MaybeArray<number>,
             options?: ExpectWebdriverIO.StringOptions
         ): Promise<void>;
     }>

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -90,7 +90,7 @@ type FnWhenElementArrayLike<ActualT, Fn> = ActualT extends ElementArrayLike ? Fn
 type FnWhenMock<ActualT, Fn> = ActualT extends MockPromise | WebdriverIO.Mock ? Fn : never
 
 interface WdioCustomAsymmetricMatchers {
-    oneOf(...values: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>): ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string>>
+    oneOf(...values: Array<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null>): ExpectWebdriverIO.OneOfPartialMatcher<string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | null>
 }
 
 /**


### PR DESCRIPTION
Expanding the `expect.oneOf` new asymetrics matcher to all matchers supporting string input.
   - See https://github.com/webdriverio/expect-webdriverio/pull/2157 FMI