### PR TITLE
fix: Refactor for bailing out wait time

### DIFF
--- a/src/matchers/asymmetrics/oneOf.ts
+++ b/src/matchers/asymmetrics/oneOf.ts
@@ -27,7 +27,7 @@ export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp |
             return false
         }
 
-        return compareTextWithArray(actual, this.sample.filter(s => s !== null), this.options).result
+        return compareTextWithArray(actual, this.sample.filter(s => s !== null), this.options).success
     }
 
     public withOptions(options: StringOptions): OneOfMatcher {

--- a/src/matchers/browser/toHaveClipboardText.ts
+++ b/src/matchers/browser/toHaveClipboardText.ts
@@ -18,16 +18,15 @@ export async function toHaveClipboardText(
         options,
     })
 
-    let actual
-    const pass = await waitUntil(
+    const { actual, success: pass } = await waitUntil(
         async () => {
             await browser.setPermissions({ name: 'clipboard-read' }, 'granted')
-            /**
-             * changes are that some browser don't support the clipboard API yet
-             */
+                // chances are that some browsers don't support the clipboard API yet
                 .catch((err) => log.warn(`Couldn't set clipboard permissions: ${err}`))
-            actual = await browser.execute(() => window.navigator.clipboard.readText())
-            return compareText(actual, expectedValue, options).result
+            const actual = await browser.execute(() => window.navigator.clipboard.readText())
+
+            const compareResult = compareText(actual, expectedValue, options)
+            return  { actual, success: compareResult.result, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveClipboardText.ts
+++ b/src/matchers/browser/toHaveClipboardText.ts
@@ -26,7 +26,7 @@ export async function toHaveClipboardText(
             const actual = await browser.execute(() => window.navigator.clipboard.readText())
 
             const compareResult = compareText(actual, expectedValue, options)
-            return  { actual, success: compareResult.result, subject: browser }
+            return  { actual, success: compareResult.success, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -31,7 +31,7 @@ export async function toHaveLocalStorageItem(
 
             const compareResult = compareText(actual, expectedValue, options)
 
-            return { actual, success: compareResult.result, subject: browser }
+            return { actual, success: compareResult.success, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -14,22 +14,24 @@ export async function toHaveLocalStorageItem(
         expectedValue: expectedValue ? [key, expectedValue] : key,
         options,
     })
-    let actual
-    const pass = await waitUntil(
+    const { actual, success: pass } = await waitUntil(
         async () => {
-            actual = await browser.execute(
+            const actual = await browser.execute(
                 (storageKey) => {
                     return localStorage.getItem(storageKey)
                 }, key)
             // if no expected value is provided, we just check if the item exists
             if (expectedValue === undefined) {
-                return actual !== null
+                return { actual, success: actual !== null, subject: browser }
             }
             // no localStorage item found
             if (actual === null) {
-                return false
+                return { actual, success: false, subject: browser }
             }
-            return compareText(actual, expectedValue, options).result
+
+            const compareResult = compareText(actual, expectedValue, options)
+
+            return { actual, success: compareResult.result, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -14,12 +14,13 @@ export async function toHaveTitle(
         options,
     })
 
-    let actual
-    const pass = await waitUntil(
+    const { actual, success } = await waitUntil(
         async () => {
-            actual = await browser.getTitle()
+            const actual = await browser.getTitle()
 
-            return compareText(actual, expectedValue, options).result
+            const compareResult = compareText(actual, expectedValue, options)
+
+            return { actual, success: compareResult.result, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }
@@ -27,7 +28,7 @@ export async function toHaveTitle(
 
     const message = enhanceError('window', expectedValue, actual, this, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {
-        pass,
+        pass: success,
         message: () => message
     }
 

--- a/src/matchers/browser/toHaveTitle.ts
+++ b/src/matchers/browser/toHaveTitle.ts
@@ -20,7 +20,7 @@ export async function toHaveTitle(
 
             const compareResult = compareText(actual, expectedValue, options)
 
-            return { actual, success: compareResult.result, subject: browser }
+            return { actual, success: compareResult.success, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveUrl.ts
+++ b/src/matchers/browser/toHaveUrl.ts
@@ -20,7 +20,7 @@ export async function toHaveUrl(
 
             const compareResult = compareText(actual, expectedValue, options)
 
-            return { actual, success: compareResult.result, subject: browser }
+            return { actual, success: compareResult.success, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/browser/toHaveUrl.ts
+++ b/src/matchers/browser/toHaveUrl.ts
@@ -14,12 +14,13 @@ export async function toHaveUrl(
         options,
     })
 
-    let actual
-    const pass = await waitUntil(
+    const { success: pass, actual } = await waitUntil(
         async () => {
-            actual = await browser.getUrl()
+            const actual = await browser.getUrl()
 
-            return compareText(actual, expectedValue, options).result
+            const compareResult = compareText(actual, expectedValue, options)
+
+            return { actual, success: compareResult.result, subject: browser }
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,6 +1,7 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
     compareText,
@@ -13,16 +14,16 @@ import { expect as wdioExpect } from '../../index.js'
 import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
 import { OneOfMatcher } from '../asymmetrics/oneOf.js'
 
-async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.StringOptions) {
+async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.StringOptions): Promise<CompareResult<string | null>> {
     const attributeValue = await el.getAttribute(attribute)
 
     if (typeof attributeValue !== 'string' || expectedValue === undefined || expectedValue === null) {
         if (isAsymmetricMatcher(expectedValue)) {
-            return { result: expectedValue.asymmetricMatch(attributeValue), value: attributeValue }
+            return { success: expectedValue.asymmetricMatch(attributeValue), actual: attributeValue }
         }
-        return { result: attributeValue === expectedValue, value: attributeValue }
+        return { success: attributeValue === expectedValue, actual: attributeValue }
     } else if ( expectedValue instanceof OneOfMatcher) {
-        return { result: expectedValue.asymmetricMatch(attributeValue), value: attributeValue }
+        return { success: expectedValue.asymmetricMatch(attributeValue), actual: attributeValue }
     }
 
     // TODO fix OneOfMatcher typing to not require casting here!

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -34,11 +34,9 @@ export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybeP
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    let el
-    let attr
-    const pass = await waitUntil(
+    const { success: pass, actual: attr, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, values: string | RegExp | AsymmetricMatcher<string> | undefined) => {
@@ -46,11 +44,6 @@ export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybeP
                 },
                 isNot
             })
-
-            el = result.subject
-            attr = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,6 +1,7 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
 import { isEmptyOrLegacyNumberOptions, validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
@@ -10,16 +11,16 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 
-async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher | undefined) {
+async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher | undefined): Promise<CompareResult<number | null>> {
     const children = await el.$$('./*').getElements()
 
     if (expectedValue === undefined) {
-        return { result: false, value: children?.length }
+        return { success: false, actual: children?.length }
     }
 
     return {
-        result: expectedValue?.asymmetricMatch(children?.length) ?? false,
-        value: children?.length
+        success: expectedValue?.asymmetricMatch(children?.length) ?? false,
+        actual: children?.length
     }
 }
 

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -94,21 +94,14 @@ export async function toHaveChildren(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
 
-    let subject
-    let children
-    const pass = await waitUntil(
+    const { success: pass, actual: children, subject } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedValue: NumberMatcher | undefined) => condition(element, expectedValue),
                 isNot
             })
-
-            subject = result.subject
-            children = result.actual
-
-            return result.success
         },
         isNot,
         { wait: commandOptions.wait, interval: commandOptions.interval }

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -34,12 +34,9 @@ export async function toHaveComputedLabel(
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    let el
-    let actualLabel
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualLabel, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
@@ -48,10 +45,6 @@ export async function toHaveComputedLabel(
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })
-            el = result.subject
-            actualLabel = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -33,12 +33,9 @@ export async function toHaveComputedRole(
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    let el
-    let actualRole
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualRole, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
@@ -47,10 +44,6 @@ export async function toHaveComputedRole(
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })
-            el = result.subject
-            actualRole = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -9,11 +9,11 @@ async function singleElementCompare(el: WebdriverIO.Element, attribute: string, 
     const actualClass = await el.getAttribute(attribute)
 
     if (value === undefined) {
-        return { result: false, value: actualClass }
+        return { success: false, actual: actualClass }
     }
 
     if (typeof actualClass !== 'string') {
-        return { result: false, value: actualClass }
+        return { success: false, actual: actualClass }
     }
 
     /**
@@ -26,12 +26,12 @@ async function singleElementCompare(el: WebdriverIO.Element, attribute: string, 
 
     const classes = actualClass.split(' ')
     const isValueInClasses = classes.some((clazz) => {
-        return compareTextOrArray(clazz, value, options).result
+        return compareTextOrArray(clazz, value, options).success
     })
 
     return {
-        result: isValueInClasses,
-        value: actualClass
+        success: isValueInClasses,
+        actual: actualClass
     }
 }
 

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -57,12 +57,9 @@ export async function toHaveElementClass(
 
     const attribute = 'class'
 
-    let el
-    let attr
-
-    const pass = await waitUntil(
+    const { success: pass, actual: attr, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, attribute, expectedValue, options),
@@ -71,10 +68,6 @@ export async function toHaveElementClass(
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })
-            el = result.subject
-            attr = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -106,12 +106,9 @@ export async function toHaveElementProperty(
 
     value = buildWdioAsymmetricMatchersWithOptions(value, options)
 
-    let elements
-    let actualProppertyValue: unknown
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualProppertyValue, subject: elements } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: value,
                 singleElementCompare: (element, expectedValue: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string>> | null | undefined) => {
@@ -121,10 +118,6 @@ export async function toHaveElementProperty(
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })
-            elements = result.subject
-            actualProppertyValue = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,6 +1,7 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { expect as wdioExpect } from '../../index.js'
 import {
@@ -18,18 +19,18 @@ async function condition(
     property: string,
     expectedValue: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string>> | null | undefined, // TODO: review if an array of expected values should be supported for this matcher similarly as other matchers
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
+): Promise<CompareResult<unknown>> {
     const { asString = false } = options
 
     const propertyValue = await el.getProperty(property)
 
     if (propertyValue === null || propertyValue === undefined || (!(expectedValue instanceof RegExp) && typeof propertyValue !== 'string' && !asString)) {
         if (isAsymmetricMatcher(expectedValue)) {
-            return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
+            return { success: expectedValue.asymmetricMatch(propertyValue), actual: propertyValue }
         }
-        return { result: propertyValue === expectedValue, value: propertyValue }
+        return { success: propertyValue === expectedValue, actual: propertyValue }
     } else if ( expectedValue instanceof OneOfMatcher) {
-        return { result: expectedValue.asymmetricMatch(propertyValue), value: propertyValue }
+        return { success: expectedValue.asymmetricMatch(propertyValue), actual: propertyValue }
     }
 
     // To review the cast to be more type safe but for now let's keep the existing behavior to ensure no regression

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -31,9 +31,7 @@ export async function toHaveHTML(
         options,
     })
 
-    let elements
-    let actualHTML
-    const pass = await waitUntil(
+    const { success: pass, actual: actualHTML, subject: elements } = await waitUntil(
         async () => {
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -44,10 +42,7 @@ export async function toHaveHTML(
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })
-            elements = result.subject
-            actualHTML = result.actual
-
-            return result.success
+            return result
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise, WdioElements } from '../../types.js'
+import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { wrapExpectedWithArray } from '../../util/elementsUtil.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
@@ -60,12 +60,9 @@ export async function toHaveHeight(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
-    let elements: WebdriverIO.Element | WdioElements | unknown
-    let actualHeight: string | number | (string | number | undefined)[] | undefined
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualHeight, subject: elements } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
@@ -73,11 +70,6 @@ export async function toHaveHeight(
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })
-
-            elements = result.subject
-            actualHeight = result.actual
-
-            return result.success
         },
         isNot,
         { wait: commandOptions.wait, interval: commandOptions.interval }

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { wrapExpectedWithArray } from '../../util/elementsUtil.js'
+import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
 import { validateNumberArrayAndExtractOptions } from '../../util/numberOptionsUtil.js'
@@ -9,12 +10,12 @@ import {
     waitUntil,
 } from '../../utils.js'
 
-async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher | undefined) {
+async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher | undefined): Promise<CompareResult<number | null>> {
     const actualHeight = await el.getSize('height')
 
     return {
-        result: expectedNumber?.asymmetricMatch(actualHeight) ?? false,
-        value: actualHeight
+        success: expectedNumber?.asymmetricMatch(actualHeight) ?? false,
+        actual: actualHeight
     }
 }
 

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -1,6 +1,7 @@
 import type { RectReturn } from '@wdio/protocols'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
     compareObject,
@@ -10,7 +11,7 @@ import {
 } from '../../utils.js'
 
 export type Size = Pick<RectReturn, 'width' | 'height'>
-async function condition(el: WebdriverIO.Element, size: Size | undefined): Promise<{ result: boolean, value: Size }> {
+async function condition(el: WebdriverIO.Element, size: Size | undefined): Promise<CompareResult<Size | null>> {
     const actualSize = await el.getSize()
 
     return compareObject(actualSize, size)

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -47,12 +47,9 @@ export async function toHaveSize(
         options,
     })
 
-    let el
-    let actualSize
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualSize, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedSize: Size | undefined) => condition(element, expectedSize),
@@ -60,11 +57,6 @@ export async function toHaveSize(
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })
-
-            el = result.subject
-            actualSize = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -11,7 +11,7 @@ import {
 
 async function condition(el: WebdriverIO.Element, style: { [key: string]: string; } | undefined, options: ExpectWebdriverIO.StringOptions): Promise<CompareResult<{ [key: string]: string | undefined; } | undefined>> {
     if (style === undefined) {
-        return { result: false, value: undefined }
+        return { success: false, actual: undefined }
     }
 
     return compareStyle(el, style, options)

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -48,12 +48,9 @@ export async function toHaveStyle(
         options,
     })
 
-    let el
-    let actualStyle
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualStyle, subject: el } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 // TODO try to make the type work without casting expectedValues to { [key: string]: string; } | undefined
@@ -62,10 +59,6 @@ export async function toHaveStyle(
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })
-            el = result.subject
-            actualStyle = result.actual
-
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -32,12 +32,10 @@ export async function toHaveText(
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    let actualText: string | string[] | undefined
-    let subject: unknown = received
     const isNewStrictCompare = getFeatureFlagValue(options, 'useToHaveTextStrictMultiElementsCompareStrategy')
-    const pass = await waitUntil(
+    const { success: pass, actual: actualText, subject: subject } = await waitUntil(
         async () => {
-            const commandResult = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, values: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | ExpectWebdriverIO.OneOfPartialMatcher<string> | undefined) => {
@@ -47,10 +45,6 @@ export async function toHaveText(
                 strategy: isNewStrictCompare ? 'NewStrictMultipleElements' : 'LegacyLooseMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })
-            subject = commandResult.subject
-            actualText = commandResult.actual
-
-            return commandResult.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElements, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { wrapExpectedWithArray } from '../../util/elementsUtil.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { validateNumberArrayAndExtractOptions, type NumberMatcher } from '../../util/numberOptionsUtil.js'
@@ -59,12 +59,9 @@ export async function toHaveWidth(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
-    let elements: WebdriverIO.Element | WdioElements | unknown
-    let actualWidth: MaybeArray<string | number | undefined> | undefined
-
-    const pass = await waitUntil(
+    const { success: pass, actual: actualWidth, subject: elements } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy( {
+            return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
@@ -72,11 +69,6 @@ export async function toHaveWidth(
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })
-
-            elements = result.subject
-            actualWidth = result.actual
-
-            return result.success
         },
         isNot,
         { wait: commandOptions.wait, interval: commandOptions.interval }

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -12,8 +12,8 @@ async function condition(el: WebdriverIO.Element, expectedNumber: NumberMatcher 
     const actualWidth = await el.getSize('width')
 
     return {
-        result: expectedNumber?.asymmetricMatch(actualWidth) ?? false,
-        value: actualWidth
+        success: expectedNumber?.asymmetricMatch(actualWidth) ?? false,
+        actual: actualWidth
     }
 }
 

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -39,21 +39,21 @@ export async function toBeElementsArrayOfSize(
     let { elements, other } = await awaitElementArray(received)
     const originalLength =  elements ? elements.length : undefined
 
-    const pass = await waitUntil(
+    const { success: pass } = await waitUntil(
         async () => {
             if (!elements) {
-                return false
+                return { success: false, subject: elements, actual: undefined }
             }
 
             // Verify if size match first before refetching elements
             const isPassing = expectedNumber.asymmetricMatch(elements.length)
             if (isPassing) {
-                return isPassing
+                return { success: isPassing, subject: elements, actual: elements.length }
             }
 
             // TODO should we do this on other matchers??
             elements = await refetchElements(elements, commandOptions.wait, true)
-            return false
+            return { success: false, subject: elements, actual: elements.length }
         },
         isNot,
         { wait: commandOptions.wait, interval: commandOptions.interval }

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -42,7 +42,7 @@ export async function toBeElementsArrayOfSize(
     const { success: pass } = await waitUntil(
         async () => {
             if (!elements) {
-                return { success: false, subject: elements, actual: undefined }
+                return { success: false, subject: elements, actual: undefined, abort: true }
             }
 
             // Verify if size match first before refetching elements

--- a/src/matchers/mock/toBeRequestedTimes.ts
+++ b/src/matchers/mock/toBeRequestedTimes.ts
@@ -35,11 +35,10 @@ export async function toBeRequestedTimes(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberAndExtractOptions(expectedValue, options)
 
-    let actual
-    const pass = await waitUntil(
+    const { success: pass, actual } = await waitUntil(
         async () => {
-            actual = received.calls.length
-            return expectedNumber.asymmetricMatch(actual)
+            const actual = received.calls.length
+            return { success: expectedNumber.asymmetricMatch(actual), subject: received, actual }
         },
         isNot,
         { wait: commandOptions.wait, interval: commandOptions.interval }

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -32,11 +32,11 @@ export async function toBeRequestedWith(
         options,
     })
 
-    let actual: RequestMock | undefined
-    const pass = await waitUntil(
+    const { success: pass, actual } = await waitUntil(
         async () => {
-            for (const call of received.calls) {
-                actual = call
+            let lastCall: RequestMock | undefined
+            for (const call of received.calls as RequestMock[]) {
+                lastCall = call
                 if (
                     methodMatcher(call.request.method, expectedValue.method) &&
                     statusCodeMatcher(call.response.status, expectedValue.statusCode) &&
@@ -47,11 +47,10 @@ export async function toBeRequestedWith(
                     // bodyMatcher(call.postData, expectedValue.postData) &&
                     // bodyMatcher(call.body, expectedValue.response)
                 ) {
-                    return true
+                    return { success: true, subject: call, actual: call }
                 }
             }
-
-            return false
+            return { success: false, subject: lastCall, actual: lastCall }
         },
         isNot,
         { ...options, wait: isNot ? 0 : options.wait }

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -3,10 +3,15 @@ import { awaitElementOrArray, isElement } from './elementsUtil.js'
 
 export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleElements'
 export type CompareResult<T> = { result: boolean; value: T }
-export type StrategyResult<T> = {
-    subject: WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | unknown;
+export type StrategyMaybeArrayResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
+    subject: E;
     success: boolean;
     actual: MaybeArray<T> | undefined;
+}
+export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
+    subject: E;
+    success: boolean;
+    actual: T | undefined;
 }
 
 /**
@@ -35,7 +40,7 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     strategy?: StrategyType,
     strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean }
 }
-): Promise<StrategyResult<Actual>> {
+): Promise<StrategyMaybeArrayResult<Actual>> {
     if (strategy === 'LegacyLooseMultipleElements') {
         return legacyMultipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot)
     }
@@ -61,7 +66,7 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     _isNot?: boolean,
 
-): Promise<StrategyResult<Actual>> => {
+): Promise<StrategyMaybeArrayResult<Actual>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
     if (!selector || isEmptyElements) {
@@ -116,7 +121,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     isNot: boolean,
     { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
-): Promise<StrategyResult<Actual>> => {
+): Promise<StrategyMaybeArrayResult<Actual>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -7,11 +7,13 @@ export type StrategyMaybeArrayResult<T, E = WebdriverIO.Element | WebdriverIO.El
     subject: E;
     success: boolean;
     actual: MaybeArray<T> | undefined;
+    abort?: boolean;
 }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
     success: boolean;
     actual: T | undefined;
+    abort?: boolean;
 }
 
 /**
@@ -74,6 +76,7 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
             subject: subject,
             success: false,
             actual: undefined,
+            abort: true,
         }
     }
 
@@ -131,6 +134,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             // For the new strategy, beside toExist, empty elements even with `.not` is considered a failure since there are no elements to compare against.
             success: isNot ? !allowEmptyElements : false,
             actual: undefined,
+            abort: !allowEmptyElements,
         }
     }
 
@@ -146,6 +150,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             subject,
             success: forceFailure ? !!isNot : compareResult.result,
             actual: compareResult.value,
+            abort: forceFailure,
         }
     }
 
@@ -195,7 +200,8 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     return {
         subject,
         success: isNot ? !(!forceFailure && isNotEmpty && isAllFalse(results)) : (!forceFailure && isNotEmpty && isAllTrue(results)),
-        actual: results.map(({ value }) => value)
+        actual: results.map(({ value }) => value),
+        abort: forceFailure,
     }
 }
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -2,13 +2,7 @@ import type { WdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
 import { awaitElementOrArray, isElement } from './elementsUtil.js'
 
 export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleElements'
-export type CompareResult<T> = { result: boolean; value: T }
-export type StrategyMaybeArrayResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
-    subject: E;
-    success: boolean;
-    actual: MaybeArray<T> | undefined;
-    abort?: boolean;
-}
+export type CompareResult<T> = { success: boolean; actual: T }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
     success: boolean;
@@ -42,7 +36,7 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     strategy?: StrategyType,
     strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean }
 }
-): Promise<StrategyMaybeArrayResult<Actual>> {
+): Promise<StrategyResult<MaybeArray<Actual>>> {
     if (strategy === 'LegacyLooseMultipleElements') {
         return legacyMultipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot)
     }
@@ -68,7 +62,7 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     _isNot?: boolean,
 
-): Promise<StrategyMaybeArrayResult<Actual>> => {
+): Promise<StrategyResult<MaybeArray<Actual>>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
     if (!selector || isEmptyElements) {
@@ -84,8 +78,8 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
         const compareResult = await singleElementCompare(selector, expectedValues)
         return {
             subject,
-            success: compareResult.result,
-            actual: compareResult.value,
+            success: compareResult.success,
+            actual: compareResult.actual,
         }
     }
 
@@ -102,8 +96,8 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
 
     return {
         subject,
-        success: results.length > 0 && results.every((res) => res.result === true),
-        actual: results.map(({ value }) => value),
+        success: results.length > 0 && results.every((res) => res.success === true),
+        actual: results.map(({ actual: value }) => value),
     }
 }
 
@@ -124,7 +118,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     isNot: boolean,
     { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
-): Promise<StrategyMaybeArrayResult<Actual>> => {
+): Promise<StrategyResult<MaybeArray<Actual>>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
 
@@ -148,8 +142,8 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
         const compareResult = await singleElementCompare(selector, expectedValues)
         return {
             subject,
-            success: forceFailure ? !!isNot : compareResult.result,
-            actual: compareResult.value,
+            success: forceFailure ? !!isNot : compareResult.success,
+            actual: compareResult.actual,
             abort: forceFailure,
         }
     }
@@ -170,7 +164,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             }
 
             const compareResult = await singleElementCompare(element, indexedExpectedValue, index)
-            return forceFailure ? { result: false, value: compareResult.value } : compareResult
+            return forceFailure ? { success: false, actual: compareResult.actual } : compareResult
         })
     )
 
@@ -184,7 +178,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     // Fill with undefined element's actual value when having less elements than expected values.
     if (Array.isArray(expectedValues) && expectedValues.length > selector.length) {
         const missingValues = Array(expectedValues.length - selector.length).fill(undefined)
-        results.push(...missingValues.map((value) => ({ result: false, value })))
+        results.push(...missingValues.map((value) => ({ success: false, actual: value })))
     }
 
     let forceFailure = false
@@ -200,10 +194,10 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     return {
         subject,
         success: isNot ? !(!forceFailure && isNotEmpty && isAllFalse(results)) : (!forceFailure && isNotEmpty && isAllTrue(results)),
-        actual: results.map(({ value }) => value),
+        actual: results.map(({ actual: value }) => value),
         abort: forceFailure,
     }
 }
 
-const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === true)
-const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === false)
+const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === true)
+const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === false)

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -5,10 +5,8 @@ export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleEle
 export type CompareResult<T> = { success: boolean; actual: T }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
-    success: boolean;
-    actual: T | undefined;
     abort?: boolean;
-}
+} & CompareResult<T | undefined>
 
 /**
  * Fetch element(s) and route them to the appropriate comparison strategy.

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -76,8 +76,7 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
         const compareResult = await singleElementCompare(selector, expectedValues)
         return {
             subject,
-            success: compareResult.success,
-            actual: compareResult.actual,
+            ...compareResult,
         }
     }
 

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -187,6 +187,6 @@ export const enhanceErrorBe = (
     return enhanceError(subject, expected, actual, { ...context, useNotInLabel: false }, verb, expectation, '', options)
 }
 
-const isSuccess = (isNot: boolean, result: boolean): boolean => {
-    return isNot ? !result : result
+const isSuccess = (isNot: boolean, success: boolean): boolean => {
+    return isNot ? !success : success
 }

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -37,7 +37,7 @@ export const waitUntil = async <T>(
                 if (passed) {
                     break
                 } else if (result?.abort) {
-                    return { subject: result.subject, success: isNot, actual: result.actual, abort: true }
+                    return { ...result, success: isNot }
                 }
                 await sleep(interval)
             } catch (err) {
@@ -50,9 +50,7 @@ export const waitUntil = async <T>(
             throw error
         }
 
-        result.success = !isNot
-
-        return result
+        return  { ...result, success: !isNot }
     } catch {
         if (error) {
             throw error

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -3,6 +3,13 @@ import type { StrategyResult } from './executeCommand.js'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+class ForceAbortError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ForceAbortError'
+    }
+}
+
 /**
  * wait for expectation to succeed
  * @param condition function
@@ -36,6 +43,8 @@ export const waitUntil = async <T>(
                 error = undefined
                 if (passed) {
                     break
+                } else if (result?.abort) {
+                    throw new ForceAbortError('force abort')
                 }
                 await sleep(interval)
             } catch (err) {
@@ -52,7 +61,7 @@ export const waitUntil = async <T>(
 
         return result
     } catch {
-        if (error) {
+        if (error && !(error instanceof ForceAbortError)) {
             throw error
         }
 

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_OPTIONS } from '../constants.js'
+import type { StrategyResult } from './executeCommand.js'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -8,11 +9,11 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
  * @param isNot     https://jestjs.io/docs/expect#thisisnot
  * @param options   wait, interval, etc
  */
-export const waitUntil = async (
-    condition: () => Promise<boolean>,
+export const waitUntil = async <T>(
+    condition: () => Promise<StrategyResult<T>>,
     isNot = false,
     { wait = DEFAULT_OPTIONS.wait, interval = DEFAULT_OPTIONS.interval } = {}
-): Promise<boolean> => {
+): Promise<StrategyResult<T>> => {
     // single attempt
     if (wait === 0) {
         return await condition()
@@ -21,6 +22,7 @@ export const waitUntil = async (
     let error: Error | undefined
 
     // wait for condition to be truthy
+    let result: StrategyResult<T> | undefined
     try {
         const start = Date.now()
         while (true) {
@@ -29,9 +31,10 @@ export const waitUntil = async (
             }
 
             try {
-                const result = isNot !== (await condition())
+                result = await condition()
+                const passed = isNot !== result?.success
                 error = undefined
-                if (result) {
+                if (passed) {
                     break
                 }
                 await sleep(interval)
@@ -45,12 +48,14 @@ export const waitUntil = async (
             throw error
         }
 
-        return !isNot
+        result.success = !isNot
+
+        return result
     } catch {
         if (error) {
             throw error
         }
 
-        return isNot
+        return { subject: result?.subject, success: isNot, actual: result?.actual }
     }
 }

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -3,13 +3,6 @@ import type { StrategyResult } from './executeCommand.js'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-class ForceAbortError extends Error {
-    constructor(message: string) {
-        super(message)
-        this.name = 'ForceAbortError'
-    }
-}
-
 /**
  * wait for expectation to succeed
  * @param condition function
@@ -44,7 +37,7 @@ export const waitUntil = async <T>(
                 if (passed) {
                     break
                 } else if (result?.abort) {
-                    throw new ForceAbortError('force abort')
+                    return { subject: result.subject, success: isNot, actual: result.actual, abort: true }
                 }
                 await sleep(interval)
             } catch (err) {
@@ -61,7 +54,7 @@ export const waitUntil = async <T>(
 
         return result
     } catch {
-        if (error && !(error instanceof ForceAbortError)) {
+        if (error) {
             throw error
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ async function executeCommandBe(
                 expectedValues: true,
                 singleElementCompare: async (element) => {
                     const result = await command(element)
-                    return { result, value: result }
+                    return { success: result, actual: result }
                 },
                 isNot,
                 strictConfiguration: { allowEmptyElements }
@@ -136,7 +136,7 @@ export const compareTextOrArray = (
     const unchangedActualText = actualText
 
     if (expectedTexts === undefined) {
-        return { value: actualText, result: false }
+        return { actual: actualText, success: false }
     }
 
     /**
@@ -155,13 +155,13 @@ export const compareTextOrArray = (
     }
 
     if (expectedTexts instanceof OneOfMatcher) {
-        return { result: expectedTexts.asymmetricMatch(actualText), value: unchangedActualText }
+        return { success: expectedTexts.asymmetricMatch(actualText), actual: unchangedActualText }
     }
 
     // TODO one day consolidate typing and internal of oneOf so we do not need the below casting!
     const compareResults = compareText(actualText, expectedTexts as string | RegExp, options)
 
-    return { result: compareResults.result, value: unchangedActualText }
+    return { success: compareResults.success, actual: unchangedActualText }
 
 }
 
@@ -181,8 +181,8 @@ export const compareText = (
 ): CompareResult<string> => {
     if (typeof actual !== 'string' || expected === null || expected === undefined) {
         return {
-            value: actual,
-            result: false,
+            actual: actual,
+            success: false,
         }
     }
 
@@ -207,48 +207,48 @@ export const compareText = (
     if (isAsymmetricMatcher(expected)) {
         const result = expected.asymmetricMatch(actual)
         return {
-            value: actual,
-            result
+            actual: actual,
+            success: result
         }
     }
 
     if (expected instanceof RegExp) {
         return {
-            value: actual,
-            result: !!actual.match(expected),
+            actual: actual,
+            success: !!actual.match(expected),
         }
     }
     if (containing) {
         return {
-            value: actual,
-            result: actual.includes(expected),
+            actual: actual,
+            success: actual.includes(expected),
         }
     }
 
     if (atStart) {
         return {
-            value: actual,
-            result: actual.startsWith(expected),
+            actual: actual,
+            success: actual.startsWith(expected),
         }
     }
 
     if (atEnd) {
         return {
-            value: actual,
-            result: actual.endsWith(expected),
+            actual: actual,
+            success: actual.endsWith(expected),
         }
     }
 
     if (atIndex) {
         return {
-            value: actual,
-            result: actual.substring(atIndex, actual.length).startsWith(expected),
+            actual: actual,
+            success: actual.substring(atIndex, actual.length).startsWith(expected),
         }
     }
 
     return {
-        value: actual,
-        result: actual === expected,
+        actual: actual,
+        success: actual === expected,
     }
 }
 
@@ -273,11 +273,11 @@ export const compareTextWithArray = (
         atIndex,
         replace,
     }: ExpectWebdriverIO.StringOptions
-) => {
+): CompareResult<string> => {
     if (typeof actual !== 'string') {
         return {
-            value: actual,
-            result: false,
+            actual: actual,
+            success: false,
         }
     }
 
@@ -303,7 +303,7 @@ export const compareTextWithArray = (
         })
     }
 
-    const textInArray = expectedArray.some((expected) => {
+    const hasFoundTextInArray = expectedArray.some((expected) => {
         if (expected instanceof RegExp) {
             return !!actual.match(expected)
         }
@@ -325,22 +325,22 @@ export const compareTextWithArray = (
         return actual === expected
     })
     return {
-        value: actual,
-        result: textInArray,
+        actual: actual,
+        success: hasFoundTextInArray,
     }
 }
 
-export const compareObject = <T>(actual: T, expected: unknown) => {
+export const compareObject = <T>(actual: T, expected: unknown): CompareResult<T> => {
     if (typeof actual !== 'object' || Array.isArray(actual)) {
         return {
-            value: actual,
-            result: false,
+            actual: actual,
+            success: false,
         }
     }
 
     return {
-        value: actual,
-        result: deepEql(actual, expected),
+        actual: actual,
+        success: deepEql(actual, expected),
     }
 }
 
@@ -356,8 +356,8 @@ export const compareStyle = async (
         atIndex,
         replace,
     }: ExpectWebdriverIO.StringOptions
-) => {
-    let result = true
+): Promise<CompareResult<Record<string, string | undefined>>> => {
+    let success = true
     const actual: Record<string, string | undefined> = {}
 
     for (const key in style) {
@@ -376,30 +376,30 @@ export const compareStyle = async (
         }
 
         if (containing) {
-            result = actualVal.includes(expectedVal)
+            success = actualVal.includes(expectedVal)
             actual[key] = actualVal
         } else if (atStart) {
-            result = actualVal.startsWith(expectedVal)
+            success = actualVal.startsWith(expectedVal)
             actual[key] = actualVal
         } else if (atEnd) {
-            result = actualVal.endsWith(expectedVal)
+            success = actualVal.endsWith(expectedVal)
             actual[key] = actualVal
         } else if (atIndex) {
-            result = actualVal.substring(atIndex, actualVal.length).startsWith(expectedVal)
+            success = actualVal.substring(atIndex, actualVal.length).startsWith(expectedVal)
             actual[key] = actualVal
         } else if (replace){
             const replacedActual = replaceActual(replace, actualVal)
-            result = replacedActual === expectedVal
+            success = replacedActual === expectedVal
             actual[key] = replacedActual
         } else {
-            result = result && actualVal === expectedVal
+            success = success && actualVal === expectedVal
             actual[key] = css.value
         }
     }
 
     return {
-        value: actual,
-        result,
+        actual: actual,
+        success,
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import type { ParsedCSSValue } from 'webdriverio'
 
 import { expect } from 'expect'
 
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise } from './types.js'
+import type { WdioElementOrArrayMaybePromise } from './types.js'
 import { wrapExpectedWithArray } from './util/elementsUtil.js'
 import type { CompareResult } from './util/executeCommand.js'
 import { executeCommandWithStrategy } from './util/executeCommand.js'
@@ -73,12 +73,10 @@ async function executeCommandBe(
 ): ExpectWebdriverIO.AsyncAssertionResult {
     const { isNot, verb = 'be', allowEmptyElements = false } = this
 
-    let subject: WdioElementMaybePromise | unknown = received
-    let actual: boolean[] | boolean | undefined
-    const pass = await waitUntil(
+    const { success: pass, actual, subject } = await waitUntil(
         async () => {
-            const result = await executeCommandWithStrategy({
-                unresolvedElements: subject,
+            return await executeCommandWithStrategy({
+                unresolvedElements: received,
                 expectedValues: true,
                 singleElementCompare: async (element) => {
                     const result = await command(element)
@@ -88,9 +86,6 @@ async function executeCommandBe(
                 strictConfiguration: { allowEmptyElements }
 
             })
-            subject = result.subject
-            actual = result.actual
-            return result.success
         },
         isNot,
         { wait: options.wait, interval: options.interval }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,7 +181,7 @@ export const compareText = (
 ): CompareResult<string> => {
     if (typeof actual !== 'string' || expected === null || expected === undefined) {
         return {
-            actual: actual,
+            actual,
             success: false,
         }
     }
@@ -207,47 +207,47 @@ export const compareText = (
     if (isAsymmetricMatcher(expected)) {
         const result = expected.asymmetricMatch(actual)
         return {
-            actual: actual,
+            actual,
             success: result
         }
     }
 
     if (expected instanceof RegExp) {
         return {
-            actual: actual,
+            actual,
             success: !!actual.match(expected),
         }
     }
     if (containing) {
         return {
-            actual: actual,
+            actual,
             success: actual.includes(expected),
         }
     }
 
     if (atStart) {
         return {
-            actual: actual,
+            actual,
             success: actual.startsWith(expected),
         }
     }
 
     if (atEnd) {
         return {
-            actual: actual,
+            actual,
             success: actual.endsWith(expected),
         }
     }
 
     if (atIndex) {
         return {
-            actual: actual,
+            actual,
             success: actual.substring(atIndex, actual.length).startsWith(expected),
         }
     }
 
     return {
-        actual: actual,
+        actual,
         success: actual === expected,
     }
 }
@@ -276,7 +276,7 @@ export const compareTextWithArray = (
 ): CompareResult<string> => {
     if (typeof actual !== 'string') {
         return {
-            actual: actual,
+            actual,
             success: false,
         }
     }
@@ -325,7 +325,7 @@ export const compareTextWithArray = (
         return actual === expected
     })
     return {
-        actual: actual,
+        actual,
         success: hasFoundTextInArray,
     }
 }
@@ -333,13 +333,13 @@ export const compareTextWithArray = (
 export const compareObject = <T>(actual: T, expected: unknown): CompareResult<T> => {
     if (typeof actual !== 'object' || Array.isArray(actual)) {
         return {
-            actual: actual,
+            actual,
             success: false,
         }
     }
 
     return {
-        actual: actual,
+        actual,
         success: deepEql(actual, expected),
     }
 }
@@ -398,7 +398,7 @@ export const compareStyle = async (
     }
 
     return {
-        actual: actual,
+        actual,
         success,
     }
 }

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -314,13 +314,14 @@ Received: undefined`
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $$(\`elements\`) to have style
 
-- Expected  - 0
-+ Received  + 1
+- Expected  - 1
++ Received  + 2
 
   Array [
     Object {
       "color": "#000",
-      "font-family": "Faktum",
+-     "font-family": "Faktum",
++     "font-family": "Wrong Value",
       "font-size": "26px",
     },
 +   undefined,
@@ -342,18 +343,20 @@ Expect $$(\`elements\`) to have style
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $$(\`elements\`) to have style
 
-- Expected  - 5
-+ Received  + 1
+- Expected  - 7
++ Received  + 3
 
   Array [
     Object {
       "color": "#000",
-      "font-family": "Faktum",
+-     "font-family": "Faktum",
++     "font-family": "Wrong Value",
       "font-size": "26px",
     },
     Object {
       "color": "#000",
-      "font-family": "Faktum",
+-     "font-family": "Faktum",
++     "font-family": "Wrong Value",
       "font-size": "26px",
     },
 -   Object {

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -108,8 +108,10 @@ const mockPost: local.NetworkAuthRequiredParameters = {
 
 describe(toBeRequestedWith, () => {
     let thisNotContext: { isNot: true,  toBeRequestedWith: typeof toBeRequestedWith }
+    let thisContext: { isNot: false,  toBeRequestedWith: typeof toBeRequestedWith }
 
     beforeEach(() => {
+        thisContext = { isNot: false,  toBeRequestedWith }
         thisNotContext = { isNot: true,  toBeRequestedWith }
     })
     test('wait for success, exact match', async () => {
@@ -119,6 +121,7 @@ describe(toBeRequestedWith, () => {
             mock.calls.push({ ...mockGet })
         }, 5)
         setTimeout(() => {
+            console.log('toBeRequestedWith.test: pushing calls', { ...mockGet }, { ...mockPost })
             mock.calls.push({ ...mockGet }, { ...mockPost })
         }, 15)
 
@@ -135,7 +138,7 @@ describe(toBeRequestedWith, () => {
         const beforeAssertion = vi.fn()
         const afterAssertion = vi.fn()
 
-        const result = await toBeRequestedWith(mock, params, { beforeAssertion, afterAssertion, wait: 500 })
+        const result = await thisContext.toBeRequestedWith(mock, params, { beforeAssertion, afterAssertion, wait: 500 })
 
         expect(result.pass).toBe(true)
         expect(beforeAssertion).toHaveBeenCalledWith({
@@ -457,7 +460,7 @@ Received      : {}`
     test('message', async () => {
         const mock: any = new TestMock()
 
-        const requested = await toBeRequestedWith(mock, {
+        const requested = await thisContext.toBeRequestedWith(mock, {
             url: () => false,
             method: ['DELETE', 'PUT'],
             requestHeaders: reduceHeaders(mockPost.request.headers),
@@ -466,7 +469,7 @@ Received      : {}`
             response: [...Array(50).keys()].map((_, id) => ({ id, name: `name_${id}` })),
         })
         expect(requested.pass).toBe(false)
-        expect(requested.message()).toEqual(`\
+        expect(stripAnsi(requested.message())).toEqual(`\
 Expect mock to be called with
 
 Expected: {"method": ["DELETE", "PUT"], "postData": "Anything ", "requestHeaders": {"Accept": "*", "Authorization": "Bearer ..2222222", "foo": "bar"}, "response": [{"id": 0, "name": "name_0"}, "... 49 more items"], "responseHeaders": {}, "url": "() => false"}
@@ -479,7 +482,7 @@ Received: "was not called"`
             method: mockPost.request.method,
         })
 
-        expect(notRequested.message()).toBe(
+        expect(stripAnsi(notRequested.message())).toBe(
             `Expect mock not to be called with
 
 - Expected [not]  - 1
@@ -544,7 +547,7 @@ Expect mock to be called with
         const mock: any = new TestMock()
         mock.calls.push({ ...mockPost })
 
-        const result = await toBeRequestedWith.call({}, mock, {
+        const result = await thisContext.toBeRequestedWith(mock, {
             url: jasmine.stringMatching(/\/api\/foo1$/),
         })
 

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -121,7 +121,6 @@ describe(toBeRequestedWith, () => {
             mock.calls.push({ ...mockGet })
         }, 5)
         setTimeout(() => {
-            console.log('toBeRequestedWith.test: pushing calls', { ...mockGet }, { ...mockPost })
             mock.calls.push({ ...mockGet }, { ...mockPost })
         }, 15)
 

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -15,7 +15,7 @@ describe('executeCommand', () => {
             const element = $('selector')
 
             it('should return success true when the element matches the expected value', async () => {
-                mockSingleCompare.mockResolvedValue({ result: true, value: 'Match' })
+                mockSingleCompare.mockResolvedValue({ success: true, actual: 'Match' })
 
                 const result = await multipleElementResultsStrategy(
                     element,
@@ -29,7 +29,7 @@ describe('executeCommand', () => {
             })
 
             it('should return success false when the element does not match the expected value', async () => {
-                mockSingleCompare.mockResolvedValue({ result: false, value: 'No Match' })
+                mockSingleCompare.mockResolvedValue({ success: false, actual: 'No Match' })
 
                 const result = await multipleElementResultsStrategy(
                     element,
@@ -48,7 +48,7 @@ describe('executeCommand', () => {
             const oneElements = chainableElementArrayFactory('selector', 1)
 
             it('should return success true when all elements match expected values', async () => {
-                mockSingleCompare.mockResolvedValue({ result: true, value: 'Match' })
+                mockSingleCompare.mockResolvedValue({ success: true, actual: 'Match' })
 
                 const result = await multipleElementResultsStrategy(
                     threeElements,
@@ -63,9 +63,9 @@ describe('executeCommand', () => {
 
             it('should return success false when some elements do not match', async () => {
                 mockSingleCompare
-                    .mockResolvedValueOnce({ result: true, value: 'Match' })
-                    .mockResolvedValueOnce({ result: false, value: 'No Match' })
-                    .mockResolvedValueOnce({ result: true, value: 'Match' })
+                    .mockResolvedValueOnce({ success: true, actual: 'Match' })
+                    .mockResolvedValueOnce({ success: false, actual: 'No Match' })
+                    .mockResolvedValueOnce({ success: true, actual: 'Match' })
 
                 const result = await multipleElementResultsStrategy(
                     threeElements,
@@ -78,7 +78,7 @@ describe('executeCommand', () => {
             })
 
             it('should pass (success=false) with .not when all elements fail to match', async () => {
-                mockSingleCompare.mockResolvedValue({ result: false, value: 'Other' })
+                mockSingleCompare.mockResolvedValue({ success: false, actual: 'Other' })
 
                 const result = await multipleElementResultsStrategy(
                     twoElements,
@@ -92,8 +92,8 @@ describe('executeCommand', () => {
 
             it('should fail (success=true) when using .not but one element matches', async () => {
                 mockSingleCompare
-                    .mockResolvedValueOnce({ result: false, value: 'Other' })
-                    .mockResolvedValueOnce({ result: true, value: 'Match' })
+                    .mockResolvedValueOnce({ success: false, actual: 'Other' })
+                    .mockResolvedValueOnce({ success: true, actual: 'Match' })
 
                 const result = await multipleElementResultsStrategy(
                     twoElements,
@@ -131,7 +131,7 @@ describe('executeCommand', () => {
             it('should handle missing elements compared to expected values array', async () => {
                 const expected = ['A', 'B'] // Expecting 2
 
-                mockSingleCompare.mockResolvedValue({ result: true, value: 'A' })
+                mockSingleCompare.mockResolvedValue({ success: true, actual: 'A' })
 
                 const result = await multipleElementResultsStrategy(
                     oneElements,

--- a/test/util/waitUntil.test.ts
+++ b/test/util/waitUntil.test.ts
@@ -185,4 +185,34 @@ describe(waitUntil, () => {
             })
         })
     })
+
+    describe('when condition returns abort: true', () => {
+        test('should return immediately without retrying (isNot=false)', async () => {
+            const condition = vi.fn().mockResolvedValue({
+                success: false,
+                abort: true,
+                subject: 'test',
+                actual: 'test',
+            })
+
+            const result = await waitUntil(condition, false, { wait: 5000, interval: 50 })
+
+            expect(result).toEqual({ success: false, subject: 'test', actual: 'test', abort: true })
+            expect(condition).toHaveBeenCalledTimes(1)
+        })
+
+        test('should return immediately without retrying (isNot=true), pass should be true since it is inverted later', async () => {
+            const condition = vi.fn().mockResolvedValue({
+                success: true,
+                abort: true,
+                subject: 'test',
+                actual: 'test',
+            })
+
+            const result = await waitUntil(condition, true, { wait: 5000, interval: 50 })
+
+            expect(result).toEqual({ success: true, subject: 'test', actual: 'test', abort: true })
+            expect(condition).toHaveBeenCalledTimes(1)
+        })
+    })
 })

--- a/test/util/waitUntil.test.ts
+++ b/test/util/waitUntil.test.ts
@@ -6,73 +6,73 @@ describe(waitUntil, () => {
         const isNot = undefined
         describe('should be pass=true for normal success', () => {
             test('should return true when condition is met', async () => {
-                const condition = vi.fn().mockResolvedValue(true)
+                const condition = vi.fn().mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
 
-                expect(result).toBe(true)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
             })
 
             test('should return true with wait 0', async () => {
-                const condition = vi.fn().mockResolvedValue(true)
+                const condition = vi.fn().mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 0 })
 
-                expect(result).toBe(true)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
             })
 
             test('should return true when condition is met within wait time', async () => {
-                const condition = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+                const condition = vi.fn().mockResolvedValueOnce({ success: false, subject: 'test', actual: 'test' }).mockResolvedValueOnce({ success: false, subject: 'test', actual: 'test' }).mockResolvedValueOnce({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 990, interval: 50 })
 
-                expect(result).toBe(true)
-                expect(condition).toBeCalledTimes(3)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
+                expect(condition).toHaveBeenCalledTimes(3)
             })
 
             test('should return true when condition errors but still is met within wait time', async () => {
-                const condition = vi.fn().mockRejectedValueOnce(new Error('Test error')).mockRejectedValueOnce(new Error('Test error')).mockResolvedValueOnce(true)
+                const condition = vi.fn().mockRejectedValueOnce(new Error('Test error')).mockRejectedValueOnce(new Error('Test error')).mockResolvedValueOnce({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 990, interval: 50 })
 
-                expect(result).toBe(true)
-                expect(condition).toBeCalledTimes(3)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
+                expect(condition).toHaveBeenCalledTimes(3)
             })
 
             test('should use default options when not provided', async () => {
-                const condition = vi.fn().mockResolvedValue(true)
+                const condition = vi.fn().mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition)
 
-                expect(result).toBe(true)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
             })
         })
 
         describe('should be pass=false for normal failure', () => {
 
             test('should return false when condition is not met within wait time', async () => {
-                const condition = vi.fn().mockResolvedValue(false)
+                const condition = vi.fn().mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 200, interval: 50 })
 
-                expect(result).toBe(false)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
             })
 
             test('should return false when condition is not met and wait is 0', async () => {
-                const condition = vi.fn().mockResolvedValue(false)
+                const condition = vi.fn().mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 0 })
 
-                expect(result).toBe(false)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
             })
 
             test('should return false if condition throws but still return false', async () => {
-                const condition = vi.fn().mockRejectedValueOnce(new Error('Always failing')).mockRejectedValueOnce(new Error('Always failing')).mockResolvedValue(false)
+                const condition = vi.fn().mockRejectedValueOnce(new Error('Always failing')).mockRejectedValueOnce(new Error('Always failing')).mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 180, interval: 50 })
 
-                expect(result).toBe(false)
-                expect(condition).toBeCalledTimes(4)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
+                expect(condition).toHaveBeenCalledTimes(4)
             })
         })
 
@@ -98,73 +98,73 @@ describe(waitUntil, () => {
         const isNot = true
         describe('should be pass=false for normal success', () => {
             test('should return false when condition is met', async () => {
-                const condition = vi.fn().mockResolvedValue(false)
+                const condition = vi.fn().mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 1000, interval: 100 })
 
-                expect(result).toBe(false)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
             })
 
             test('should return false with wait 0', async () => {
-                const condition = vi.fn().mockResolvedValue(false)
+                const condition = vi.fn().mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 0 })
 
-                expect(result).toBe(false)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
             })
 
             test('should return false when condition is met within wait time', async () => {
-                const condition = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+                const condition = vi.fn().mockResolvedValueOnce({ success: true, subject: 'test', actual: 'test' }).mockResolvedValueOnce({ success: true, subject: 'test', actual: 'test' }).mockResolvedValueOnce({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 990, interval: 50 })
 
-                expect(result).toBe(false) // success for .not, boolean is inverted later by jest's expect library
-                expect(condition).toBeCalledTimes(3)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' }) // success for .not, boolean is inverted later by jest's expect library
+                expect(condition).toHaveBeenCalledTimes(3)
             })
 
             test('should return false when condition errors but still is met within wait time', async () => {
-                const condition = vi.fn().mockRejectedValueOnce(new Error('Test error')).mockRejectedValueOnce(new Error('Test error')).mockResolvedValueOnce(false)
+                const condition = vi.fn().mockRejectedValueOnce(new Error('Test error')).mockRejectedValueOnce(new Error('Test error')).mockResolvedValueOnce({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 990, interval: 50 })
 
-                expect(result).toBe(false)
-                expect(condition).toBeCalledTimes(3)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
+                expect(condition).toHaveBeenCalledTimes(3)
             })
 
             test('should use default options when not provided', async () => {
-                const condition = vi.fn().mockResolvedValue(false)
+                const condition = vi.fn().mockResolvedValue({ success: false, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot)
 
-                expect(result).toBe(false)
+                expect(result).toEqual({ success: false, subject: 'test', actual: 'test' })
             })
         })
 
         describe('should be pass=true for normal failure', () => {
 
             test('should return true when condition is not met within wait time', async () => {
-                const condition = vi.fn().mockResolvedValue(true)
+                const condition = vi.fn().mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 200, interval: 50 })
 
-                expect(result).toBe(true)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
             })
 
             test('should return true when condition is not met and wait is 0', async () => {
-                const condition = vi.fn().mockResolvedValue(true)
+                const condition = vi.fn().mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 0 })
 
-                expect(result).toBe(true)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
             })
 
             test('should return true if condition throws but still return true', async () => {
-                const condition = vi.fn().mockRejectedValueOnce(new Error('Always failing')).mockRejectedValueOnce(new Error('Always failing')).mockResolvedValue(true)
+                const condition = vi.fn().mockRejectedValueOnce(new Error('Always failing')).mockRejectedValueOnce(new Error('Always failing')).mockResolvedValue({ success: true, subject: 'test', actual: 'test' })
 
                 const result = await waitUntil(condition, isNot, { wait: 190, interval: 50 })
 
-                expect(result).toBe(true)
-                expect(condition).toBeCalledTimes(4)
+                expect(result).toEqual({ success: true, subject: 'test', actual: 'test' })
+                expect(condition).toHaveBeenCalledTimes(4)
             })
         })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -34,148 +34,148 @@ vi.mock('../src/util/elementsUtil.js', async (importOriginal) => {
 describe('utils', () => {
     describe(compareText, () => {
         test('should pass when strings match', () => {
-            expect(compareText('foo', 'foo', {}).result).toBe(true)
+            expect(compareText('foo', 'foo', {}).success).toBe(true)
         })
 
         test('should fail when strings do not match', () => {
-            expect(compareText('foo', 'bar', {}).result).toBe(false)
+            expect(compareText('foo', 'bar', {}).success).toBe(false)
         })
 
         test('should pass when trims away white space', () => {
-            expect(compareText(' foo ', 'foo', {}).result).toBe(true)
+            expect(compareText(' foo ', 'foo', {}).success).toBe(true)
         })
 
         test('should fail without trimming away white space', () => {
-            expect(compareText(' foo ', 'foo ', { trim: false }).result).toBe(false)
+            expect(compareText(' foo ', 'foo ', { trim: false }).success).toBe(false)
         })
 
         test('should pass if same word but wrong case and using ignoreCase', () => {
-            expect(compareText(' FOO ', 'foo', { ignoreCase: true }).result).toBe(true)
-            expect(compareText(' foo ', 'FOO', { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' FOO ', 'foo', { ignoreCase: true }).success).toBe(true)
+            expect(compareText(' foo ', 'FOO', { ignoreCase: true }).success).toBe(true)
         })
 
         test('should pass if string contains expected and using containing', () => {
-            expect(compareText('qwe_AsD_zxc', 'asd', { ignoreCase: true, containing: true }).result).toBe(true)
+            expect(compareText('qwe_AsD_zxc', 'asd', { ignoreCase: true, containing: true }).success).toBe(true)
         })
 
         test('should support stringContaining asymmetric matchers', () => {
-            expect(compareText('foo', expect.stringContaining('oo'), {}).result).toBe(true)
-            expect(compareText('foo', expect.not.stringContaining('oo'), {}).result).toBe(false)
+            expect(compareText('foo', expect.stringContaining('oo'), {}).success).toBe(true)
+            expect(compareText('foo', expect.not.stringContaining('oo'), {}).success).toBe(false)
         })
 
         test('should support stringMatching asymmetric matchers', () => {
-            expect(compareText('foo', expect.stringMatching(/.*oo.*/), {}).result).toBe(true)
-            expect(compareText('foo', expect.not.stringMatching(/.*oo.*/), {}).result).toBe(false)
+            expect(compareText('foo', expect.stringMatching(/.*oo.*/), {}).success).toBe(true)
+            expect(compareText('foo', expect.not.stringMatching(/.*oo.*/), {}).success).toBe(false)
         })
 
         test('should support stringContaining asymmetric and using ignoreCase', () => {
-            expect(compareText(' FOO ', expect.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
-            expect(compareText(' FOO ', expect.not.stringContaining('foo'), { ignoreCase: true }).result).toBe(false)
-            expect(compareText(' Foo ', expect.stringContaining('FOO'), { ignoreCase: true }).result).toBe(true)
-            expect(compareText(' Foo ', expect.not.stringContaining('FOO'), { ignoreCase: true }).result).toBe(false)
-            expect(compareText(' foo ', expect.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' FOO ', expect.stringContaining('foo'), { ignoreCase: true }).success).toBe(true)
+            expect(compareText(' FOO ', expect.not.stringContaining('foo'), { ignoreCase: true }).success).toBe(false)
+            expect(compareText(' Foo ', expect.stringContaining('FOO'), { ignoreCase: true }).success).toBe(true)
+            expect(compareText(' Foo ', expect.not.stringContaining('FOO'), { ignoreCase: true }).success).toBe(false)
+            expect(compareText(' foo ', expect.stringContaining('foo'), { ignoreCase: true }).success).toBe(true)
         })
 
         test('should support jasmine.stringContaining matchers and using ignoreCase', () => {
-            expect(compareText(' FOO ', jasmine.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
-            expect(compareText(' Foo ', jasmine.stringContaining('FOO'), { ignoreCase: true }).result).toBe(true)
-            expect(compareText(' foo ', jasmine.stringContaining('foo'), { ignoreCase: true }).result).toBe(true)
+            expect(compareText(' FOO ', jasmine.stringContaining('foo'), { ignoreCase: true }).success).toBe(true)
+            expect(compareText(' Foo ', jasmine.stringContaining('FOO'), { ignoreCase: true }).success).toBe(true)
+            expect(compareText(' foo ', jasmine.stringContaining('foo'), { ignoreCase: true }).success).toBe(true)
         })
 
         test('should support jasmine.stringMatching matchers', () => {
-            expect(compareText(' FOO ', jasmine.stringMatching(/.*foo.*/i), {}).result).toBe(true)
+            expect(compareText(' FOO ', jasmine.stringMatching(/.*foo.*/i), {}).success).toBe(true)
         })
 
         test('should support undefined/null expected value', () => {
-            expect(compareText(' FOO ', undefined, {}).result).toBe(false)
-            expect(compareText(' FOO ', null, {}).result).toBe(false)
+            expect(compareText(' FOO ', undefined, {}).success).toBe(false)
+            expect(compareText(' FOO ', null, {}).success).toBe(false)
         })
     })
 
     describe(compareTextWithArray, () => {
         test('should pass if strings match in array', () => {
-            expect(compareTextWithArray('foo', ['foo', 'bar'], {}).result).toBe(true)
+            expect(compareTextWithArray('foo', ['foo', 'bar'], {}).success).toBe(true)
         })
 
         test('should fail if string does not match in array', () => {
-            expect(compareTextWithArray('foo', ['foot', 'bar'], {}).result).toBe(false)
+            expect(compareTextWithArray('foo', ['foot', 'bar'], {}).success).toBe(false)
         })
 
         test('should pass if white space and using trim', () => {
-            expect(compareTextWithArray(' foo ', ['foo', 'bar'], { trim: true }).result).toBe(true)
+            expect(compareTextWithArray(' foo ', ['foo', 'bar'], { trim: true }).success).toBe(true)
         })
 
         test('should pass if wrong case and using ignoreCase', () => {
-            expect(compareTextWithArray(' FOO ', ['foO', 'bar'], { trim: true, ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', ['foO', 'BAR'], { trim: true, ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', ['foOo', 'BAR'], { trim: true, ignoreCase: true }).result).toBe(false)
-            expect(compareTextWithArray(' FOO ', ['foOO', 'bar'], { trim: true, ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' FOO ', ['foO', 'bar'], { trim: true, ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', ['foO', 'BAR'], { trim: true, ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', ['foOo', 'BAR'], { trim: true, ignoreCase: true }).success).toBe(false)
+            expect(compareTextWithArray(' FOO ', ['foOO', 'bar'], { trim: true, ignoreCase: true }).success).toBe(false)
         })
 
         test('should pass if string contains and using containing', () => {
-            expect(compareTextWithArray('qwe_AsD_zxc', ['foo', 'ZXC'], { ignoreCase: true, containing: true }).result).toBe(true)
-            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxc'], { ignoreCase: true, containing: true }).result).toBe(true)
-            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: true }).result).toBe(false)
-            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: false }).result).toBe(false)
+            expect(compareTextWithArray('qwe_AsD_zxc', ['foo', 'ZXC'], { ignoreCase: true, containing: true }).success).toBe(true)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxc'], { ignoreCase: true, containing: true }).success).toBe(true)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: true }).success).toBe(false)
+            expect(compareTextWithArray('qwe_AsD_ZXC', ['foo', 'zxcc'], { ignoreCase: true, containing: false }).success).toBe(false)
         })
 
         test('should support asymmetric matchers', () => {
-            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.stringContaining('oobb')], {}).result).toBe(true)
-            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.stringContaining('oo')], {}).result).toBe(true)
-            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')], {}).result).toBe(false)
-            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.not.stringContaining('oo')], {}).result).toBe(false)
-            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.not.stringContaining('oobb')], {}).result).toBe(true)
-            expect(compareTextWithArray('foo', [expect.not.stringContaining('oobb'), expect.not.stringContaining('oo')], {}).result).toBe(true)
-            expect(compareTextWithArray('foo', [expect.not.stringContaining('oof'), expect.not.stringContaining('oobb')], {}).result).toBe(true)
-            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.not.stringContaining('foo')], {}).result).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.stringContaining('oobb')], {}).success).toBe(true)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.stringContaining('oo')], {}).success).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.stringContaining('oobb')], {}).success).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oobb'), expect.not.stringContaining('oo')], {}).success).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('oo'), expect.not.stringContaining('oobb')], {}).success).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oobb'), expect.not.stringContaining('oo')], {}).success).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oof'), expect.not.stringContaining('oobb')], {}).success).toBe(true)
+            expect(compareTextWithArray('foo', [expect.not.stringContaining('oo'), expect.not.stringContaining('foo')], {}).success).toBe(false)
         })
 
         test('should support asymmetric matchers and using ignoreCase', () => {
-            expect(compareTextWithArray(' FOO ', [expect.stringContaining('foo'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' FOO ', [expect.not.stringContaining('foo'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(false)
-            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.stringContaining('oobb')], { ignoreCase: true }).result).toBe(false)
-            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(false)
-            expect(compareTextWithArray('foo', [expect.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('OO'), expect.not.stringContaining('FOOO')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OOO')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).result).toBe(false)
+            expect(compareTextWithArray(' FOO ', [expect.stringContaining('foo'), expect.stringContaining('oobb')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' FOO ', [expect.not.stringContaining('foo'), expect.stringContaining('oobb')], { ignoreCase: true }).success).toBe(false)
+            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), expect.stringContaining('oobb')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.stringContaining('oobb')], { ignoreCase: true }).success).toBe(false)
+            expect(compareTextWithArray(' foo ', [expect.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).success).toBe(false)
+            expect(compareTextWithArray('foo', [expect.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('OO'), expect.not.stringContaining('FOOO')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOOO'), expect.not.stringContaining('OOO')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [expect.not.stringContaining('FOO'), expect.not.stringContaining('OO')], { ignoreCase: true }).success).toBe(false)
         })
 
         test('should support jasmine asymmetric matchers', () => {
-            expect(compareTextWithArray('foo', [jasmine.stringContaining('oobb'), jasmine.stringContaining('oo')], {}).result).toBe(true)
+            expect(compareTextWithArray('foo', [jasmine.stringContaining('oobb'), jasmine.stringContaining('oo')], {}).success).toBe(true)
         })
 
         test('should support jasmine asymmetric matchers and using ignoreCase', () => {
-            expect(compareTextWithArray(' FOO ', [jasmine.stringContaining('foo'), jasmine.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), jasmine.stringContaining('oobb')], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).result).toBe(true)
-            expect(compareTextWithArray('foo', [jasmine.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).result).toBe(true)
+            expect(compareTextWithArray(' FOO ', [jasmine.stringContaining('foo'), jasmine.stringContaining('oobb')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), jasmine.stringContaining('oobb')], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray('foo', [jasmine.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).success).toBe(true)
         })
     })
 
     describe(compareObject, () => {
         test('should pass if the objects are equal', () => {
-            expect(compareObject({ 'foo': 'bar' }, { 'foo': 'bar' }).result).toBe(true)
+            expect(compareObject({ 'foo': 'bar' }, { 'foo': 'bar' }).success).toBe(true)
         })
 
         test('should pass if the objects are deep equal', () => {
-            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'bar': 'baz' } }).result).toBe(true)
+            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'bar': 'baz' } }).success).toBe(true)
         })
 
         test('should fail if the objects are not equal', () => {
-            expect(compareObject({ 'foo': 'bar' }, { 'baz': 'quux' }).result).toBe(false)
+            expect(compareObject({ 'foo': 'bar' }, { 'baz': 'quux' }).success).toBe(false)
         })
 
         test('should fail if the objects are only shallow equal', () => {
-            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'baz': 'quux' } }).result).toBe(false)
+            expect(compareObject({ 'foo': { 'bar': 'baz' } }, { 'foo': { 'baz': 'quux' } }).success).toBe(false)
         })
 
         test('should fail if the actual value is a number or array', () => {
-            expect(compareObject(10, { 'foo': 'bar' }).result).toBe(false)
-            expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).result).toBe(false)
+            expect(compareObject(10, { 'foo': 'bar' }).success).toBe(false)
+            expect(compareObject([{ 'foo': 'bar' }], { 'foo': 'bar' }).success).toBe(false)
         })
     })
 


### PR DESCRIPTION
As pointed out by Greptile [in Bug B here](https://github.com/webdriverio/expect-webdriverio/pull/1990#issuecomment-5075102204), implementing a bail-out mechanism to abort earlier in cases where we know we will fail and do not need to exhaust all the wait time.
By refactoring `waitUntil` to receive the full context, we can enhance its behaviour while still returning the appropriate fetched actual and subject (like an awaited element).

This also streamlines the code instead of using a local variable to capture modified actual & elements (subject)