### PR TITLE
feat: Support some command options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1099,11 +1099,12 @@ For Jasmine, see the official documentation for [expect/expectAsync](https://jas
 
 ## Modifiers
 
+### .not
 WebdriverIO supports usage of modifiers as `.not` and it will wait until the reverse condition is meet
 
 ```ts
 // Wait until the element is no longer present
-await expect(element).not.toBeDisplayed()
+await expect($('element')).not.toBeDisplayed()
 
 // Wait until the text is no more 'some title'
 await expect(browser).not.toHaveTitle('some title')
@@ -1112,13 +1113,31 @@ await expect(browser).not.toHaveTitle('some title')
 In case immediate assertion is required, use `{ wait: 0 }`
 ```ts
 // Ensure element is not present right now
-await expect(element).not.toBeDisplayed({ wait: 0 })
+await expect($('element')).not.toBeDisplayed({ wait: 0 })
 
 // Ensure the text is not 'some title' right now
 await expect(browser).not.toHaveTitle('some title', { wait: 0 })
 ```
 
 **Note:** You can pair `.not` with asymmetric matchers, but to enable the wait-until behavior, `.not` must be used directly on the `expect()` call. 
+
+### some()
+
+since: v6.0.0
+
+The custom `some()` modifiers also exists with a different syntax then `.not` allowing to asserrt that only one element from multiple elements meet the assertion
+
+```ts
+// Allow to succeed only if one element matches (or not match)
+// Succeeds if at least one element matches either 'optionA' or 'optionB'
+await expect(some($$('elements'))).toHaveText(expect.oneOf('optionA', 'optionB'));
+// Succeeds if at least one element does not matches either 'forbiddenTextA' or 'forbiddenTextB'
+await expect(some($$('elements'))).not.toHaveText(/forbiddenTextA|forbiddenTextB/);
+// Succeeds if the first element matches 'valueForIndex0' OR the second matches 'valueForIndex1'
+await expect(some($$('elements'))).toHaveText(['valueForIndex0', 'valueForIndex1']);
+```
+
+**Note**: On `toHaveText`, the feature flag `useToHaveTextStrictMultiElementsCompareStrategy` must be enable to have `some()` working.
 
 ## Asymmetric Matchers
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1125,7 +1125,7 @@ await expect(browser).not.toHaveTitle('some title', { wait: 0 })
 
 since: v6.0.0
 
-The custom `some()` modifiers also exists with a different syntax then `.not` allowing to asserrt that only one element from multiple elements meet the assertion
+The custom `some()` function (distinct syntax compared to `.not`) allows you to assert that at least one element from multiple elements meets the assertion.
 
 ```ts
 // Allow to succeed only if one element matches (or not match)

--- a/docs/MultipleElements.md
+++ b/docs/MultipleElements.md
@@ -94,12 +94,16 @@ await expect(elements).toHaveText([
 // Negation with `.not`
 // Every element in the list must NOT match the regex pattern.
 await expect(elements).not.toHaveText(/forbiddenTextA|forbiddenTextB/);
+
+// Allow to succeed only if one element matches (or not match)
+// Succeeds if at least one element matches either 'optionA' or 'optionB'
+await expect(some(elements)).toHaveText(expect.oneOf('optionA', 'optionB'));
+// Succeeds if at least one element does not matches either 'forbiddenTextA' or 'forbiddenTextB'
+await expect(some(elements)).not.toHaveText(/forbiddenTextA|forbiddenTextB/);
+// Succeeds if the first element matches 'valueForIndex0' OR the second matches 'valueForIndex1'
+await expect(some(elements)).toHaveText(['valueForIndex0', 'valueForIndex1']);
 ```
 
 ## COMING SOON
 
-```ts
-// To allow passing if at least one element matches, we can introduce a `.some` modifier.
-await expect(elements).toHaveText('myValue1',{ some: true });
-await expect(elements).toBeDisplayed({ some: true });
-```
+- Refresh ElementArrays automatically on failures for more robust assertions

--- a/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
@@ -1,5 +1,5 @@
 import { browser, $, $$ } from '@wdio/globals'
-import { expect } from 'expect-webdriverio'
+import { expect, some } from 'expect-webdriverio'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {
@@ -43,6 +43,14 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(nav).toBeDisplayed()
         })
 
+        it('should verify that some elements are displayed', async () => {
+            const nav = $$('nav')
+
+            await expect(some(nav)).toBeDisplayed()
+            await expect(some(await nav)).toBeDisplayed()
+            await expect(some(await nav.filter(n => n.isExisting()))).toBeDisplayedInViewport()
+        })
+
         it('should verify element is displayed in viewport', async () => {
             const searchButton = await $('.DocSearch-Button')
             await expect(searchButton).toBeDisplayedInViewport()
@@ -67,6 +75,8 @@ describe('WebdriverIO Custom Matchers', () => {
     })
 
     describe('Element text matchers', () => {
+        const newStrictStrategy = { featureFlags: { useToHaveTextStrictMultiElementsCompareStrategy: true } }
+
         it('should verify element text', async () => {
             const docsLink = await $('=Docs')
             await expect(docsLink).toBeDisplayed()
@@ -81,6 +91,24 @@ describe('WebdriverIO Custom Matchers', () => {
         it('should verify text with options', async () => {
             const heading = await $$('h1')[1]  // Second h1 has text
             await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
+        })
+
+        it("should verify multiple elements's texts with options", async () => {
+            const headings = await $$('h1')
+
+            await expect(headings).toHaveText(expect.oneOf('','OPEN SOURCE'), { ignoreCase: true, containing: true, ...newStrictStrategy.featureFlags})
+        })
+
+        it("should verify multiple elements's texts exactly", async () => {
+            const headings = await $$('h1')
+
+            await expect(headings).toHaveText(['', 'Open Source and Open Governed'], newStrictStrategy)
+        })
+
+        it("should verify some elements with oneOf", async () => {
+            const headings = await $$('h1')
+
+            await expect(some(headings)).toHaveText(expect.oneOf('Open Source and Open Governed'), newStrictStrategy)
         })
 
         it('should verify element text with expected array', async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -137,7 +137,8 @@ describe('WebdriverIO Custom Matchers', () => {
 
                 it('should verify text with array of text with oneOf', async () => {
                     const heading = await $$('h1')
-                    await expect(heading).toHaveText(expect.oneOf('1','Open source'), { ignoreCase: true, containing: true })
+
+                    await expect(heading).toHaveText(expect.oneOf('','Open source'), { ignoreCase: true, containing: true })
                 })
 
                 it('should verify text with array of text without exact array match', async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -251,7 +251,10 @@ describe('WebdriverIO Custom Matchers', () => {
 
                 it('should verify some text with array of text', async () => {
                     const heading = await $$('h1')
+
                     await expect(some(heading)).toHaveText(['DoesNotMatch','Open Source and Open Governed'])
+                    await expect(some(heading)).toHaveText('Open Source and Open Governed')
+                    await expect(some(heading)).toHaveText('open source', { ignoreCase: true, containing: true })
                 })
 
                 it('should verify text with array of text without exact array match', async () => {
@@ -274,12 +277,6 @@ describe('WebdriverIO Custom Matchers', () => {
                     const heading = await $$('h1').getElements()
 
                     await expect(heading).toHaveText(['','Open Source and Open Governed'], { ignoreCase: true, containing: true })
-                })
-
-                it('should verify if some elements match', async () => {
-                    const heading = await $$('h1').getElements()
-
-                    await expect(heading).toHaveText('Open Source and Open Governed', { ignoreCase: true, containing: true, some: true })
                 })
 
                 it('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -79,7 +79,7 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(await nav.filter(n => n.isExisting())).toBeDisplayedInViewport()
         })
 
-        it.only('should verify that some elements are displayed', async () => {
+        it('should verify that some elements are displayed', async () => {
             const nav = $$('nav')
 
             await expect(some(nav)).toBeDisplayed()
@@ -112,9 +112,8 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(docsLink).toHaveText('Docs')
         })
 
-        it('should verify element text with expected array', async () => {
+        it('should verify element text with expected array (deprecated) or oneOf', async () => {
             const docsLink = await $('=Docs')
-            await expect(docsLink).toHaveText('Docs')
             await expect(docsLink).toHaveText(['Docs', 'Doc'])
             await expect(docsLink).toHaveText(expect.oneOf('Docs', 'Doc'))
         })
@@ -167,7 +166,6 @@ describe('WebdriverIO Custom Matchers', () => {
 
                     await expect(heading).toHaveText('OPEN SOURCE', { ignoreCase: true, containing: true })
                 })
-
 
                 describe('Empty elemetns', () => {
                     it('should fails if there is no elements with Element[]', async () => {
@@ -249,6 +247,11 @@ describe('WebdriverIO Custom Matchers', () => {
                 it('should verify text with array of text & with options with awaited ChainablePromiseArray', async () => {
                     const heading = await $$('h1')
                     await expect(heading).toHaveText(['','Open source'], { ignoreCase: true, containing: true })
+                })
+
+                it('should verify some text with array of text', async () => {
+                    const heading = await $$('h1')
+                    await expect(some(heading)).toHaveText(['DoesNotMatch','Open Source and Open Governed'])
                 })
 
                 it('should verify text with array of text without exact array match', async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -78,6 +78,14 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(await nav).toBeDisplayed()
             await expect(await nav.filter(n => n.isExisting())).toBeDisplayedInViewport()
         })
+
+        it('should verify that some elements are displayed', async () => {
+            const nav = $$('nav')
+
+            await expect(nav).toBeDisplayed({ some: true })
+            await expect(await nav).toBeDisplayed({ some: true })
+            await expect(await nav.filter(n => n.isExisting())).toBeDisplayedInViewport()
+        })
     })
 
     describe('Element state matchers', () => {
@@ -261,7 +269,14 @@ describe('WebdriverIO Custom Matchers', () => {
 
                 it('should verify text with options with awaited getElements ChainablePromiseArray', async () => {
                     const heading = await $$('h1').getElements()
+
                     await expect(heading).toHaveText(['','Open Source and Open Governed'], { ignoreCase: true, containing: true })
+                })
+
+                it('should verify if some elements match', async () => {
+                    const heading = await $$('h1').getElements()
+
+                    await expect(heading).toHaveText('Open Source and Open Governed', { ignoreCase: true, containing: true, some: true })
                 })
 
                 it('should verify text with options with filetered awaited getElements ChainablePromiseArray', async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -1,5 +1,5 @@
 import { browser, $, $$ } from '@wdio/globals'
-import { setFeatureFlags } from 'expect-webdriverio'
+import { setFeatureFlags, some } from 'expect-webdriverio'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {
@@ -82,9 +82,9 @@ describe('WebdriverIO Custom Matchers', () => {
         it('should verify that some elements are displayed', async () => {
             const nav = $$('nav')
 
-            await expect(nav).toBeDisplayed({ some: true })
-            await expect(await nav).toBeDisplayed({ some: true })
-            await expect(await nav.filter(n => n.isExisting())).toBeDisplayedInViewport()
+            await expect(some(nav)).toBeDisplayed()
+            await expect(some(await nav)).toBeDisplayed()
+            await expect(some(await nav.filter(n => n.isExisting()))).toBeDisplayedInViewport()
         })
     })
 

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -79,7 +79,7 @@ describe('WebdriverIO Custom Matchers', () => {
             await expect(await nav.filter(n => n.isExisting())).toBeDisplayedInViewport()
         })
 
-        it('should verify that some elements are displayed', async () => {
+        it.only('should verify that some elements are displayed', async () => {
             const nav = $$('nav')
 
             await expect(some(nav)).toBeDisplayed()

--- a/playgrounds/mocha/wdio.conf.ts
+++ b/playgrounds/mocha/wdio.conf.ts
@@ -17,12 +17,12 @@ export const config: WebdriverIO.Config = {
     // ==================
     //
     specs: [
-        //'./test/specs/**/*.test.ts',
+        './test/specs/**/*.test.ts',
         //'./test/specs/**/basic-matchers.test.ts',
         //'./test/specs/**/visual-snapshot.test.ts'
         //'./test/specs/**/soft-expect.test.ts',
         //'./test/specs/**/snapshot.test.ts'
-        './test/specs/**/wdio-matchers.test.ts'
+        //'./test/specs/**/wdio-matchers.test.ts'
         //'./test/specs/**/network-matchers.test.ts'
     ],
 

--- a/playgrounds/mocha/wdio.conf.ts
+++ b/playgrounds/mocha/wdio.conf.ts
@@ -17,12 +17,12 @@ export const config: WebdriverIO.Config = {
     // ==================
     //
     specs: [
-        './test/specs/**/*.test.ts',
+        //'./test/specs/**/*.test.ts',
         //'./test/specs/**/basic-matchers.test.ts',
         //'./test/specs/**/visual-snapshot.test.ts'
         //'./test/specs/**/soft-expect.test.ts',
         //'./test/specs/**/snapshot.test.ts'
-        //'./test/specs/**/wdio-matchers.test.ts'
+        './test/specs/**/wdio-matchers.test.ts'
         //'./test/specs/**/network-matchers.test.ts'
     ],
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_OPTIONS: Required<ExpectWebdriverIO.DefaultOptions> = {
     featureFlags: DEFAULT_FEATURE_FLAGS
 }
 
-export const DEFAULT_OPTIONS_TO_BE_DISPLAYED: Required<Omit<ExpectWebdriverIO.ToBeDisplayedOptions, 'message'>> = {
+export const DEFAULT_OPTIONS_TO_BE_DISPLAYED: Required<Omit<ExpectWebdriverIO.ToBeDisplayedOptions, 'message' | 'some'>> = {
     ...DEFAULT_OPTIONS,
     withinViewport: false,
     contentVisibilityAuto: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { DEFAULT_OPTIONS, defaultOptionsList } from './constants.js'
 import createSoftExpect from './softExpect.js'
 import { SoftAssertService } from './softAssert.js'
 import { oneOf } from './matchers/asymmetrics/oneOf.js'
+import { some as wdioSome } from './matchers/modifiers/some.js'
 
 /**
  * Contains the custom WDIO matchers, registered through `expect.extend()`.
@@ -69,6 +70,7 @@ Object.defineProperty(wdioExpect, 'clearSoftFailures', {
 
 // Fully configured global expect instance with all the custom WDIO matchers, asymmetric matchers, and soft assertions
 export const expect = wdioExpect
+export const some = wdioSome
 
 // Default options for the expect-webdriverio library
 export const getDefaultOptions = (): ExpectWebdriverIO.DefaultOptions => DEFAULT_OPTIONS

--- a/src/matchers/element/toBeClickable.ts
+++ b/src/matchers/element/toBeClickable.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeClickable(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'clickable'

--- a/src/matchers/element/toBeDisabled.ts
+++ b/src/matchers/element/toBeDisabled.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeDisabled(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'disabled'

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import { DEFAULT_OPTIONS_TO_BE_DISPLAYED } from '../../constants.js'
 
 export async function toBeDisplayed(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.ToBeDisplayedOptions = DEFAULT_OPTIONS_TO_BE_DISPLAYED,
 ) {
     this.expectation = this.expectation || 'displayed'

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -4,7 +4,7 @@ import { DEFAULT_OPTIONS_TO_BE_DISPLAYED } from '../../constants.js'
 
 export async function toBeDisplayed(
     received: WdioElementOrArrayMaybePromise,
-    options: ExpectWebdriverIO.ToBeDisplayedOptions = DEFAULT_OPTIONS_TO_BE_DISPLAYED,
+    options: ExpectWebdriverIO.ToBeDisplayedOptions & ExpectWebdriverIO.MultiElementOptions = DEFAULT_OPTIONS_TO_BE_DISPLAYED,
 ) {
     this.expectation = this.expectation || 'displayed'
 

--- a/src/matchers/element/toBeDisplayed.ts
+++ b/src/matchers/element/toBeDisplayed.ts
@@ -4,7 +4,7 @@ import { DEFAULT_OPTIONS_TO_BE_DISPLAYED } from '../../constants.js'
 
 export async function toBeDisplayed(
     received: WdioElementOrArrayMaybePromise,
-    options: ExpectWebdriverIO.ToBeDisplayedOptions & ExpectWebdriverIO.MultiElementOptions = DEFAULT_OPTIONS_TO_BE_DISPLAYED,
+    options: ExpectWebdriverIO.ToBeDisplayedOptions = DEFAULT_OPTIONS_TO_BE_DISPLAYED,
 ) {
     this.expectation = this.expectation || 'displayed'
 

--- a/src/matchers/element/toBeDisplayedInViewport.ts
+++ b/src/matchers/element/toBeDisplayedInViewport.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeDisplayedInViewport(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'displayed in viewport'

--- a/src/matchers/element/toBeEnabled.ts
+++ b/src/matchers/element/toBeEnabled.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeEnabled(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'enabled'

--- a/src/matchers/element/toBeExisting.ts
+++ b/src/matchers/element/toBeExisting.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toExist(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'exist'
@@ -26,13 +26,13 @@ export async function toExist(
     return result
 }
 
-export function toBeExisting(el: WdioElementOrArrayMaybePromise, options?: ExpectWebdriverIO.CommandOptions) {
+export function toBeExisting(el: MaybeSomeWdioElementOrArrayMaybePromise, options?: ExpectWebdriverIO.CommandOptions) {
     this.expectation = 'existing'
     this.verb = 'be'
 
     return toExist.call(this, el, options)
 }
-export function toBePresent(el: WdioElementOrArrayMaybePromise, options?: ExpectWebdriverIO.CommandOptions) {
+export function toBePresent(el: MaybeSomeWdioElementOrArrayMaybePromise, options?: ExpectWebdriverIO.CommandOptions) {
     this.expectation = 'present'
     this.verb = 'be'
 

--- a/src/matchers/element/toBeFocused.ts
+++ b/src/matchers/element/toBeFocused.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeFocused(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'focused'

--- a/src/matchers/element/toBeSelected.ts
+++ b/src/matchers/element/toBeSelected.ts
@@ -1,9 +1,9 @@
 import { executeCommandBe } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 
 export async function toBeSelected(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
     this.expectation = this.expectation || 'selected'
@@ -25,7 +25,7 @@ export async function toBeSelected(
     return result
 }
 
-export async function toBeChecked (received: WdioElementOrArrayMaybePromise, options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS) {
+export async function toBeChecked (received: MaybeSomeWdioElementOrArrayMaybePromise, options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS) {
     this.expectation = 'checked'
     this.matcherName = 'toBeChecked'
 

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -43,7 +43,9 @@ export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybeP
                 singleElementCompare: (element, values: string | RegExp | AsymmetricMatcher<string> | undefined) => {
                     return conditionAttributeValueMatchWithExpected(element, attribute, values, options)
                 },
-                isNot
+                isNot,
+                strategy: 'NewStrictMultipleElements',
+                strictConfiguration: {  some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -35,7 +35,7 @@ export async function toHaveAttributeAndValue(received: MaybeSomeWdioElementOrAr
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    const { success: pass, actual: attr, subject: el } = await waitUntil(
+    const { success: pass, actual: attr, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -53,7 +53,7 @@ export async function toHaveAttributeAndValue(received: MaybeSomeWdioElementOrAr
     )
 
     const expected = wrapExpectedWithArray(el, attr, expectedValue)
-    const message = enhanceError(el, expected, attr, this, verb, expectation, attribute, options)
+    const message = enhanceError(el, expected, attr, { isNot, isSome }, verb, expectation, attribute, options)
 
     return {
         pass,

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -1,6 +1,6 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
@@ -30,7 +30,7 @@ async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element,
     return compareText(attributeValue, expectedValue as string | RegExp | AsymmetricMatcher<string> | undefined, options)
 }
 
-export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybePromise, attribute: string, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
+export async function toHaveAttributeAndValue(received: MaybeSomeWdioElementOrArrayMaybePromise, attribute: string, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>, options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS) {
     const { expectation = 'attribute', verb = 'have', isNot } = this
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
@@ -65,7 +65,7 @@ export async function toHaveAttributeAndValue(received: WdioElementOrArrayMaybeP
  * deprecated since 5.7.1, remove in v6.0.0. Passing explicit `undefined` as a value is deprecated. Omit the third argument entirely or use `toHaveAttribute(el, attribute, options)`.
  */
 export async function toHaveAttribute(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     attribute: string,
     value: undefined,
     options?: ExpectWebdriverIO.StringOptions
@@ -75,7 +75,7 @@ export async function toHaveAttribute(
  * When called with only the attribute name (and optional configuration options).
  */
 export async function toHaveAttribute(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     attribute: string,
 ): Promise<AssertionResult>
 
@@ -101,7 +101,7 @@ export async function toHaveAttribute(
 ): Promise<AssertionResult>
 
 export async function toHaveAttribute(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     attribute: string,
     value?: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -45,7 +45,6 @@ export async function toHaveAttributeAndValue(received: MaybeSomeWdioElementOrAr
                 },
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: {  some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -1,6 +1,6 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import type { NumberMatcher } from '../../util/numberOptionsUtil.js'
@@ -29,7 +29,7 @@ async function condition(el: WebdriverIO.Element, expectedValue: NumberMatcher |
  * Same as `expect(el).toHaveChildren({ gte: 1 })` or `expect(el).toHaveChildren({ gte: 1 }, options)`.
  */
 export async function toHaveChildren(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
 ): Promise<AssertionResult>
 
 /**
@@ -75,7 +75,7 @@ export async function toHaveChildren(
 ): Promise<AssertionResult>
 
 export async function toHaveChildren(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValueOrOptions?: MaybeArray<number | ExpectWebdriverIO.NumberMatcher> | ExpectWebdriverIO.NumberOptions | ExpectWebdriverIO.CommandOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -95,7 +95,7 @@ export async function toHaveChildren(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
 
-    const { success: pass, actual: children, subject } = await waitUntil(
+    const { success: pass, actual: children, subject, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -111,7 +111,7 @@ export async function toHaveChildren(
     )
 
     const expectedArray = wrapExpectedWithArray(subject, children, expectedNumber)
-    const message = enhanceError(subject, expectedArray, children, this, verb, expectation, '', commandOptions)
+    const message = enhanceError(subject, expectedArray, children, { isNot, isSome }, verb, expectation, '', commandOptions)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -101,7 +101,9 @@ export async function toHaveChildren(
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedValue: NumberMatcher | undefined) => condition(element, expectedValue),
-                isNot
+                isNot,
+                strategy: 'NewStrictMultipleElements',
+                strictConfiguration: { some: commandOptions.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -103,7 +103,6 @@ export async function toHaveChildren(
                 singleElementCompare: (element, expectedValue: NumberMatcher | undefined) => condition(element, expectedValue),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { some: commandOptions.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -43,7 +43,7 @@ export async function toHaveComputedLabel(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true }
+                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -34,7 +34,7 @@ export async function toHaveComputedLabel(
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    const { success: pass, actual: actualLabel, subject: el } = await waitUntil(
+    const { success: pass, actual: actualLabel, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -54,7 +54,7 @@ export async function toHaveComputedLabel(
         el,
         wrapExpectedWithArray(el, actualLabel, expectedValue),
         actualLabel,
-        this,
+        { isNot, isSome },
         verb,
         expectation,
         '',

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
     compareTextOrArray,
@@ -20,7 +20,7 @@ async function singleElementCompare(
 }
 
 export async function toHaveComputedLabel(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ) {
@@ -43,7 +43,7 @@ export async function toHaveComputedLabel(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: true }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
     compareTextOrArray,
@@ -19,7 +19,7 @@ async function singleElementCompare(
 }
 
 export async function toHaveComputedRole(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ) {
@@ -42,7 +42,7 @@ export async function toHaveComputedRole(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: true }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -42,7 +42,7 @@ export async function toHaveComputedRole(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true }
+                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -33,7 +33,7 @@ export async function toHaveComputedRole(
 
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
-    const { success: pass, actual: actualRole, subject: el } = await waitUntil(
+    const { success: pass, actual: actualRole, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -53,7 +53,7 @@ export async function toHaveComputedRole(
         el,
         wrapExpectedWithArray(el, actualRole, expectedValue),
         actualRole,
-        this,
+        { isNot, isSome },
         verb,
         expectation,
         '',

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -1,6 +1,6 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { compareText, compareTextOrArray, enhanceError, isAsymmetricMatcher, waitUntil, wrapExpectedWithArray } from '../../utils.js'
@@ -43,7 +43,7 @@ export function toHaveClass(...args: unknown[]) {
 }
 
 export async function toHaveElementClass(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<string | RegExp | WdioAsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
@@ -66,7 +66,7 @@ export async function toHaveElementClass(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: true }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -57,7 +57,7 @@ export async function toHaveElementClass(
 
     const attribute = 'class'
 
-    const { success: pass, actual: attr, subject: el } = await waitUntil(
+    const { success: pass, actual: attr, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -73,7 +73,7 @@ export async function toHaveElementClass(
         { wait: options.wait, interval: options.interval }
     )
 
-    const message = enhanceError(el, wrapExpectedWithArray(el, attr, expectedValue), attr, this, verb, expectation, '', options)
+    const message = enhanceError(el, wrapExpectedWithArray(el, attr, expectedValue), attr, { isNot, isSome }, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -66,7 +66,7 @@ export async function toHaveElementClass(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true }
+                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -117,7 +117,7 @@ export async function toHaveElementProperty(
                 },
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false }
+                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -1,6 +1,6 @@
 import type { AssertionResult } from 'expect-webdriverio'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { expect as wdioExpect } from '../../index.js'
@@ -55,7 +55,7 @@ export async function toHaveElementProperty(
  * Same as `toHaveElementProperty(el, property, expect.anything())`.
  */
 export async function toHaveElementProperty(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     property: string,
 ): Promise<AssertionResult>
 
@@ -83,7 +83,7 @@ export async function toHaveElementProperty(
 
 // Implementation signature broadened to accept union types safely
 export async function toHaveElementProperty(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     property: string,
     value?: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher | null>  | undefined,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
@@ -117,7 +117,7 @@ export async function toHaveElementProperty(
                 },
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: false }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -107,7 +107,7 @@ export async function toHaveElementProperty(
 
     value = buildWdioAsymmetricMatchersWithOptions(value, options)
 
-    const { success: pass, actual: actualProppertyValue, subject: elements } = await waitUntil(
+    const { success: pass, actual: actualProppertyValue, subject: elements, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -125,7 +125,7 @@ export async function toHaveElementProperty(
     )
 
     const expected = wrapExpectedWithArray(elements, actualProppertyValue, value)
-    const message = enhanceError(elements, expected, actualProppertyValue, this, verb, expectation, property, options)
+    const message = enhanceError(elements, expected, actualProppertyValue, { isNot, isSome }, verb, expectation, property, options)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -31,7 +31,7 @@ export async function toHaveHTML(
         options,
     })
 
-    const { success: pass, actual: actualHTML, subject: elements } = await waitUntil(
+    const { success: pass, actual: actualHTML, subject: elements, context: { isSome } = {} } = await waitUntil(
         async () => {
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -49,7 +49,7 @@ export async function toHaveHTML(
     )
 
     const expectedValues = wrapExpectedWithArray(elements, actualHTML, expectedValue)
-    const message = enhanceError(elements, expectedValues, actualHTML, this, verb, expectation, '', options)
+    const message = enhanceError(elements, expectedValues, actualHTML, { isNot, isSome }, verb, expectation, '', options)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -7,7 +7,7 @@ import {
 } from '../../utils.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
-import type { WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import type { AssertionResult } from 'expect-webdriverio'
 import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
 
@@ -17,7 +17,7 @@ async function singleElementCompare(el: WebdriverIO.Element, html: MaybeArrayOrO
 }
 
 export async function toHaveHTML(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.HTMLOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {
@@ -40,7 +40,7 @@ export async function toHaveHTML(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: true }
             })
             return result
         },

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -40,7 +40,7 @@ export async function toHaveHTML(
                 isNot,
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
-                strictConfiguration: { allowArrayWithSingleElement: true }
+                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
             })
             return result
         },

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { wrapExpectedWithArray } from '../../util/elementsUtil.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
@@ -47,7 +47,7 @@ export async function toHaveHeight(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 export async function toHaveHeight(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<number | ExpectWebdriverIO.NumberMatcher> | ExpectWebdriverIO.NumberOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
@@ -69,7 +69,7 @@ export async function toHaveHeight(
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: false }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -69,7 +69,7 @@ export async function toHaveHeight(
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false }
+                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -61,7 +61,7 @@ export async function toHaveHeight(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
-    const { success: pass, actual: actualHeight, subject: elements } = await waitUntil(
+    const { success: pass, actual: actualHeight, subject: elements, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -81,7 +81,7 @@ export async function toHaveHeight(
         elements,
         expectedValues,
         actualHeight,
-        this,
+        { isNot, isSome },
         verb,
         expectation,
         '',

--- a/src/matchers/element/toHaveHref.ts
+++ b/src/matchers/element/toHaveHref.ts
@@ -1,6 +1,6 @@
 import { toHaveAttributeAndValue } from './toHaveAttribute.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { AssertionResult } from 'expect-webdriverio'
 
 /**
@@ -22,7 +22,7 @@ export async function toHaveHref(
 ): Promise<AssertionResult>
 
 export async function toHaveHref(
-    el: WdioElementOrArrayMaybePromise,
+    el: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArrayOrOneOf<string | RegExp | WdioAsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {

--- a/src/matchers/element/toHaveId.ts
+++ b/src/matchers/element/toHaveId.ts
@@ -1,6 +1,6 @@
 import { toHaveAttributeAndValue } from './toHaveAttribute.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { AssertionResult } from 'expect-webdriverio'
 
 /**
@@ -22,7 +22,7 @@ export async function toHaveId(
 ): Promise<AssertionResult>
 
 export async function toHaveId(
-    el: WdioElementOrArrayMaybePromise,
+    el: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult> {

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -48,7 +48,7 @@ export async function toHaveSize(
         options,
     })
 
-    const { success: pass, actual: actualSize, subject: el } = await waitUntil(
+    const { success: pass, actual: actualSize, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -67,7 +67,7 @@ export async function toHaveSize(
         el,
         wrapExpectedWithArray(el, actualSize, expectedValue),
         actualSize,
-        this,
+        { isNot, isSome },
         verb,
         expectation,
         '',

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -56,7 +56,7 @@ export async function toHaveSize(
                 singleElementCompare: (element, expectedSize: Size | undefined) => condition(element, expectedSize),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false }
+                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -1,6 +1,6 @@
 import type { RectReturn } from '@wdio/protocols'
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
@@ -36,7 +36,7 @@ export async function toHaveSize(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 export async function toHaveSize(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<Size>,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ) {
@@ -56,7 +56,7 @@ export async function toHaveSize(
                 singleElementCompare: (element, expectedSize: Size | undefined) => condition(element, expectedSize),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: false }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -48,7 +48,7 @@ export async function toHaveStyle(
         options,
     })
 
-    const { success: pass, actual: actualStyle, subject: el } = await waitUntil(
+    const { success: pass, actual: actualStyle, subject: el, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -65,7 +65,7 @@ export async function toHaveStyle(
     )
 
     const expected = wrapExpectedWithArray(el, actualStyle, expectedValue)
-    const message = enhanceError(el, expected, actualStyle, this, verb, expectation, '', options)
+    const message = enhanceError(el, expected, actualStyle, { isNot, isSome }, verb, expectation, '', options)
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { MaybeArray, WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { MaybeArray, WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import {
@@ -36,7 +36,7 @@ export async function toHaveStyle(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 export async function toHaveStyle(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<{ [key: string]: string; }>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<ExpectWebdriverIO.AssertionResult> {
@@ -57,7 +57,7 @@ export async function toHaveStyle(
                 singleElementCompare: (element, expectedValues) => condition(element, expectedValues as { [key: string]: string; } | undefined, options),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: false }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -57,7 +57,7 @@ export async function toHaveStyle(
                 singleElementCompare: (element, expectedValues) => condition(element, expectedValues as { [key: string]: string; } | undefined, options),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false }
+                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -33,7 +33,7 @@ export async function toHaveText(
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     const isNewStrictCompare = getFeatureFlagValue(options, 'useToHaveTextStrictMultiElementsCompareStrategy')
-    const { success: pass, actual: actualText, subject: subject } = await waitUntil(
+    const { success: pass, actual: actualText, subject: subject, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -51,7 +51,7 @@ export async function toHaveText(
     )
 
     const expected = fillSingleExpectedForElementArray(subject, expectedValue)
-    const message = enhanceError(subject, expected, actualText, this, verb, expectation, '', options)
+    const message = enhanceError(subject, expected, actualText, { isNot, isSome }, verb, expectation, '', options)
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
         message: (): string => message

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -43,7 +43,7 @@ export async function toHaveText(
                 },
                 isNot,
                 strategy: isNewStrictCompare ? 'NewStrictMultipleElements' : 'LegacyLooseMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: true }
+                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -5,7 +5,7 @@ import {
     getFeatureFlagValue,
     waitUntil,
 } from '../../utils.js'
-import type { MaybeArray, WdioElementOrArrayMaybePromise } from '../../types.js'
+import type { MaybeArray, MaybeSomeWdioElementOrArrayMaybePromise } from '../../types.js'
 import type { CompareResult } from '../../util/executeCommand.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { fillSingleExpectedForElementArray } from '../../util/elementsUtil.js'
@@ -18,7 +18,7 @@ async function compareElement(el: WebdriverIO.Element, expectedText: MaybeArray<
 }
 
 export async function toHaveText(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | ExpectWebdriverIO.OneOfPartialMatcher<string>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ) {
@@ -43,7 +43,7 @@ export async function toHaveText(
                 },
                 isNot,
                 strategy: isNewStrictCompare ? 'NewStrictMultipleElements' : 'LegacyLooseMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: true, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: true }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveValue.ts
+++ b/src/matchers/element/toHaveValue.ts
@@ -1,5 +1,5 @@
 import { toHaveElementProperty } from './toHaveElementProperty.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { AssertionResult } from 'expect-webdriverio'
 
@@ -22,7 +22,7 @@ export function toHaveValue(
 ): Promise<AssertionResult>
 
 export function toHaveValue(
-    el: WdioElementOrArrayMaybePromise,
+    el: MaybeSomeWdioElementOrArrayMaybePromise,
     value: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>>,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
 ): Promise<AssertionResult>{
@@ -31,7 +31,7 @@ export function toHaveValue(
 
 // toHaveElementProperty.call does not respect well the tsc so using the below workaround to make it work with the correct typing.
 type ToHaveElementPropertyFn = (
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     property: string,
     value: MaybeArrayOrOneOf<string | number | RegExp | AsymmetricMatcher<string> | null> | ExpectWebdriverIO.StringOptions | undefined,
     options?: ExpectWebdriverIO.StringOptions

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_OPTIONS } from '../../constants.js'
-import type { WdioElementMaybePromise, WdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
+import type { WdioElementMaybePromise, MaybeSomeWdioElementOrArrayMaybePromise, WdioElementsMaybePromise } from '../../types.js'
 import { wrapExpectedWithArray } from '../../util/elementsUtil.js'
 import { executeCommandWithStrategy } from '../../util/executeCommand.js'
 import { validateNumberArrayAndExtractOptions, type NumberMatcher } from '../../util/numberOptionsUtil.js'
@@ -45,7 +45,7 @@ export async function toHaveWidth(
 ): Promise<ExpectWebdriverIO.AssertionResult>
 
 export async function toHaveWidth(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     expectedValue: MaybeArray<number | ExpectWebdriverIO.NumberMatcher> | ExpectWebdriverIO.NumberOptions,
     options: ExpectWebdriverIO.CommandOptions = DEFAULT_OPTIONS
 ):Promise<ExpectWebdriverIO.AssertionResult> {
@@ -67,7 +67,7 @@ export async function toHaveWidth(
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
+                strictConfiguration: { allowArrayWithSingleElement: false }
             })
         },
         isNot,

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -59,7 +59,7 @@ export async function toHaveWidth(
 
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
-    const { success: pass, actual: actualWidth, subject: elements } = await waitUntil(
+    const { success: pass, actual: actualWidth, subject: elements, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
@@ -79,7 +79,7 @@ export async function toHaveWidth(
         elements,
         expectedValues,
         actualWidth,
-        this,
+        { isNot, isSome },
         verb,
         expectation,
         '',

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -67,7 +67,7 @@ export async function toHaveWidth(
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
                 isNot,
                 strategy: 'NewStrictMultipleElements',
-                strictConfiguration: { allowArrayWithSingleElement: false }
+                strictConfiguration: { allowArrayWithSingleElement: false, some: options.some }
             })
         },
         isNot,

--- a/src/matchers/modifiers/some.ts
+++ b/src/matchers/modifiers/some.ts
@@ -1,7 +1,9 @@
-const SOME_TAG = Symbol('expect-webdriverio.some')
+const SOME_TAG = 'expect-webdriverio.some'
+const SOME_SYMBOL = Symbol.for(SOME_TAG)
 
 export class SomeElementsWrapper<T> {
-    readonly [SOME_TAG] = true
+    // Not used but keeping in case it is needed in the future for type checking
+    readonly [SOME_SYMBOL] = true
     constructor(public readonly elements: T) {}
 }
 

--- a/src/matchers/modifiers/some.ts
+++ b/src/matchers/modifiers/some.ts
@@ -1,0 +1,14 @@
+const SOME_TAG = Symbol('expect-webdriverio.some')
+
+export class SomeElementsWrapper<T> {
+    readonly [SOME_TAG] = true
+    constructor(public readonly elements: T) {}
+}
+
+export function some<T>(elements: T): SomeElementsWrapper<T> {
+    return new SomeElementsWrapper(elements)
+}
+
+export function isSomeWrapper(value: unknown): value is SomeElementsWrapper<unknown> {
+    return value instanceof SomeElementsWrapper
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { ExpectationResult, MatcherContext } from 'expect'
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
+import type { SomeElementsWrapper } from './matchers/modifiers/some.js'
 
 export type WdioElementMaybePromise =
     WebdriverIO.Element |
@@ -11,12 +12,13 @@ export type WdioElementsMaybePromise =
     WdioElements |
     ChainablePromiseArray | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
-export type WdioElementOrArrayMaybePromise =
-    WdioElementMaybePromise |
-    WdioElementsMaybePromise
+export type MaybeSomeWdioElementOrArrayMaybePromise =
+    WdioElementMaybePromise | WdioElementsMaybePromise |
+    SomeElementsWrapper<WdioElementMaybePromise | WdioElementsMaybePromise>
 
 export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
     (this: Context, actual: unknown, ...expected: unknown[]): ExpectationResult;
 }
 
 export type MaybeArray<T> = T | T[]
+export type MaybeSome<T> = T | SomeElementsWrapper<T>

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,11 @@ export type WdioElementsMaybePromise =
     WdioElements |
     ChainablePromiseArray | Promise<WebdriverIO.Element[]> | Promise<WebdriverIO.ElementArray>
 
+export type WdioElementOrArrayMaybePromise =
+    WdioElementMaybePromise | WdioElementsMaybePromise
+
 export type MaybeSomeWdioElementOrArrayMaybePromise =
-    WdioElementMaybePromise | WdioElementsMaybePromise |
-    SomeElementsWrapper<WdioElementMaybePromise | WdioElementsMaybePromise>
+    MaybeSome<WdioElementMaybePromise | WdioElementsMaybePromise>
 
 export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
     (this: Context, actual: unknown, ...expected: unknown[]): ExpectationResult;

--- a/src/util/elementsUtil.ts
+++ b/src/util/elementsUtil.ts
@@ -1,4 +1,4 @@
-import type { WdioElementOrArrayMaybePromise, WdioElements, WdioElementsMaybePromise } from '../types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise, WdioElements, WdioElementsMaybePromise } from '../types.js'
 
 /**
  * Wraps the expected value in an array if both the target element (`el`) and the `actual` value are arrays.
@@ -103,7 +103,7 @@ export const isElementOrArrayLike = (obj: unknown): obj is WebdriverIO.ElementAr
  *  - `other`: Contains the original value if it was a primitive, `undefined`, or not a recognized element/array.
  */
 export const awaitElementOrArray = async(
-    received: WdioElementOrArrayMaybePromise | PromiseLike<WebdriverIO.Element> | unknown
+    received: MaybeSomeWdioElementOrArrayMaybePromise | PromiseLike<WebdriverIO.Element> | unknown
 ): Promise<{ selector?: WdioElements | WebdriverIO.Element, elements?: WdioElements, element?: WebdriverIO.Element, other?: unknown, isEmptyElements?: boolean }> => {
     if (!received || typeof received !== 'object') {
         return { other: received }

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -1,4 +1,5 @@
-import type { WdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
+import { isSomeWrapper } from '../matchers/modifiers/some.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
 import { awaitElementOrArray, isElement } from './elementsUtil.js'
 
 export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleElements'
@@ -27,7 +28,7 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     strategy = 'NewStrictMultipleElements',
     strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false, some: false }
 } :{
-    unresolvedElements: WdioElementOrArrayMaybePromise | unknown
+    unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | ReturnType<typeof isSomeWrapper> | unknown
     expectedValues: MaybeArray<Expected> | unknown
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected>, index?: number) => Promise<CompareResult<Actual>>
     isNot: boolean
@@ -39,8 +40,11 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
         return legacyMultipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot)
     }
 
+    const isSome = isSomeWrapper(unresolvedElements)
+    const actualReceived = isSome ? unresolvedElements.elements : unresolvedElements
+
     // Default new strategy for single & multiple element results, which is more consistent and less ambigious than the legacy strategy.
-    return multipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot, strictConfiguration)
+    return multipleElementResultsStrategy(actualReceived, expectedValues, singleElementCompare, { isNot, isSome }, strictConfiguration)
 }
 
 /**
@@ -55,7 +59,7 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
  * Kept for backward compatibility, to not be breaking but still be able to rollout the below new strategy.
  */
 export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
-    unresolvedElements: WdioElementOrArrayMaybePromise | unknown,
+    unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | unknown,
     expectedValues: MaybeArray<Expected> | undefined,
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     _isNot?: boolean,
@@ -110,11 +114,11 @@ export const legacyMultipleElementResultsStrategy = async <Expected, Actual>(
  * `allowEmptyElements` to let an empty element set pass the assertion instead of failing.
  */
 export const multipleElementResultsStrategy = async <Actual, Expected>(
-    unresolvedElements: WdioElementOrArrayMaybePromise | unknown,
+    unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | unknown,
     expectedValues: MaybeArray<Expected> | undefined,
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
-    isNot: boolean,
-    { allowEmptyElements = false, allowArrayWithSingleElement = false, some = false } = {}
+    { isNot, isSome }: { isNot: boolean; isSome: boolean },
+    { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
 ): Promise<StrategyResult<MaybeArray<Actual>>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
@@ -187,8 +191,8 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     const isNotEmpty = results.length > 0
 
     const success = isNot
-        ? !(!forceFailure && isNotEmpty && (some ? isAtLeastOneFalse(results) : isAllFalse(results)))
-        : (!forceFailure && isNotEmpty && (some ? isAtLeastOneTrue(results) : isAllTrue(results)))
+        ? !(!forceFailure && isNotEmpty && (isSome ? isAtLeastOneFalse(results) : isAllFalse(results)))
+        : (!forceFailure && isNotEmpty && (isSome ? isAtLeastOneTrue(results) : isAllTrue(results)))
 
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.
     // If there are no elements, it is considered a failure in both case with and without `.not`, as there are no elements to compare against.

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -27,14 +27,14 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     singleElementCompare,
     isNot,
     strategy = 'NewStrictMultipleElements',
-    strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false, some: false }
+    strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false }
 } :{
-    unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | ReturnType<typeof isSomeWrapper> | unknown
+    unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | unknown
     expectedValues: MaybeArray<Expected> | unknown
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected>, index?: number) => Promise<CompareResult<Actual>>
     isNot: boolean
     strategy?: StrategyType,
-    strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean, some?: boolean }
+    strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean }
 }
 ): Promise<StrategyResult<MaybeArray<Actual>>> {
     const isSome = isSomeWrapper(unresolvedElements)

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -37,11 +37,13 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean, some?: boolean }
 }
 ): Promise<StrategyResult<MaybeArray<Actual>>> {
+    const isSome = isSomeWrapper(unresolvedElements)
+
     if (strategy === 'LegacyLooseMultipleElements') {
+        console.error('some(elements) works only when enabling `useToHaveTextStrictMultiElementsCompareStrategy`')
         return legacyMultipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot)
     }
 
-    const isSome = isSomeWrapper(unresolvedElements)
     const actualReceived = isSome ? unresolvedElements.elements : unresolvedElements
 
     // Default new strategy for single & multiple element results, which is more consistent and less ambigious than the legacy strategy.

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -25,14 +25,14 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     singleElementCompare,
     isNot,
     strategy = 'NewStrictMultipleElements',
-    strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false }
+    strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false, some: false }
 } :{
     unresolvedElements: WdioElementOrArrayMaybePromise | unknown
     expectedValues: MaybeArray<Expected> | unknown
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected>, index?: number) => Promise<CompareResult<Actual>>
     isNot: boolean
     strategy?: StrategyType,
-    strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean }
+    strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean, some?: boolean }
 }
 ): Promise<StrategyResult<MaybeArray<Actual>>> {
     if (strategy === 'LegacyLooseMultipleElements') {
@@ -114,7 +114,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     expectedValues: MaybeArray<Expected> | undefined,
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
     isNot: boolean,
-    { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
+    { allowEmptyElements = false, allowArrayWithSingleElement = false, some = false } = {}
 ): Promise<StrategyResult<MaybeArray<Actual>>> => {
     const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
     const subject = selector ?? other
@@ -186,15 +186,21 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     const isNotEmpty = results.length > 0
 
+    const success = isNot
+        ? !(!forceFailure && isNotEmpty && (some ? isAtLeastOneFalse(results) : isAllFalse(results)))
+        : (!forceFailure && isNotEmpty && (some ? isAtLeastOneTrue(results) : isAllTrue(results)))
+
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.
     // If there are no elements, it is considered a failure in both case with and without `.not`, as there are no elements to compare against.
     return {
         subject,
-        success: isNot ? !(!forceFailure && isNotEmpty && isAllFalse(results)) : (!forceFailure && isNotEmpty && isAllTrue(results)),
-        actual: results.map(({ actual: value }) => value),
+        success,
+        actual: results.map(({ value }) => value)
         abort: forceFailure,
     }
 }
 
-const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === true)
-const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === false)
+const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === true)
+const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === false)
+const isAtLeastOneTrue = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.result === true)
+const isAtLeastOneFalse = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.result === false)

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -7,6 +7,7 @@ export type CompareResult<T> = { success: boolean; actual: T }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
     abort?: boolean;
+    context?: { isSome: boolean };
 } & CompareResult<T | undefined>
 
 /**
@@ -130,6 +131,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             success: isNot ? !allowEmptyElements : false,
             actual: undefined,
             abort: !allowEmptyElements,
+            context: { isSome }
         }
     }
 
@@ -146,6 +148,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             success: forceFailure ? !!isNot : compareResult.success,
             actual: compareResult.actual,
             abort: forceFailure,
+            context: { isSome }
         }
     }
 
@@ -201,6 +204,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
         success,
         actual: results.map(({ actual }) => actual),
         abort: forceFailure,
+        context: { isSome }
     }
 }
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -195,12 +195,12 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     return {
         subject,
         success,
-        actual: results.map(({ value }) => value)
+        actual: results.map(({ actual }) => actual),
         abort: forceFailure,
     }
 }
 
-const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === true)
-const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.result === false)
-const isAtLeastOneTrue = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.result === true)
-const isAtLeastOneFalse = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.result === false)
+const isAllTrue = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === true)
+const isAllFalse = (results: CompareResult<unknown>[]): boolean => results.every((res) => res.success === false)
+const isAtLeastOneTrue = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.success === true)
+const isAtLeastOneFalse = (results: CompareResult<unknown>[]): boolean => results.some((res) => res.success === false)

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -40,7 +40,9 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     const isSome = isSomeWrapper(unresolvedElements)
 
     if (strategy === 'LegacyLooseMultipleElements') {
-        console.error('some(elements) works only when enabling `useToHaveTextStrictMultiElementsCompareStrategy`')
+        if (isSome) {
+            throw new Error('some(elements) works only when enabling `useToHaveTextStrictMultiElementsCompareStrategy`')
+        }
         return legacyMultipleElementResultsStrategy(unresolvedElements, expectedValues, singleElementCompare, isNot)
     }
 

--- a/src/util/formatMessage.ts
+++ b/src/util/formatMessage.ts
@@ -53,7 +53,7 @@ export const enhanceError = (
     subject: string | WebdriverIO.Element | WdioElements | unknown,
     expected: unknown,
     actual: unknown,
-    context: { isNot: boolean, useNotInLabel?: boolean },
+    context: { isNot: boolean, useNotInLabel?: boolean, isSome?: boolean },
     verb: string,
     expectation: string,
     expectedValueArgument2 = '', {
@@ -117,8 +117,10 @@ ${label.received}: ${printReceived(actual)}`
         expectedValueArgument2 = ` ${expectedValueArgument2}`
     }
 
+    const some = context.isSome ? 'some of ' : ''
+
     const msg = `\
-${message}Expect ${subjectStr} ${not(isNot)}to ${verb}${expectation}${expectedValueArgument2}${contain}
+${message}Expect ${some}${subjectStr} ${not(isNot)}to ${verb}${expectation}${expectedValueArgument2}${contain}
 
 ${diffString}`
 
@@ -166,7 +168,7 @@ const printArrayWithMatchingItemInRed = (
 export const enhanceErrorBe = (
     subject: WebdriverIO.Element | WdioElements | unknown,
     results: boolean[] | boolean | undefined,
-    context: { isNot: boolean, verb: string, expectation: string },
+    context: { isNot: boolean, isSome: boolean, verb: string, expectation: string },
     options: ExpectWebdriverIO.CommandOptions
 ) => {
     const { isNot, verb, expectation } = context

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -56,6 +56,6 @@ export const waitUntil = async <T>(
             throw error
         }
 
-        return { subject: result?.subject, success: isNot, actual: result?.actual }
+        return { ...result, subject: result?.subject, success: isNot, actual: result?.actual }
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import type { ParsedCSSValue } from 'webdriverio'
 
 import { expect } from 'expect'
 
-import type { WdioElementOrArrayMaybePromise } from './types.js'
+import type { MaybeSomeWdioElementOrArrayMaybePromise } from './types.js'
 import { wrapExpectedWithArray } from './util/elementsUtil.js'
 import type { CompareResult } from './util/executeCommand.js'
 import { executeCommandWithStrategy } from './util/executeCommand.js'
@@ -67,7 +67,7 @@ export function getAsymmetricMatcherValue<T>(
 }
 
 async function executeCommandBe(
-    received: WdioElementOrArrayMaybePromise,
+    received: MaybeSomeWdioElementOrArrayMaybePromise,
     command: (el: WebdriverIO.Element) => Promise<boolean>,
     options: ExpectWebdriverIO.CommandOptions = {}
 ): ExpectWebdriverIO.AsyncAssertionResult {
@@ -83,7 +83,7 @@ async function executeCommandBe(
                     return { success: result, actual: result }
                 },
                 isNot,
-                strictConfiguration: { allowEmptyElements, some: options.some },
+                strictConfiguration: { allowEmptyElements },
 
             })
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ async function executeCommandBe(
 ): ExpectWebdriverIO.AsyncAssertionResult {
     const { isNot, verb = 'be', allowEmptyElements = false } = this
 
-    const { success: pass, actual, subject } = await waitUntil(
+    const { success: pass, actual, subject, context: { isSome } = {} } = await waitUntil(
         async () => {
             return await executeCommandWithStrategy({
                 unresolvedElements: received,
@@ -91,7 +91,7 @@ async function executeCommandBe(
         { wait: options.wait, interval: options.interval }
     )
 
-    const message = enhanceErrorBe(subject, actual, { ...this, verb }, options)
+    const message = enhanceErrorBe(subject, actual, { ...this, verb, isSome }, options)
 
     return {
         pass,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export function getAsymmetricMatcherValue<T>(
 async function executeCommandBe(
     received: WdioElementOrArrayMaybePromise,
     command: (el: WebdriverIO.Element) => Promise<boolean>,
-    options: ExpectWebdriverIO.CommandOptions
+    options: ExpectWebdriverIO.CommandOptions & ExpectWebdriverIO.MultiElementOptions = {}
 ): ExpectWebdriverIO.AsyncAssertionResult {
     const { isNot, verb = 'be', allowEmptyElements = false } = this
 
@@ -83,7 +83,7 @@ async function executeCommandBe(
                     return { success: result, actual: result }
                 },
                 isNot,
-                strictConfiguration: { allowEmptyElements }
+                strictConfiguration: { allowEmptyElements, some: options.some },
 
             })
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export function getAsymmetricMatcherValue<T>(
 async function executeCommandBe(
     received: WdioElementOrArrayMaybePromise,
     command: (el: WebdriverIO.Element) => Promise<boolean>,
-    options: ExpectWebdriverIO.CommandOptions & ExpectWebdriverIO.MultiElementOptions = {}
+    options: ExpectWebdriverIO.CommandOptions = {}
 ): ExpectWebdriverIO.AsyncAssertionResult {
     const { isNot, verb = 'be', allowEmptyElements = false } = this
 

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -1,6 +1,7 @@
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 import { expectTypeOf } from 'vitest'
-import { some } from '../../src/matchers/modifiers/some.js'
+import { some } from 'expect-webdriverio'
+import type { SomeElementsWrapper } from '../../src/matchers/modifiers/some.js'
 
 describe('WebDriverIO Expect Type Assertions under Mocha', () => {
     const chainableElement = {} as unknown as ChainablePromiseElement
@@ -107,8 +108,6 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveText('text')).toEqualTypeOf<Promise<void>>()
 
-                expectTypeOf(expect(some(element)).toHaveText(expect.stringContaining('text'))).toEqualTypeOf<Promise<void>>()
-
                 await expect(element).toHaveText(
                     'My-Ex-Am-Ple',
                     {
@@ -127,13 +126,6 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(chainableElement).toHaveText(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(chainableElement).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
 
-                expectTypeOf(expect(some(chainableElement)).toHaveText('text')).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(some(chainableElement)).toHaveText(/text/)).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf('text1', 'text2'))).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf(expect.stringContaining('text1'), expect.stringContaining('text2')))).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
-                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
-
                 expectTypeOf(expect(chainableElement).not.toHaveText('text')).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(chainableElement).toHaveText).parameter(0).extract<number>().toBeNever()
@@ -147,6 +139,16 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(elementArray).toHaveText(['text1', expect.oneOf(/text1/, /text2/), expect.oneOf(expect.stringContaining('text3'))])).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(elementArray).not.toHaveText('text')).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(some(elementArray)).toHaveText('text')).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText(/text/)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText(['text1', 'text2'])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText([expect.stringContaining('text1'), expect.stringContaining('text2')])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText([/text1/, /text2/])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText(['text1', /text1/, expect.stringContaining('text3')])).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(elementArray)).toHaveText(['text1', expect.oneOf(/text1/, /text2/), expect.oneOf(expect.stringContaining('text3'))])).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(some(elementArray)).not.toHaveText('text')).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(elementArray).toHaveText).parameter(0).extract<number>().toBeNever()
 
@@ -1108,6 +1110,22 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
             expect(number).toEqual(expect.closeTo(1.0001, 0.0001))
             // New from jest 30, should work!
             expect(['apple', 'banana', 'cherry']).toEqual(expect.arrayOf(expect.any(String)))
+        })
+    })
+
+    describe('Wdio custom some modifier', () => {
+        it('should have some work with elements what ever the type', async () => {
+            expectTypeOf(some([element])).toEqualTypeOf<SomeElementsWrapper<WebdriverIO.Element[]>>()
+            expectTypeOf(some(chainableArray)).toEqualTypeOf<SomeElementsWrapper<typeof chainableArray>>()
+            expectTypeOf(some(Promise.resolve([element]))).toEqualTypeOf<SomeElementsWrapper<Promise<WebdriverIO.Element[]>>>()
+        })
+
+        it('should not work with element', () => {
+            // @ts-expect-error some(element)
+            expectTypeOf(some(element)).toBeTypeError()
+
+            // @ts-expect-error some(chainableElement)
+            expectTypeOf(some(chainableElement)).toBeTypeError()
         })
     })
 })

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -1,5 +1,6 @@
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 import { expectTypeOf } from 'vitest'
+import { some } from '../../src/matchers/modifiers/some.js'
 
 describe('WebDriverIO Expect Type Assertions under Mocha', () => {
     const chainableElement = {} as unknown as ChainablePromiseElement
@@ -104,6 +105,10 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(element).toHaveText(expect.oneOf(expect.stringContaining('text1'), expect.stringContaining('text2')))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveText(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(element).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(element).toHaveText('text')).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(some(element)).toHaveText(expect.stringContaining('text'))).toEqualTypeOf<Promise<void>>()
+
                 await expect(element).toHaveText(
                     'My-Ex-Am-Ple',
                     {
@@ -121,6 +126,13 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(chainableElement).toHaveText(expect.oneOf(expect.stringContaining('text1'), expect.stringContaining('text2')))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(chainableElement).toHaveText(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
                 expectTypeOf(expect(chainableElement).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
+
+                expectTypeOf(expect(some(chainableElement)).toHaveText('text')).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(chainableElement)).toHaveText(/text/)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf('text1', 'text2'))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf(expect.stringContaining('text1'), expect.stringContaining('text2')))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf(/text1/, /text2/))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(some(chainableElement)).toHaveText(expect.oneOf('text1', /text1/, expect.stringContaining('text3')))).toEqualTypeOf<Promise<void>>()
 
                 expectTypeOf(expect(chainableElement).not.toHaveText('text')).toEqualTypeOf<Promise<void>>()
 

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -7,6 +7,7 @@ import stripAnsi from 'strip-ansi'
 import { notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { DEFAULT_OPTIONS } from '../../../src/constants.js'
 import { setDefaultOptions, setOptions } from '../../../src/index.js'
+import { some } from '../../../src/matchers/modifiers/some.js'
 
 vi.mock('@wdio/globals')
 
@@ -537,7 +538,7 @@ Received: []`)
                 vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
                 vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
 
-                const result = await thisContext.toBeDisplayed(elements, { some: true })
+                const result = await thisContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(true)
             })
@@ -568,7 +569,7 @@ Expect ${selectorName} to be displayed
                 vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
                 vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
 
-                const result = await thisNotContext.toBeDisplayed(elements, { some: true })
+                const result = await thisNotContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
             })

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -531,6 +531,71 @@ Expect [] to be displayed
 Expected: "at least one result"
 Received: []`)
         })
+
+        describe('with some option', () => {
+            test('success with some option', async () => {
+                vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
+                vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
+
+                const result = await thisContext.toBeDisplayed(elements, { some: true })
+
+                expect(result.pass).toBe(true)
+            })
+
+            test('failures with some option', async () => {
+                vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
+                vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(false)
+
+                const result = await thisContext.toBeDisplayed(elements, { some: true })
+
+                expect(result.pass).toBe(false)
+                // TODO : improve message for some option
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} to be displayed
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "displayed",
+-   "displayed",
++   "not displayed",
++   "not displayed",
+  ]`)
+            })
+
+            test('not success (pass=false) with some option', async () => {
+                vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
+                vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
+
+                const result = await thisNotContext.toBeDisplayed(elements, { some: true })
+
+                expect(result.pass).toBe(false) // success, boolean is inverted later because of `.not`
+            })
+
+            test('not - failures (pass=true) with some option', async () => {
+                vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(true)
+                vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
+
+                const result = await thisNotContext.toBeDisplayed(elements, { some: true })
+
+                expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
+                // TODO dprevost: improve message for some option
+                expect(stripAnsi(result.message())).toEqual(`\
+Expect ${selectorName} not to be displayed
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "not displayed",
+-   "not displayed",
++   "displayed",
++   "displayed",
+  ]`
+                )
+            })
+        })
     })
 
     test.for([

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -547,7 +547,7 @@ Received: []`)
                 vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(false)
                 vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(false)
 
-                const result = await thisContext.toBeDisplayed(elements, { some: true })
+                const result = await thisContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(false)
                 // TODO : improve message for some option
@@ -578,7 +578,7 @@ Expect ${selectorName} to be displayed
                 vi.mocked(awaitedElements[0].isDisplayed).mockResolvedValue(true)
                 vi.mocked(awaitedElements[1].isDisplayed).mockResolvedValue(true)
 
-                const result = await thisNotContext.toBeDisplayed(elements, { some: true })
+                const result = await thisNotContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
                 // TODO dprevost: improve message for some option

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -550,9 +550,8 @@ Received: []`)
                 const result = await thisContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(false)
-                // TODO : improve message for some option
                 expect(stripAnsi(result.message())).toEqual(`\
-Expect ${selectorName} to be displayed
+Expect some of ${selectorName} to be displayed
 
 - Expected  - 2
 + Received  + 2
@@ -581,9 +580,8 @@ Expect ${selectorName} to be displayed
                 const result = await thisNotContext.toBeDisplayed(some(elements))
 
                 expect(result.pass).toBe(true) // failure, boolean is inverted later because of `.not`
-                // TODO dprevost: improve message for some option
                 expect(stripAnsi(result.message())).toEqual(`\
-Expect ${selectorName} not to be displayed
+Expect some of ${selectorName} not to be displayed
 
 - Expected  - 2
 + Received  + 2

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -603,15 +603,7 @@ Expect ${selectorName} to have text
                 })
 
                 test('should not support some modifiers', async () => {
-                    const result = await thisContext.toHaveText( some(els), 'webdriverio', { wait: 0 })
-
-                    expect(result.pass).toBe(false)
-                    expect(stripAnsi(result.message())).toEqual(`\
-Expect {"elements":[{"selector":"sel","index":0,"parent":{},"elementId":"sel"},{"selector":"sel","index":1,... to have text
-
-Expected: "webdriverio"
-Received: undefined`
-                    )
+                    await expect(thisContext.toHaveText(some(els), 'webdriverio', { wait: 0 })).rejects.toThrow('some(elements) works only when enabling `useToHaveTextStrictMultiElementsCompareStrategy`')
                 })
 
                 describe('when using .not', () => {

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -5,7 +5,7 @@ import type { ChainablePromiseArray } from 'webdriverio'
 import { $Factory, chainableElementArrayFactory, elementArrayFactory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
-import { setFeatureFlags } from '../../../src/index.js'
+import { setFeatureFlags, some } from '../../../src/index.js'
 import { expect as wdioExpect } from '../../../src/index.js'
 
 vi.mock('@wdio/globals')
@@ -602,6 +602,18 @@ Expect ${selectorName} to have text
                     expect(stripAnsi(result.message())).toMatch(/Test\nExpect .* to have text/)
                 })
 
+                test('should not support some modifiers', async () => {
+                    const result = await thisContext.toHaveText( some(els), 'webdriverio', { wait: 0 })
+
+                    expect(result.pass).toBe(false)
+                    expect(stripAnsi(result.message())).toEqual(`\
+Expect {"elements":[{"selector":"sel","index":0,"parent":{},"elementId":"sel"},{"selector":"sel","index":1,... to have text
+
+Expected: "webdriverio"
+Received: undefined`
+                    )
+                })
+
                 describe('when using .not', () => {
                     test('should succeed (pass=false) if none of the received elements match the expected text', async () => {
                         const result = await thisNotContext.toHaveText(els, ['NotHaveThisText1', 'NotHaveThisText2'])
@@ -1186,7 +1198,7 @@ Expect ${selectorName} to have text
                     expect(stripAnsi(result.message())).toMatch(/Test\nExpect .* to have text/)
                 })
 
-                describe('when using .not', () => {
+                describe('when using .not modifier', () => {
                     test('should succeed (pass=false) if none of the received elements match the expected text', async () => {
                         const result = await thisNotContext.toHaveText(els, ['NotHaveThisText1', 'NotHaveThisText2'])
 
@@ -1257,6 +1269,39 @@ Expect ${selectorName} not to have text
 
 Expected [not]: [/NotMatching.*/i, /Get Starte.*/i]
 Received      : ["WebdriverIO", "Get Started"]`
+                        )
+                    })
+                })
+
+                describe('when using some() modifier', () => {
+                    test('should succeed when using some() modifier and only one element matches', async () => {
+                        vi.mocked((await els)[0].getText).mockResolvedValue('Does not match')
+                        vi.mocked((await els)[1].getText).mockResolvedValue('webdriverio')
+
+                        const result = await thisContext.toHaveText( some(els), 'webdriverio')
+
+                        expect(result.pass).toBe(true)
+                    })
+
+                    test('should fails with `some` text when no element matches', async () => {
+                        vi.mocked((await els)[0].getText).mockResolvedValue('Does not match')
+                        vi.mocked((await els)[1].getText).mockResolvedValue('Also does not match')
+
+                        const result = await thisContext.toHaveText( some(els), 'webdriverio')
+
+                        expect(result.pass).toBe(false)
+                        expect(stripAnsi(result.message())).toEqual(`\
+Expect some of ${selectorName} to have text
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "webdriverio",
+-   "webdriverio",
++   "Does not match",
++   "Also does not match",
+  ]`
                         )
                     })
                 })

--- a/test/matchers/modifiers/some.test.ts
+++ b/test/matchers/modifiers/some.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+import { $$ } from '@wdio/globals'
+import { SomeElementsWrapper } from '../../../src/matchers/modifiers/some'
+
+vi.mock('@wdio/globals')
+
+describe('SomeElementsWrapper', () => {
+    it('should create a SomeElementsWrapper instance', () => {
+        const elements = $$('div')
+        const wrapper = new SomeElementsWrapper(elements)
+
+        expect(wrapper).toBeInstanceOf(SomeElementsWrapper)
+    })
+    it('should have the elements property', () => {
+        const elements = $$('div')
+        const wrapper = new SomeElementsWrapper(elements)
+
+        expect(wrapper.elements).toEqual(elements)
+    })
+})

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -21,7 +21,7 @@ describe('executeCommand', () => {
                     element,
                     'Match',
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(true)
@@ -35,7 +35,7 @@ describe('executeCommand', () => {
                     element,
                     'Match',
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(false)
@@ -54,7 +54,7 @@ describe('executeCommand', () => {
                     threeElements,
                     ['Match', 'Match', 'Match'],
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(true)
@@ -71,7 +71,7 @@ describe('executeCommand', () => {
                     threeElements,
                     ['Match', 'Match', 'Match'],
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(false)
@@ -84,7 +84,7 @@ describe('executeCommand', () => {
                     twoElements,
                     'Match',
                     mockSingleCompare,
-                    true // isNot: true
+                    { isNot: true, isSome: false } // isNot: true
                 )
 
                 expect(result.success).toBe(false) // false is success for .not, since it is inverted later by Jest
@@ -99,7 +99,7 @@ describe('executeCommand', () => {
                     twoElements,
                     'Match',
                     mockSingleCompare,
-                    true // isNot: true
+                    { isNot: true, isSome: false }
                 )
 
                 expect(result.success).toBe(true) // true is failure for .not, since it is inverted later by Jest
@@ -110,7 +110,7 @@ describe('executeCommand', () => {
                     [],
                     'Match',
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(false)
@@ -121,7 +121,7 @@ describe('executeCommand', () => {
                     [],
                     'Match',
                     mockSingleCompare,
-                    true, // isNot
+                    { isNot: false, isSome: false },
                     { allowEmptyElements: true }
                 )
 
@@ -137,7 +137,7 @@ describe('executeCommand', () => {
                     oneElements,
                     expected,
                     mockSingleCompare,
-                    false
+                    { isNot: false, isSome: false }
                 )
 
                 expect(result.success).toBe(false)

--- a/test/util/formatMessage.test.ts
+++ b/test/util/formatMessage.test.ts
@@ -25,7 +25,7 @@ describe('formatMessage', () => {
                     'window',
                     expected,
                     actual,
-                    { isNot: false },
+                    { isNot: false, isSome: false },
                     'have',
                     'title',
                 ))
@@ -61,7 +61,7 @@ Received: "Test Actual Value"`)
                         'window',
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'title'
                     ))
@@ -97,7 +97,7 @@ Received      : "Test Same"`
                         'window',
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'title',
                         '',
@@ -124,7 +124,7 @@ Received: "Test Actual Value"`)
                         'window',
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'title',
                         '',
@@ -151,7 +151,7 @@ Received      : "same value"`)
                     'window',
                     'Test Expected Value',
                     'Test Actual Value',
-                    { isNot: false },
+                    { isNot: false, isSome: false },
                     'have',
                     'title',
                     '',
@@ -183,7 +183,7 @@ Received: "Test Actual Value"`)
                         'window',
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'property',
                         expectedArg2,
@@ -209,7 +209,7 @@ Received: "Actual Property Value"`)
                         'window',
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'property',
                         expectedArg2,
@@ -235,7 +235,7 @@ Received      : "Actual Property Value"`)
             { actual: {}, selectorName: '{}' },
             { actual: ['1', '2'], selectorName: '["1","2"]' },
         ])('should return failure message for unsupported type $actual when isNot is false', async ({ actual, selectorName }) => {
-            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: false }, 'have', 'text')
+            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: false, isSome: false }, 'have', 'text')
 
             expect(stripAnsi(result)).toEqual(`\
 Expect ${selectorName} to have text
@@ -253,7 +253,7 @@ Received: undefined`)
             { actual: {}, selectorName: '{}' },
             { actual: ['1', '2'], selectorName: '["1","2"]' },
         ])('should return failure message for unsupported type $actual when isNot is true', async ({ actual, selectorName }) => {
-            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: true }, 'have', 'text')
+            const result = await enhanceError(actual as any, 'webdriverio', undefined, { isNot: true, isSome: false }, 'have', 'text')
 
             expect(stripAnsi(result)).toEqual(`\
 Expect ${selectorName} not to have text
@@ -276,7 +276,7 @@ Received      : undefined`)
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     ))
@@ -303,7 +303,7 @@ Expect ${elementName} to have text
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     ))
@@ -329,7 +329,7 @@ Expect ${elementName} to have text
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     ))
@@ -358,7 +358,7 @@ Expect ${elementName} to have text
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     ))
@@ -381,7 +381,7 @@ Received      : ["Test Expected Value 1", "Test Expected Value 2"]`
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     ))
@@ -406,7 +406,7 @@ Received      : ["Test Expected Value 1", "Test Actual Value 2"]`
                         elements,
                         expected,
                         actual,
-                        { isNot },
+                        { isNot, isSome: false },
                         'have',
                         'text',
                     )
@@ -431,7 +431,7 @@ Received      : ["Test Actual Value 1", "Test Expected Value 2"]`
                 const expected = jasmine.any(String)
                 const actual = 'Test Actual Value'
 
-                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+                const result = await enhanceError(subject, expected, actual, { isNot: false, isSome: false }, 'have', 'text')
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect $(\`element\`) to have text
@@ -445,7 +445,7 @@ Received: "Test Actual Value"`)
                 const expected = [jasmine.any(String), jasmine.any(Number)]
                 const actual = [null, 'Test Actual Value 2']
 
-                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+                const result = await enhanceError(subject, expected, actual, { isNot: false, isSome: false }, 'have', 'text')
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect $$(\`element\`) to have text
@@ -467,7 +467,7 @@ Expect $$(\`element\`) to have text
                 const expected = jasmine.any(String)
                 const actual = 'Test Actual Value'
 
-                const result = await enhanceError(subject, expected, actual, { isNot: true }, 'have', 'text')
+                const result = await enhanceError(subject, expected, actual, { isNot: true, isSome: false }, 'have', 'text')
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect $(\`element\`) not to have text
@@ -481,7 +481,7 @@ Received      : "Test Actual Value"`)
                 const expected = [jasmine.any(String), jasmine.any(Number)]
                 const actual = ['Test Actual Value 2', 1]
 
-                const result = await enhanceError(subject, expected, actual, { isNot: true }, 'have', 'text')
+                const result = await enhanceError(subject, expected, actual, { isNot: true, isSome: false }, 'have', 'text')
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect $$(\`element\`) not to have text
@@ -497,13 +497,37 @@ Received      : ["Test Actual Value 2", 1]`)
                 const expected = expect.any(String)
                 const actual = 'Test Actual Value'
 
-                const result = await enhanceError(subject, expected, actual, { isNot: false }, 'have', 'text')
+                const result = await enhanceError(subject, expected, actual, { isNot: false, isSome: false }, 'have', 'text')
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect $(\`element\`) to have text
 
 Expected: Any<String>
 Received: "Test Actual Value"`)
+            })
+        })
+
+        describe('given some elements', () => {
+            test('should return failure message for some elements when isNot is false', async () => {
+                const subject = elementArrayFactory('element', 2)
+                const expected = ['Test Expected Value 1', 'Test Expected Value 2']
+                const actual = ['Test Actual Value 1', 'Test Actual Value 2']
+
+                const result = await enhanceError(subject, expected, actual, { isNot: false, isSome: true }, 'have', 'text')
+
+                // TODO maybe one day try to change `- Expected  - 2` to `- Expected one of - 2` but this is not supported by jest-diff yet!
+                expect(stripAnsi(result)).toEqual(`\
+Expect some of $$(\`element\`) to have text
+
+- Expected  - 2
++ Received  + 2
+
+  Array [
+-   "Test Expected Value 1",
+-   "Test Expected Value 2",
++   "Test Actual Value 1",
++   "Test Actual Value 2",
+  ]`)
             })
         })
     })
@@ -518,7 +542,7 @@ Received: "Test Actual Value"`)
 
             const isNot = false
             test('when isNot is false and failure with result having pass=false', () => {
-                const message = stripAnsi(enhanceErrorBe(subject, [false], { isNot, verb, expectation }, options ))
+                const message = stripAnsi(enhanceErrorBe(subject, [false], { isNot, verb, expectation, isSome: false }, options ))
                 expect(message).toEqual(`\
 Expect $(\`element\`) to be displayed
 
@@ -528,7 +552,7 @@ Received: "not displayed"`)
 
             test('with custom message', () => {
                 const customMessage = 'Custom Error Message'
-                const message = stripAnsi(enhanceErrorBe(subject, [false], { isNot, verb, expectation }, { ...options, message: customMessage }))
+                const message = stripAnsi(enhanceErrorBe(subject, [false], { isNot, verb, expectation, isSome: false }, { ...options, message: customMessage }))
                 expect(message).toEqual(`\
 Custom Error Message
 Expect $(\`element\`) to be displayed
@@ -539,7 +563,7 @@ Received: "not displayed"`)
 
             test('when isNot is true and failure with result having pass=true (inverted later by Jest)', () => {
                 const isNot = true
-                const message = stripAnsi(enhanceErrorBe(subject, [true], { isNot, verb, expectation }, options))
+                const message = stripAnsi(enhanceErrorBe(subject, [true], { isNot, verb, expectation, isSome: false }, options))
                 expect(message).toEqual(`\
 Expect $(\`element\`) not to be displayed
 
@@ -557,7 +581,7 @@ Received: "displayed"`)
                 { actual: {}, selectorName: '{}' },
                 { actual: ['1', '2'], selectorName: '["1","2"]' },
             ])('should return failure message for unsupported type $actual when isNot is false and not result from element function call', async ({ actual: subject, selectorName }) => {
-                const result = await enhanceErrorBe(subject as any,  [], { isNot, verb, expectation }, options)
+                const result = await enhanceErrorBe(subject as any,  [], { isNot, verb, expectation, isSome: false }, options)
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect ${selectorName} to be displayed
@@ -575,7 +599,7 @@ Received: "not displayed"`)
                 { actual: {}, selectorName: '{}' },
                 { actual: ['1', '2'], selectorName: '["1","2"]' },
             ])('should return failure message for unsupported type $actual when isNot is true and not result from element function call', async ({ actual: subject, selectorName }) => {
-                const result = await enhanceErrorBe(subject as any, [], { isNot: true, verb, expectation }, options)
+                const result = await enhanceErrorBe(subject as any, [], { isNot: true, verb, expectation, isSome: false }, options)
 
                 expect(stripAnsi(result)).toEqual(`\
 Expect ${selectorName} not to be displayed
@@ -592,7 +616,7 @@ Received: "displayed"`)
                 const isNot = false
 
                 test('failure with all results having pass=false', () => {
-                    const message = stripAnsi(enhanceErrorBe(subject, [false, false], { isNot, verb, expectation }, options ))
+                    const message = stripAnsi(enhanceErrorBe(subject, [false, false], { isNot, verb, expectation, isSome: false }, options ))
                     expect(message).toEqual(`\
 Expect $$(\`elements\`) to be displayed
 
@@ -608,7 +632,7 @@ Expect $$(\`elements\`) to be displayed
                 })
 
                 test('failure with first results having pass=true', () => {
-                    const message = enhanceErrorBe(subject, [true, false], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe(subject, [true, false], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect $$(\`elements\`) to be displayed
 
@@ -623,7 +647,7 @@ Expect $$(\`elements\`) to be displayed
                 })
 
                 test('failure with second results having pass=true', () => {
-                    const message = enhanceErrorBe(subject, [false, true], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe(subject, [false, true], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect $$(\`elements\`) to be displayed
 
@@ -638,7 +662,7 @@ Expect $$(\`elements\`) to be displayed
                 })
 
                 test('when no element', () => {
-                    const message = enhanceErrorBe([], [], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe([], [], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect [] to be displayed
 
@@ -651,7 +675,7 @@ Received: []`)
                 const isNot = true
 
                 test('failure with all results having pass=true', () => {
-                    const message = enhanceErrorBe(subject, [true, true], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe(subject, [true, true], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect $$(\`elements\`) not to be displayed
 
@@ -667,7 +691,7 @@ Expect $$(\`elements\`) not to be displayed
                 })
 
                 test('failure with first results having success pass=false (inverted later)', () => {
-                    const message = enhanceErrorBe(subject, [false, true], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe(subject, [false, true], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect $$(\`elements\`) not to be displayed
 
@@ -682,7 +706,7 @@ Expect $$(\`elements\`) not to be displayed
                 })
 
                 test('failure with second results having success pass=false (inverted later)', () => {
-                    const message = enhanceErrorBe(subject, [true, false], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe(subject, [true, false], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect $$(\`elements\`) not to be displayed
 
@@ -697,7 +721,7 @@ Expect $$(\`elements\`) not to be displayed
                 })
 
                 test('when no elements', () => {
-                    const message = enhanceErrorBe([], [], { isNot, verb, expectation }, options )
+                    const message = enhanceErrorBe([], [], { isNot, verb, expectation, isSome: false }, options )
                     expect(stripAnsi(message)).toEqual(`\
 Expect [] not to be displayed
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -268,7 +268,7 @@ Received: "not displayed"`)
                 expect(enhanceErrorBe).toHaveBeenCalledWith(
                     await received,
                     false,
-                    expect.objectContaining({ isNot: false }),
+                    expect.objectContaining({ isNot: false, isSome: false }),
                     options
                 )
             })
@@ -296,6 +296,7 @@ Received: "not displayed"`)
                         {
                             expectation: 'displayed',
                             isNot: true,
+                            isSome: false,
                             verb: 'be',
                         },
                         options
@@ -319,6 +320,7 @@ Received: "displayed"`)
                         {
                             expectation: 'displayed',
                             isNot: true,
+                            isSome: false,
                             verb: 'be',
                         },
                         options

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1076,6 +1076,18 @@ declare namespace ExpectWebdriverIO {
         featureFlags?: FeatureFlags
     }
 
+    /**
+     * Options for multi-element matchers, such as `toHaveText` and `toHaveHTML`.
+     * These options allow you to specify how the matcher should behave when dealing with multiple elements.
+     */
+    type MultiElementOptions = {
+        /**
+         * Pass strict comparison if at least one element matches the expected value (or not matches with .not).
+         * Default: false
+         */
+        some?: boolean
+    }
+
     interface CommandOptions extends DefaultOptions {
         /**
          * user message to prepend before assertion error

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1076,23 +1076,17 @@ declare namespace ExpectWebdriverIO {
         featureFlags?: FeatureFlags
     }
 
-    /**
-     * Options for multi-element matchers, such as `toHaveText` and `toHaveHTML`.
-     * These options allow you to specify how the matcher should behave when dealing with multiple elements.
-     */
-    type MultiElementOptions = {
-        /**
-         * Pass strict comparison if at least one element matches the expected value (or not matches with .not).
-         * Default: false
-         */
-        some?: boolean
-    }
-
     interface CommandOptions extends DefaultOptions {
         /**
          * user message to prepend before assertion error
          */
         message?: string
+
+        /**
+         * Pass strict elements comparison if at least one element matches the expected value (or not matches with .not).
+         * Default: false
+         */
+        some?: boolean
     }
 
     interface HTMLOptions extends StringOptions {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -68,9 +68,10 @@ type ArrayOfElementsPromise = Promise<WebdriverIO.Element[]>
 /**
  * Type helpers to be able to targets specific types mostly used in conjunctions with the Type of the `actual` parameter of the `expect`
  */
-type ElementOrArrayLike = ElementLike | ElementArrayLike
+type ElementOrMaybeSomeArrayLike = ElementLike | MaybeSomeElementArrayLike
 type ElementLike = WebdriverIO.Element | ChainablePromiseElement
-type ElementArrayLike = MaybeSome<WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise>
+type ElementArrayLike = WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise
+type MaybeSomeElementArrayLike = MaybeSome<WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise>
 type MockPromise = Promise<WebdriverIO.Mock>
 
 /**
@@ -85,8 +86,8 @@ type FnWhenBrowser<ActualT, Fn> = ActualT extends WebdriverIO.Browser ? Fn : nev
  *
  * Fix: If type inference issues arise, split the implementation into separate interfaces
  */
-type FnWhenElementOrArrayLike<ActualT, FnElement, FnArray = FnElement> = ActualT extends ElementArrayLike ? FnArray : ActualT extends ElementLike ? FnElement: never
-type FnWhenElementArrayLike<ActualT, Fn> = ActualT extends ElementArrayLike ? Fn : never
+type FnWhenElementOrArrayLike<ActualT, FnElement, FnArray = FnElement> = ActualT extends MaybeSomeElementArrayLike ? FnArray : ActualT extends ElementLike ? FnElement: never
+type FnWhenElementArrayLike<ActualT, Fn> = ActualT extends MaybeSomeElementArrayLike ? Fn : never
 
 /**
  * Same as the other but because of Jasmine and it's expectAsync typing which does not force T to be a promise, then we need to account for `WebdriverIO.Mock

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -23,6 +23,8 @@ type ExpectLibMatcherContext = import('expect').MatcherContext
 type MatchersObject = Parameters<typeof import('expect').expect.extend>[0]
 type ExpectLibAnything = ReturnType<typeof expect.any> | ReturnType<typeof expect.anything>
 
+type WdioSome<T> = import('../src/matchers/modifiers/some.js').SomeElementsWrapper<T>
+
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,6 +35,8 @@ type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherCont
  * Indicates that a value can be either one T or an array of T.
  */
 type MaybeArray<T> = T | T[]
+
+type MaybeSome<T> = T | WdioSome<T>
 
 /**
  * Indicates that a value can be either one T, an array of T with oneOf of T, or a oneOf matcher of T.
@@ -65,8 +69,8 @@ type ArrayOfElementsPromise = Promise<WebdriverIO.Element[]>
  * Type helpers to be able to targets specific types mostly used in conjunctions with the Type of the `actual` parameter of the `expect`
  */
 type ElementOrArrayLike = ElementLike | ElementArrayLike
-type ElementLike = WebdriverIO.Element | ChainablePromiseElement
-type ElementArrayLike = WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise
+type ElementLike = MaybeSome<WebdriverIO.Element | ChainablePromiseElement>
+type ElementArrayLike = MaybeSome<WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise>
 type MockPromise = Promise<WebdriverIO.Mock>
 
 /**

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1086,12 +1086,6 @@ declare namespace ExpectWebdriverIO {
          * user message to prepend before assertion error
          */
         message?: string
-
-        /**
-         * Pass strict elements comparison if at least one element matches the expected value (or not matches with .not).
-         * Default: false
-         */
-        some?: boolean
     }
 
     interface HTMLOptions extends StringOptions {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -69,7 +69,7 @@ type ArrayOfElementsPromise = Promise<WebdriverIO.Element[]>
  * Type helpers to be able to targets specific types mostly used in conjunctions with the Type of the `actual` parameter of the `expect`
  */
 type ElementOrArrayLike = ElementLike | ElementArrayLike
-type ElementLike = MaybeSome<WebdriverIO.Element | ChainablePromiseElement>
+type ElementLike = WebdriverIO.Element | ChainablePromiseElement
 type ElementArrayLike = MaybeSome<WebdriverIO.ElementArray | ChainablePromiseArray | WebdriverIO.Element[] | ArrayOfElementsPromise | ElementArrayPromise>
 type MockPromise = Promise<WebdriverIO.Mock>
 
@@ -1257,6 +1257,19 @@ declare namespace ExpectWebdriverIO {
      * Allow to match one of the specified value.
      */
     type OneOfPartialMatcher<T> = ExpectWebdriverIO.PartialMatcher<T[]>
+
+    /**
+     * Quantifier modifier. Wraps a `$$()` result so that the matcher passes
+     * when at least one element satisfies the condition (∃ semantics).
+     *
+     * @example
+     * await expect(some($$('.items'))).toBeDisplayed()
+     * await expect(some($$('.items'))).not.toBeDisplayed() // at least one is NOT displayed
+     * await expect(some($$('.items'))).toHaveText('foo')
+     */
+    function some<T extends ElementArrayLike>(
+        elements: T
+    ): WdioSome<T>
 }
 
 declare module 'expect-webdriverio' {


### PR DESCRIPTION
Fixes https://github.com/webdriverio/expect-webdriverio/issues/512

Add an elements wrapper to allow asserting if only one element in the element array matches the expected value. So in the below, the assertion succeeds if one element in the group is displayed (or not displayed)

```ts
await expect(some($$('.manyElems'))).toBeDisplayed()
await expect(some($$('.manyElems'))).not.toBeDisplayed()

await expect(some($$('.manyElems'))).toHaveText('myText')
```

Note: We have explored a better syntax with a `.some` modifier similar to `.not` (see below); however, doing so requires overriding the assertion function on expect and also using `expect.setState()` so that the some is passed in the this context, which does not seem safe at all. See [POC here](https://github.com/webdriverio/expect-webdriverio/pull/2151/changes#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

```ts
await expect($$('.manyElems')).some.toBeDisplayed()
```

⚠️ `some()` for `toHaveText()` is supported only when enabling the new `useToHaveTextStrictMultiElementsCompareStrategy` 

New failure message representing the some modifier usage
<img width="504" height="167" alt="image" src="https://github.com/user-attachments/assets/a2d16484-cc69-4e0b-a783-3b3556424849" />

