### PR TITLE
feat: automatically refresh arrays on failures

### DIFF
--- a/__mocks__/@wdio/globals.ts
+++ b/__mocks__/@wdio/globals.ts
@@ -2,20 +2,4 @@
  * Global mocks on root only as vitest support
  * Re-exporting from test folder to benefit from typed mocks
  */
-import { browser } from '../../test/__mocks__/@wdio/globals'
-
-export function $(selector: string) {
-    return browser.$(selector)
-}
-
-export function $$(selector: string) {
-    return browser.$$(selector)
-}
-
-export { browser }
-
-export default {
-    browser,
-    $: browser.$,
-    $$: browser.$$,
-}
+export { browser, $$, $ } from '../../test/__mocks__/@wdio/globals'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,9 @@ export default wdioEslint.config([
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/consistent-type-imports': 'off',
             'vitest/no-identical-title': 'error',
+            'vitest/no-disabled-tests': 'warn',
+            'vitest/no-focused-tests': 'error',
+            'vitest/valid-expect': 'error'
         }
     },
     {

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -36,14 +36,14 @@ export async function toHaveAttributeAndValue(received: MaybeSomeWdioElementOrAr
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     const { success: pass, actual: attr, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, values: string | RegExp | AsymmetricMatcher<string> | undefined) => {
                     return conditionAttributeValueMatchWithExpected(element, attribute, values, options)
                 },
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
             })
         },

--- a/src/matchers/element/toHaveChildren.ts
+++ b/src/matchers/element/toHaveChildren.ts
@@ -96,12 +96,12 @@ export async function toHaveChildren(
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValueOrOptions, options, { supportDefaultAsGteThen1: true })
 
     const { success: pass, actual: children, subject, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedValue: NumberMatcher | undefined) => condition(element, expectedValue),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
             })
         },

--- a/src/matchers/element/toHaveComputedLabel.ts
+++ b/src/matchers/element/toHaveComputedLabel.ts
@@ -35,12 +35,12 @@ export async function toHaveComputedLabel(
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     const { success: pass, actual: actualLabel, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }

--- a/src/matchers/element/toHaveComputedRole.ts
+++ b/src/matchers/element/toHaveComputedRole.ts
@@ -34,12 +34,12 @@ export async function toHaveComputedRole(
     expectedValue = buildWdioAsymmetricMatchersWithOptions(expectedValue, options)
 
     const { success: pass, actual: actualRole, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }

--- a/src/matchers/element/toHaveElementClass.ts
+++ b/src/matchers/element/toHaveElementClass.ts
@@ -58,12 +58,12 @@ export async function toHaveElementClass(
     const attribute = 'class'
 
     const { success: pass, actual: attr, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, attribute, expectedValue, options),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -108,14 +108,14 @@ export async function toHaveElementProperty(
     value = buildWdioAsymmetricMatchersWithOptions(value, options)
 
     const { success: pass, actual: actualProppertyValue, subject: elements, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: value,
                 singleElementCompare: (element, expectedValue: MaybeOneOf<string | number | RegExp | AsymmetricMatcher<string>> | null | undefined) => {
                     return condition(element, property, expectedValue, options)
                 },
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })

--- a/src/matchers/element/toHaveHTML.ts
+++ b/src/matchers/element/toHaveHTML.ts
@@ -32,12 +32,12 @@ export async function toHaveHTML(
     })
 
     const { success: pass, actual: actualHTML, subject: elements, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             const result = await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined) => singleElementCompare(element, expectedValue, options),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 // TODO: Replace (without breaking the API) array by oneOf/anyOf as will we should put in place for multiple elements
                 strictConfiguration: { allowArrayWithSingleElement: true }

--- a/src/matchers/element/toHaveHeight.ts
+++ b/src/matchers/element/toHaveHeight.ts
@@ -62,12 +62,12 @@ export async function toHaveHeight(
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
     const { success: pass, actual: actualHeight, subject: elements, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })

--- a/src/matchers/element/toHaveSize.ts
+++ b/src/matchers/element/toHaveSize.ts
@@ -49,12 +49,12 @@ export async function toHaveSize(
     })
 
     const { success: pass, actual: actualSize, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, expectedSize: Size | undefined) => condition(element, expectedSize),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })

--- a/src/matchers/element/toHaveStyle.ts
+++ b/src/matchers/element/toHaveStyle.ts
@@ -49,13 +49,13 @@ export async function toHaveStyle(
     })
 
     const { success: pass, actual: actualStyle, subject: el, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 // TODO try to make the type work without casting expectedValues to { [key: string]: string; } | undefined
                 singleElementCompare: (element, expectedValues) => condition(element, expectedValues as { [key: string]: string; } | undefined, options),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })

--- a/src/matchers/element/toHaveText.ts
+++ b/src/matchers/element/toHaveText.ts
@@ -34,14 +34,14 @@ export async function toHaveText(
 
     const isNewStrictCompare = getFeatureFlagValue(options, 'useToHaveTextStrictMultiElementsCompareStrategy')
     const { success: pass, actual: actualText, subject: subject, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedValue,
                 singleElementCompare: (element, values: MaybeArray<string | RegExp | AsymmetricMatcher<string>> | ExpectWebdriverIO.OneOfPartialMatcher<string> | undefined) => {
                     return compareElement(element, values, options)
                 },
-                isNot,
+                context: { isNot, iteration },
                 strategy: isNewStrictCompare ? 'NewStrictMultipleElements' : 'LegacyLooseMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: true }
             })

--- a/src/matchers/element/toHaveWidth.ts
+++ b/src/matchers/element/toHaveWidth.ts
@@ -60,12 +60,12 @@ export async function toHaveWidth(
     const { numberMatcher: expectedNumber, commandOptions } = validateNumberArrayAndExtractOptions(expectedValue, options)
 
     const { success: pass, actual: actualWidth, subject: elements, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy( {
                 unresolvedElements: received,
                 expectedValues: expectedNumber,
                 singleElementCompare: (element, expectedNumber: NumberMatcher | undefined) => condition(element, expectedNumber),
-                isNot,
+                context: { isNot, iteration },
                 strategy: 'NewStrictMultipleElements',
                 strictConfiguration: { allowArrayWithSingleElement: false }
             })

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -1,9 +1,9 @@
 import { waitUntil, enhanceError, } from '../../utils.js'
-import { refetchElements } from '../../util/refetchElements.js'
+import { refetchElements, replaceElements } from '../../util/refetchElements.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementsMaybePromise } from '../../types.js'
 import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
-import { awaitElementArray } from '../../util/elementsUtil.js'
+import { awaitElementArray, isArray, isStrictlyElementArray } from '../../util/elementsUtil.js'
 
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,
@@ -51,7 +51,6 @@ export async function toBeElementsArrayOfSize(
                 return { success: isPassing, subject: elements, actual: elements.length }
             }
 
-            // TODO should we do this on other matchers??
             elements = await refetchElements(elements, commandOptions.wait, true)
             return { success: false, subject: elements, actual: elements.length }
         },
@@ -59,10 +58,18 @@ export async function toBeElementsArrayOfSize(
         { wait: commandOptions.wait, interval: commandOptions.interval }
     )
 
-    // TODO By using `(await received).push(elements[index])` we could update Promises of arrays, should we support that?
-    if (Array.isArray(received) && pass && originalLength !== undefined && elements) {
-        for (let index = originalLength; index < elements.length; index++) {
-            received.push(elements[index])
+    if (pass && originalLength !== undefined && (isArray(received) || received instanceof Promise) && elements !== received) {
+        let receivedArray: WebdriverIO.ElementArray | undefined = undefined
+        if (received instanceof Promise) {
+            received = await received
+            if ('getElements' in received) {
+                receivedArray = await received.getElements()
+            }
+        } else if (isStrictlyElementArray(received)) {
+            receivedArray = received
+        }
+        if (receivedArray && isStrictlyElementArray(elements)) {
+            replaceElements(receivedArray, elements)
         }
     }
 

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -40,9 +40,12 @@ export async function toBeElementsArrayOfSize(
     const originalLength =  elements ? elements.length : undefined
 
     const { success: pass } = await waitUntil(
-        async () => {
+        async (iteration) => {
             if (!elements) {
                 return { success: false, subject: elements, actual: undefined, abort: true }
+            }
+            if (iteration > 0) {
+                elements = await refetchElements(elements, commandOptions.wait, true)
             }
 
             // Verify if size match first before refetching elements
@@ -51,7 +54,6 @@ export async function toBeElementsArrayOfSize(
                 return { success: isPassing, subject: elements, actual: elements.length }
             }
 
-            elements = await refetchElements(elements, commandOptions.wait, true)
             return { success: false, subject: elements, actual: elements.length }
         },
         isNot,

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -45,7 +45,7 @@ export async function toBeElementsArrayOfSize(
                 return { success: false, subject: elements, actual: undefined, abort: true }
             }
             if (iteration > 0) {
-                elements = await refetchElements(elements, commandOptions.wait, true)
+                elements = await refetchElements(elements)
             }
 
             // Verify if size match first before refetching elements

--- a/src/matchers/elements/toBeElementsArrayOfSize.ts
+++ b/src/matchers/elements/toBeElementsArrayOfSize.ts
@@ -1,9 +1,9 @@
 import { waitUntil, enhanceError, } from '../../utils.js'
-import { refetchElements, replaceElements } from '../../util/refetchElements.js'
+import { refetchElements, syncronizeElements } from '../../util/refetchElements.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
 import type { WdioElementsMaybePromise } from '../../types.js'
 import { validateNumberAndExtractOptions } from '../../util/numberOptionsUtil.js'
-import { awaitElementArray, isArray, isStrictlyElementArray } from '../../util/elementsUtil.js'
+import { awaitElementArray, isStrictlyElementArray } from '../../util/elementsUtil.js'
 
 export async function toBeElementsArrayOfSize(
     received: WdioElementsMaybePromise,
@@ -58,19 +58,8 @@ export async function toBeElementsArrayOfSize(
         { wait: commandOptions.wait, interval: commandOptions.interval }
     )
 
-    if (pass && originalLength !== undefined && (isArray(received) || received instanceof Promise) && elements !== received) {
-        let receivedArray: WebdriverIO.ElementArray | undefined = undefined
-        if (received instanceof Promise) {
-            received = await received
-            if ('getElements' in received) {
-                receivedArray = await received.getElements()
-            }
-        } else if (isStrictlyElementArray(received)) {
-            receivedArray = received
-        }
-        if (receivedArray && isStrictlyElementArray(elements)) {
-            replaceElements(receivedArray, elements)
-        }
+    if (pass && originalLength !== undefined && elements !== received && (isStrictlyElementArray(received) || received instanceof Promise) && isStrictlyElementArray(elements)) {
+        await syncronizeElements(received, elements)
     }
 
     const actual = originalLength

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -1,13 +1,15 @@
 import { isSomeWrapper } from '../matchers/modifiers/some.js'
 import type { MaybeSomeWdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
-import { awaitElementOrArray, isElement } from './elementsUtil.js'
+import { awaitElementOrArray, isArray, isElement, isStrictlyElementArray } from './elementsUtil.js'
+import { refetchElements, refreshElements } from './refetchElements.js'
 
 export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleElements'
 export type CompareResult<T> = { success: boolean; actual: T }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
     abort?: boolean;
-    context?: { isSome: boolean };
+    refreshElements?: boolean;
+    context?: { isSome: boolean, refreshedElements?: boolean };
 } & CompareResult<T | undefined>
 
 /**
@@ -125,17 +127,22 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     { isNot, isSome }: { isNot: boolean; isSome: boolean },
     { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
 ): Promise<StrategyResult<MaybeArray<Actual>>> => {
-    const { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
+    // eslint-disable-next-line prefer-const
+    let { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
+
     const subject = selector ?? other
 
     if (!selector || isEmptyElements) {
+        if (isEmptyElements && isStrictlyElementArray(selector)) {
+            selector =  await refreshElements(selector)
+        }
         return {
             subject: subject,
             // For the new strategy, beside toExist, empty elements even with `.not` is considered a failure since there are no elements to compare against.
             success: isNot ? !allowEmptyElements : false,
             actual: undefined,
-            abort: !allowEmptyElements,
-            context: { isSome }
+            abort: !allowEmptyElements && !isStrictlyElementArray(selector),
+            context: { isSome },
         }
     }
 
@@ -166,7 +173,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
             if (Array.isArray(indexedExpectedValue)) {
                 indexedExpectedValue = undefined // Force failure when we do not support array with single element, to avoid confusion with the new strategy.
                 forceFailure = true
-            } else if (Array.isArray(expectedValues) && expectedValues.length !== selector.length && index >= expectedValues.length) {
+            } else if (Array.isArray(expectedValues) && isArray(selector) && expectedValues.length !== selector.length && index >= expectedValues.length) {
                 // Ensure we fails when expected vs number of elements do not match, mostly since some matchers asserting existence might pass when passing undefined expected value to fake a failure.
                 forceFailure = true
             }
@@ -190,7 +197,6 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     }
 
     let forceFailure = false
-    // TODO mismatch lengths requires depleting the entire timeout instead of failing fast, to fix later!
     if (Array.isArray(expectedValues) && expectedValues.length !== selector.length) {
         forceFailure = true
     }
@@ -201,14 +207,17 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
         ? !(!forceFailure && isNotEmpty && (isSome ? isAtLeastOneFalse(results) : isAllFalse(results)))
         : (!forceFailure && isNotEmpty && (isSome ? isAtLeastOneTrue(results) : isAllTrue(results)))
 
+    if (!success) {
+        selector =  await refetchElements(selector)
+    }
+
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.
     // If there are no elements, it is considered a failure in both case with and without `.not`, as there are no elements to compare against.
     return {
         subject,
         success,
         actual: results.map(({ actual }) => actual),
-        abort: forceFailure,
-        context: { isSome }
+        context: { isSome },
     }
 }
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -130,7 +130,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     if (iteration > 0 && isStrictlyElementArray(selector)) {
         // WARNING: This synchronize the element's array with the latest refetched elements and so altering selector state!
-        refreshElementArray(selector)
+        await refreshElementArray(selector)
     }
 
     const subject = selector ?? other

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -128,17 +128,16 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     { isNot, isSome, iteration }: { isNot: boolean; isSome: boolean; iteration: number },
     { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
 ): Promise<StrategyResult<MaybeArray<Actual>>> => {
-    // eslint-disable-next-line prefer-const
-    let { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
+    const { selector, other } = await awaitElementOrArray(unresolvedElements)
 
     if (iteration > 0 && isStrictlyElementArray(selector)) {
+        // WARNING: This synchronize the element's array with the latest refetched elements and so altering selector state!
         await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
-        isEmptyElements = selector.length === 0
     }
 
     const subject = selector ?? other
 
-    if (!selector || isEmptyElements) {
+    if (!selector || (Array.isArray(selector) && selector.length === 0)) {
 
         return {
             subject: subject,

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -210,9 +210,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
         : (!forceFailure && isNotEmpty && (isSome ? isAtLeastOneTrue(results) : isAllTrue(results)))
 
     if (!success && isStrictlyElementArray(selector)) {
-        console.log('BEFORE selector length', selector.length)
         await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
-        console.log('AFTER selector length', selector.length)
     }
 
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -28,14 +28,14 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     unresolvedElements,
     expectedValues,
     singleElementCompare,
-    isNot,
+    context: { isNot, iteration },
     strategy = 'NewStrictMultipleElements',
     strictConfiguration = { allowEmptyElements: false, allowArrayWithSingleElement: false }
 } :{
     unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | unknown
     expectedValues: MaybeArray<Expected> | unknown
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected>, index?: number) => Promise<CompareResult<Actual>>
-    isNot: boolean
+    context: { isNot: boolean, iteration: number },
     strategy?: StrategyType,
     strictConfiguration?: { allowEmptyElements?: boolean, allowArrayWithSingleElement?: boolean }
 }
@@ -52,7 +52,7 @@ export async function executeCommandWithStrategy<Actual, Expected>( {
     const actualReceived = isSome ? unresolvedElements.elements : unresolvedElements
 
     // Default new strategy for single & multiple element results, which is more consistent and less ambigious than the legacy strategy.
-    return multipleElementResultsStrategy(actualReceived, expectedValues, singleElementCompare, { isNot, isSome }, strictConfiguration)
+    return multipleElementResultsStrategy(actualReceived, expectedValues, singleElementCompare, { isNot, isSome, iteration }, strictConfiguration)
 }
 
 /**
@@ -125,18 +125,21 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     unresolvedElements: MaybeSomeWdioElementOrArrayMaybePromise | unknown,
     expectedValues: MaybeArray<Expected> | undefined,
     singleElementCompare: (awaitedElement: WebdriverIO.Element, expectedValues: MaybeArray<Expected> | undefined, index?: number) => Promise<CompareResult<Actual>>,
-    { isNot, isSome }: { isNot: boolean; isSome: boolean },
+    { isNot, isSome, iteration }: { isNot: boolean; isSome: boolean; iteration: number },
     { allowEmptyElements = false, allowArrayWithSingleElement = false } = {}
 ): Promise<StrategyResult<MaybeArray<Actual>>> => {
     // eslint-disable-next-line prefer-const
     let { selector, other, isEmptyElements } = await awaitElementOrArray(unresolvedElements)
 
+    if (iteration > 0 && isStrictlyElementArray(selector)) {
+        await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
+        isEmptyElements = selector.length === 0
+    }
+
     const subject = selector ?? other
 
     if (!selector || isEmptyElements) {
-        if (isEmptyElements && isStrictlyElementArray(selector)) {
-            await refreshElementArray(selector)
-        }
+
         return {
             subject: subject,
             // For the new strategy, beside toExist, empty elements even with `.not` is considered a failure since there are no elements to compare against.
@@ -208,10 +211,6 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
     const success = isNot
         ? !(!forceFailure && isNotEmpty && (isSome ? isAtLeastOneFalse(results) : isAllFalse(results)))
         : (!forceFailure && isNotEmpty && (isSome ? isAtLeastOneTrue(results) : isAllTrue(results)))
-
-    if (!success && isStrictlyElementArray(selector)) {
-        await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
-    }
 
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.
     // If there are no elements, it is considered a failure in both case with and without `.not`, as there are no elements to compare against.

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -130,7 +130,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     if (iteration > 0 && isStrictlyElementArray(selector)) {
         // WARNING: This synchronize the element's array with the latest refetched elements and so altering selector state!
-        await refreshElementArray(selector)
+        refreshElementArray(selector)
     }
 
     const subject = selector ?? other

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_OPTIONS } from '../constants.js'
 import { isSomeWrapper } from '../matchers/modifiers/some.js'
 import type { MaybeSomeWdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
 import { awaitElementOrArray, isArray, isElement, isStrictlyElementArray } from './elementsUtil.js'
@@ -132,7 +131,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     if (iteration > 0 && isStrictlyElementArray(selector)) {
         // WARNING: This synchronize the element's array with the latest refetched elements and so altering selector state!
-        await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
+        await refreshElementArray(selector)
     }
 
     const subject = selector ?? other

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -8,8 +8,7 @@ export type CompareResult<T> = { success: boolean; actual: T }
 export type StrategyResult<T, E = WebdriverIO.Element | WebdriverIO.ElementArray | WebdriverIO.Element[] | WebdriverIO.Browser | unknown> = {
     subject: E;
     abort?: boolean;
-    refreshElements?: boolean;
-    context?: { isSome: boolean, refreshedElements?: boolean };
+    context?: { isSome: boolean };
 } & CompareResult<T | undefined>
 
 /**

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -199,7 +199,6 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     let forceFailure = false
     if (Array.isArray(expectedValues) && expectedValues.length !== selector.length) {
-        console.warn(`Warning: Number of expected values (${expectedValues.length}) does not match number of elements (${selector.length}). This will force a failure result.`)
         forceFailure = true
     }
 

--- a/src/util/executeCommand.ts
+++ b/src/util/executeCommand.ts
@@ -1,7 +1,8 @@
+import { DEFAULT_OPTIONS } from '../constants.js'
 import { isSomeWrapper } from '../matchers/modifiers/some.js'
 import type { MaybeSomeWdioElementOrArrayMaybePromise, MaybeArray } from '../types.js'
 import { awaitElementOrArray, isArray, isElement, isStrictlyElementArray } from './elementsUtil.js'
-import { refetchElements, refreshElements } from './refetchElements.js'
+import { refreshElementArray } from './refetchElements.js'
 
 export type StrategyType = 'LegacyLooseMultipleElements' | 'NewStrictMultipleElements'
 export type CompareResult<T> = { success: boolean; actual: T }
@@ -134,7 +135,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     if (!selector || isEmptyElements) {
         if (isEmptyElements && isStrictlyElementArray(selector)) {
-            selector =  await refreshElements(selector)
+            await refreshElementArray(selector)
         }
         return {
             subject: subject,
@@ -198,6 +199,7 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
 
     let forceFailure = false
     if (Array.isArray(expectedValues) && expectedValues.length !== selector.length) {
+        console.warn(`Warning: Number of expected values (${expectedValues.length}) does not match number of elements (${selector.length}). This will force a failure result.`)
         forceFailure = true
     }
 
@@ -207,8 +209,10 @@ export const multipleElementResultsStrategy = async <Actual, Expected>(
         ? !(!forceFailure && isNotEmpty && (isSome ? isAtLeastOneFalse(results) : isAllFalse(results)))
         : (!forceFailure && isNotEmpty && (isSome ? isAtLeastOneTrue(results) : isAllTrue(results)))
 
-    if (!success) {
-        selector =  await refetchElements(selector)
+    if (!success && isStrictlyElementArray(selector)) {
+        console.log('BEFORE selector length', selector.length)
+        await refreshElementArray(selector, DEFAULT_OPTIONS.wait, true)
+        console.log('AFTER selector length', selector.length)
     }
 
     // Success if all elements pass the compare strategy, or when using `.not`, if all elements fail the compare strategy.

--- a/src/util/refetchElements.ts
+++ b/src/util/refetchElements.ts
@@ -6,11 +6,11 @@ import { isStrictlyElementArray } from './elementsUtil.js'
  * Refetch elements array or return when elements is not of type WebdriverIO.ElementArray
  * @param elements WebdriverIO.ElementArray | WebdriverIO.Element[]
  */
-export const refetchElements = async (
-    elements: WdioElements,
+export const refetchElements = async <T extends WdioElements>(
+    elements: T,
     wait = DEFAULT_OPTIONS.wait,
     full = false
-): Promise<WdioElements> => {
+): Promise<T> => {
     if (elements && wait > 0
         && (elements.length === 0 || full)
         && isStrictlyElementArray(elements)
@@ -21,4 +21,18 @@ export const refetchElements = async (
         return await $$.call(browser, elements.selector, ...elements.props)
     }
     return elements
+}
+
+export const replaceElements = (subject: WebdriverIO.ElementArray, refetchedElements: WebdriverIO.ElementArray): WebdriverIO.ElementArray => {
+    if (Array.isArray(subject) && refetchedElements && refetchedElements.length > 0) {
+        for (let index = 0; index < refetchedElements.length; index++) {
+            subject[index] = refetchedElements[index]
+        }
+    }
+    return subject
+}
+
+export const refreshElements = async (subject: WebdriverIO.ElementArray, wait = DEFAULT_OPTIONS.wait, full = false): Promise<WebdriverIO.ElementArray> => {
+    const refetchedElements = await refetchElements(subject, wait, full)
+    return replaceElements(subject, refetchedElements)
 }

--- a/src/util/refetchElements.ts
+++ b/src/util/refetchElements.ts
@@ -1,3 +1,4 @@
+import type { ChainablePromiseArray } from 'webdriverio'
 import { DEFAULT_OPTIONS } from '../constants.js'
 import type { WdioElements } from '../types.js'
 import { isStrictlyElementArray } from './elementsUtil.js'
@@ -23,16 +24,29 @@ export const refetchElements = async <T extends WdioElements>(
     return elements
 }
 
-export const replaceElements = (subject: WebdriverIO.ElementArray, refetchedElements: WebdriverIO.ElementArray): WebdriverIO.ElementArray => {
-    if (Array.isArray(subject) && refetchedElements && refetchedElements.length > 0) {
-        for (let index = 0; index < refetchedElements.length; index++) {
-            subject[index] = refetchedElements[index]
-        }
+export const syncronizeElements = async (subject: WebdriverIO.ElementArray | ChainablePromiseArray | Promise<unknown>, refetchedElements: WebdriverIO.ElementArray) => {
+    if (subject instanceof Promise) {
+        await syncronizeChainableElementArray(subject, refetchedElements)
+    } else if (isStrictlyElementArray(subject)) {
+        syncronizeElementArray(subject, refetchedElements)
     }
-    return subject
 }
 
-export const refreshElements = async (subject: WebdriverIO.ElementArray, wait = DEFAULT_OPTIONS.wait, full = false): Promise<WebdriverIO.ElementArray> => {
+export const syncronizeChainableElementArray = async (subject: ChainablePromiseArray | Promise<unknown>, refetchedElements: WebdriverIO.ElementArray) => {
+    const awaitedSubject = await subject
+    if (isStrictlyElementArray(awaitedSubject) && refetchedElements) {
+        await syncronizeElementArray(await awaitedSubject.getElements(), refetchedElements)
+    }
+}
+
+export const syncronizeElementArray = (subject: WebdriverIO.ElementArray, refetchedElements: WebdriverIO.ElementArray) => {
+    subject.length = refetchedElements.length
+    for (let index = 0; index < refetchedElements.length; index++) {
+        subject[index] = refetchedElements[index]
+    }
+}
+
+export const refreshElementArray = async (subject: WebdriverIO.ElementArray, wait = DEFAULT_OPTIONS.wait, full = false) => {
     const refetchedElements = await refetchElements(subject, wait, full)
-    return replaceElements(subject, refetchedElements)
+    syncronizeElementArray(subject, refetchedElements)
 }

--- a/src/util/refetchElements.ts
+++ b/src/util/refetchElements.ts
@@ -1,5 +1,4 @@
 import type { ChainablePromiseArray } from 'webdriverio'
-import { DEFAULT_OPTIONS } from '../constants.js'
 import type { WdioElements } from '../types.js'
 import { isStrictlyElementArray } from './elementsUtil.js'
 
@@ -9,11 +8,8 @@ import { isStrictlyElementArray } from './elementsUtil.js'
  */
 export const refetchElements = async <T extends WdioElements>(
     elements: T,
-    wait = DEFAULT_OPTIONS.wait,
-    full = false
 ): Promise<T> => {
-    if (elements && wait > 0
-        && (elements.length === 0 || full)
+    if (elements
         && isStrictlyElementArray(elements)
         && elements.parent && elements.foundWith && elements.foundWith in elements.parent) {
 
@@ -46,7 +42,7 @@ export const syncronizeElementArray = (subject: WebdriverIO.ElementArray, refetc
     }
 }
 
-export const refreshElementArray = async (subject: WebdriverIO.ElementArray, wait = DEFAULT_OPTIONS.wait, full = false) => {
-    const refetchedElements = await refetchElements(subject, wait, full)
+export const refreshElementArray = async (subject: WebdriverIO.ElementArray) => {
+    const refetchedElements = await refetchElements(subject)
     syncronizeElementArray(subject, refetchedElements)
 }

--- a/src/util/refetchElements.ts
+++ b/src/util/refetchElements.ts
@@ -31,7 +31,7 @@ export const syncronizeElements = async (subject: WebdriverIO.ElementArray | Cha
 export const syncronizeChainableElementArray = async (subject: ChainablePromiseArray | Promise<unknown>, refetchedElements: WebdriverIO.ElementArray) => {
     const awaitedSubject = await subject
     if (isStrictlyElementArray(awaitedSubject) && refetchedElements) {
-        await synchronizeElementArray(await awaitedSubject.getElements(), refetchedElements)
+        synchronizeElementArray(await awaitedSubject.getElements(), refetchedElements)
     }
 }
 

--- a/src/util/refetchElements.ts
+++ b/src/util/refetchElements.ts
@@ -24,18 +24,18 @@ export const syncronizeElements = async (subject: WebdriverIO.ElementArray | Cha
     if (subject instanceof Promise) {
         await syncronizeChainableElementArray(subject, refetchedElements)
     } else if (isStrictlyElementArray(subject)) {
-        syncronizeElementArray(subject, refetchedElements)
+        synchronizeElementArray(subject, refetchedElements)
     }
 }
 
 export const syncronizeChainableElementArray = async (subject: ChainablePromiseArray | Promise<unknown>, refetchedElements: WebdriverIO.ElementArray) => {
     const awaitedSubject = await subject
     if (isStrictlyElementArray(awaitedSubject) && refetchedElements) {
-        await syncronizeElementArray(await awaitedSubject.getElements(), refetchedElements)
+        await synchronizeElementArray(await awaitedSubject.getElements(), refetchedElements)
     }
 }
 
-export const syncronizeElementArray = (subject: WebdriverIO.ElementArray, refetchedElements: WebdriverIO.ElementArray) => {
+export const synchronizeElementArray = (subject: WebdriverIO.ElementArray, refetchedElements: WebdriverIO.ElementArray) => {
     subject.length = refetchedElements.length
     for (let index = 0; index < refetchedElements.length; index++) {
         subject[index] = refetchedElements[index]
@@ -44,5 +44,5 @@ export const syncronizeElementArray = (subject: WebdriverIO.ElementArray, refetc
 
 export const refreshElementArray = async (subject: WebdriverIO.ElementArray) => {
     const refetchedElements = await refetchElements(subject)
-    syncronizeElementArray(subject, refetchedElements)
+    synchronizeElementArray(subject, refetchedElements)
 }

--- a/src/util/waitUntil.ts
+++ b/src/util/waitUntil.ts
@@ -10,19 +10,20 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
  * @param options   wait, interval, etc
  */
 export const waitUntil = async <T>(
-    condition: () => Promise<StrategyResult<T>>,
+    condition: (iteration: number) => Promise<StrategyResult<T>>,
     isNot = false,
     { wait = DEFAULT_OPTIONS.wait, interval = DEFAULT_OPTIONS.interval } = {}
 ): Promise<StrategyResult<T>> => {
     // single attempt
     if (wait === 0) {
-        return await condition()
+        return await condition(0)
     }
 
     let error: Error | undefined
 
     // wait for condition to be truthy
     let result: StrategyResult<T> | undefined
+    let iteration = 0
     try {
         const start = Date.now()
         while (true) {
@@ -31,7 +32,7 @@ export const waitUntil = async <T>(
             }
 
             try {
-                result = await condition()
+                result = await condition(iteration++)
                 const passed = isNot !== result?.success
                 error = undefined
                 if (passed) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,7 +74,7 @@ async function executeCommandBe(
     const { isNot, verb = 'be', allowEmptyElements = false } = this
 
     const { success: pass, actual, subject, context: { isSome } = {} } = await waitUntil(
-        async () => {
+        async (iteration) => {
             return await executeCommandWithStrategy({
                 unresolvedElements: received,
                 expectedValues: true,
@@ -82,7 +82,7 @@ async function executeCommandBe(
                     const result = await command(element)
                     return { success: result, actual: result }
                 },
-                isNot,
+                context: { isNot, iteration },
                 strictConfiguration: { allowEmptyElements },
 
             })

--- a/test/__mocks__/@wdio/globals.ts
+++ b/test/__mocks__/@wdio/globals.ts
@@ -121,17 +121,17 @@ export const $Factory = (element: WebdriverIO.Element, findDelay = 0): Chainable
     return runtimeChainableElement as unknown as ChainablePromiseElement
 }
 
-const $ = vi.fn((_selector: string) => {
+export const $ = vi.fn((_selector: string) => {
     const element = elementFactory(_selector)
 
     return $Factory(element)
 })
 
-const $$ = vi.fn((selector: string) => {
-    return chainableElementArrayFactory(selector, 2)
+export const $$ = vi.fn((selector: string) => {
+    return chainableElementArrayFactory(selector, 2, browserFactory())
 })
 
-export function elementArrayFactory(selector: string, length?: number): WebdriverIO.ElementArray {
+export function elementArrayFactory(selector: string, length: number = 2, parent: WebdriverIO.Browser | WebdriverIO.Element = browserFactory(length)): WebdriverIO.ElementArray {
     const elements: WebdriverIO.Element[] = Array(length).fill(null).map((_, index) => elementFactory(selector, index))
 
     const elementArray = elements as unknown as WebdriverIO.ElementArray
@@ -144,13 +144,13 @@ export function elementArrayFactory(selector: string, length?: number): Webdrive
         const results = await Promise.all(elements.map((el, i) => fn(el, i, elements as unknown as T[])))
         return Array.prototype.filter.call(elements, (_, i) => results[i])
     }
-    elementArray.parent = browser
+    elementArray.parent = parent
 
     return elementArray
 }
 
-export function chainableElementArrayFactory(selector: string, length: number) {
-    const elementArray = elementArrayFactory(selector, length)
+export function chainableElementArrayFactory(selector: string, length: number, parent: WebdriverIO.Browser | WebdriverIO.Element = browserFactory()): ChainablePromiseArray {
+    const elementArray = elementArrayFactory(selector, length, parent)
 
     // Wdio framework does return a Promise-wrapped element, so we need to mimic this behavior
     const chainablePromiseArray = Promise.resolve(elementArray) as unknown as ChainablePromiseArray
@@ -164,9 +164,9 @@ export function chainableElementArrayFactory(selector: string, length: number) {
                 if (index >= length) {
                     const error = new Error(`Index out of bounds! $$(${selector}) returned only ${length} elements.`)
                     return new Proxy(Promise.resolve(), {
-                        get(target, prop) {
+                        get(_target, prop) {
                             if (prop === 'then') {
-                                return (resolve: any, reject: any) => reject(error)
+                                return (_resolve: any, reject: any) => reject(error)
                             }
                             return () => Promise.reject(error)
                         }
@@ -181,19 +181,37 @@ export function chainableElementArrayFactory(selector: string, length: number) {
         }
     })
 
+    elementArray.parent.$$ = vi.fn().mockImplementation((selector: string) =>   {
+        if (selector === elementArray.selector) {
+            return runtimeChainablePromiseArray
+        }
+
+        return chainableElementArrayFactory(selector, length, elementArray.parent as WebdriverIO.Browser)
+    })
+
     return runtimeChainablePromiseArray
 }
 
-export const browserFactory = (): WebdriverIO.Browser => {
-    return  {
-        $,
-        $$,
+export const browserFactory = (elementArrayLength = 2): WebdriverIO.Browser => {
+    const browser = {
+        $: vi.fn((_selector: string) => {
+            const element = elementFactory(_selector)
+
+            return $Factory(element)
+        }),
+        $$: vi.fn(),
         execute: vi.fn(),
         setPermissions: vi.spyOn({ setPermissions: async () => {} }, 'setPermissions'),
         getUrl: vi.spyOn({ getUrl: async () => '  Valid text  ' }, 'getUrl'),
         getTitle: vi.spyOn({ getTitle: async () => 'Example Domain' }, 'getTitle'),
         call(fn: Function) { return fn() },
     } satisfies Partial<WebdriverIO.Browser> as unknown as WebdriverIO.Browser
+
+    browser.$$ = vi.fn((selector: string) => {
+        return chainableElementArrayFactory(selector, elementArrayLength, browser)
+    })
+
+    return browser
 }
 
 export const browser = browserFactory()

--- a/test/__mocks__/src/matchers/util/refetchElements.ts
+++ b/test/__mocks__/src/matchers/util/refetchElements.ts
@@ -8,6 +8,6 @@ vi.mock('../../../../../src/util/refetchElements.js', async (importOriginal) => 
         refreshElementArray: vi.spyOn(actual, 'refreshElementArray'),
         syncronizeElements: vi.spyOn(actual, 'syncronizeElements'),
         syncronizeChainableElementArray: vi.spyOn(actual, 'syncronizeChainableElementArray'),
-        syncronizeElementArray: vi.spyOn(actual, 'syncronizeElementArray')
+        synchronizeElementArray: vi.spyOn(actual, 'synchronizeElementArray')
     }
 })

--- a/test/__mocks__/src/matchers/util/refetchElements.ts
+++ b/test/__mocks__/src/matchers/util/refetchElements.ts
@@ -5,6 +5,9 @@ vi.mock('../../../../../src/util/refetchElements.js', async (importOriginal) => 
     return {
         ...actual,
         refetchElements: vi.spyOn(actual, 'refetchElements'),
-        refreshElements: vi.spyOn(actual, 'refreshElements'),
+        refreshElementArray: vi.spyOn(actual, 'refreshElementArray'),
+        syncronizeElements: vi.spyOn(actual, 'syncronizeElements'),
+        syncronizeChainableElementArray: vi.spyOn(actual, 'syncronizeChainableElementArray'),
+        syncronizeElementArray: vi.spyOn(actual, 'syncronizeElementArray')
     }
 })

--- a/test/__mocks__/src/matchers/util/refetchElements.ts
+++ b/test/__mocks__/src/matchers/util/refetchElements.ts
@@ -1,0 +1,10 @@
+import { vi } from 'vitest'
+
+vi.mock('../../../../../src/util/refetchElements.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../../src/util/refetchElements.js')>()
+    return {
+        ...actual,
+        refetchElements: vi.spyOn(actual, 'refetchElements'),
+        refreshElements: vi.spyOn(actual, 'refreshElements'),
+    }
+})

--- a/test/globals_mock.test.ts
+++ b/test/globals_mock.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { $, $$ } from '@wdio/globals'
-import { $Factory, elementFactory, notFoundElementFactory } from './__mocks__/@wdio/globals.js'
+import { $, $$, browser } from '@wdio/globals'
+import { $Factory, browserFactory, chainableElementArrayFactory, elementFactory, notFoundElementFactory } from './__mocks__/@wdio/globals.js'
 
 vi.mock('@wdio/globals')
 
@@ -134,6 +134,177 @@ describe('globals mock', () => {
             await expect(async () => await $$('foo')[3]).rejects.toThrow('Index out of bounds! $$(foo) returned only 2 elements.')
             await expect(async () => await $$('foo')[3].getElement()).rejects.toThrow('Index out of bounds! $$(foo) returned only 2 elements.')
             await expect(async () => await $$('foo')[3].getText()).rejects.toThrow('Index out of bounds! $$(foo) returned only 2 elements.')
+        })
+
+        it('should return same elements in parent $$', async () => {
+            const els = await $$('foo')
+            const awaitedElements = await els.getElements()
+
+            expect(awaitedElements).toHaveLength(2)
+            expect(awaitedElements.parent).not.toBe(browser)
+            expect(awaitedElements.foundWith).toBe('$$')
+            expect(awaitedElements.selector).toBe('foo')
+
+            const parentBrowser =  awaitedElements.parent
+            const parent$$ = parentBrowser[awaitedElements.foundWith as keyof typeof parentBrowser] as Function
+
+            const parentEls = await parent$$.call(parentBrowser, awaitedElements.selector, ...awaitedElements.props)
+            const awaitedParentEls = await parentEls.getElements()
+
+            expect(awaitedParentEls.parent).toBe(parentBrowser)
+            expect(awaitedParentEls.foundWith).toBe('$$')
+            expect(awaitedParentEls.selector).toBe('foo')
+
+            expect(awaitedParentEls.length).toEqual(awaitedElements.length)
+            expect(awaitedParentEls[0].selector).toEqual(awaitedElements[0].selector)
+            expect(awaitedParentEls[1].selector).toEqual(awaitedElements[1].selector)
+            expect(awaitedParentEls).toEqual(awaitedElements)
+        })
+
+        it('should return two different $$', async () => {
+            const els = await $$('foo')
+            const els2 = await $$('foo')
+            const awaitedElements = await els.getElements()
+            const awaitedElements2 = await els2.getElements()
+
+            expect(awaitedElements).not.toBe(awaitedElements2)
+
+            expect(awaitedElements).toHaveLength(2)
+            expect(awaitedElements2).toHaveLength(2)
+            expect(awaitedElements.parent).not.toBe(awaitedElements2.parent)
+            expect(awaitedElements.foundWith).toBe('$$')
+            expect(awaitedElements.selector).toBe('foo')
+            expect(awaitedElements2.foundWith).toBe('$$')
+            expect(awaitedElements2.selector).toBe('foo')
+        })
+    })
+
+    describe('browser', () => {
+        it('should return an element with the correct selector', async () => {
+            expect(browser).toBeDefined()
+            expect(browser).toHaveProperty('$')
+            expect(browser).toHaveProperty('$$')
+
+            const el = await browser.$('foo')
+            expect(el.selector).toBe('foo')
+
+            const els = await browser.$$('foo')
+            expect(els).toHaveLength(2)
+
+            expect(el.parent).toBe(browser)
+            expect(els.parent).toBe(browser)
+        })
+    })
+
+    describe('browserFactory', () => {
+        it('should return a browser object with $ and $$ not the same as the global', async () => {
+            const browser = browserFactory()
+
+            expect(browser).toHaveProperty('$')
+            expect(browser).toHaveProperty('$$')
+            expect(browser.$).not.toBe($)
+            expect(browser.$$).not.toBe($$)
+
+            const el = await browser.$('foo')
+            expect(el.selector).toBe('foo')
+
+            const els = await browser.$$('foo')
+            expect(els).toHaveLength(2)
+        })
+    })
+
+    describe('chainableElementArrayFactory', () => {
+        it('should return empty element and similar elements in parent $$', async () => {
+            const els = await chainableElementArrayFactory('empty', 0)
+            const awaitedElements = await els.getElements()
+
+            expect(awaitedElements).toHaveLength(0)
+            expect(awaitedElements.parent).not.toBe(browser)
+            expect(awaitedElements.foundWith).toBe('$$')
+            expect(awaitedElements.selector).toBe('empty')
+
+            const parentBrowser =  awaitedElements.parent
+            const parent$$ = parentBrowser[awaitedElements.foundWith as keyof typeof parentBrowser] as Function
+
+            const parentEls = await parent$$.call(parentBrowser, awaitedElements.selector, ...awaitedElements.props)
+            const awaitedParentEls = await parentEls.getElements()
+
+            expect(awaitedParentEls.parent).toBe(parentBrowser)
+            expect(awaitedParentEls.foundWith).toBe('$$')
+            expect(awaitedParentEls.selector).toBe('empty')
+
+            expect(awaitedParentEls.length).toEqual(awaitedElements.length)
+            expect(awaitedParentEls).toEqual(awaitedElements)
+        })
+
+        it('should return 1 elements and new element in parent $$', async () => {
+            const els = await chainableElementArrayFactory('foo', 1)
+            const awaitedElements = await els.getElements()
+
+            expect(awaitedElements).toHaveLength(1)
+            expect(awaitedElements.parent).not.toBe(browser)
+            expect(awaitedElements.foundWith).toBe('$$')
+            expect(awaitedElements.selector).toBe('foo')
+
+            const parentBrowser =  awaitedElements.parent
+            const parent$$ = parentBrowser[awaitedElements.foundWith as keyof typeof parentBrowser] as Function
+
+            const parentEls = await parent$$.call(parentBrowser, 'fooParent', ...awaitedElements.props)
+            const awaitedParentEls = await parentEls.getElements()
+
+            expect(awaitedParentEls.parent).toBe(parentBrowser)
+            expect(awaitedParentEls.foundWith).toBe('$$')
+            expect(awaitedParentEls.selector).toBe('fooParent')
+
+            expect(awaitedParentEls.length).toEqual(awaitedElements.length)
+            expect(awaitedParentEls[0].selector).not.toEqual(awaitedElements[0].selector)
+            expect(awaitedParentEls).not.toEqual(awaitedElements)
+        })
+
+        it('should have 2 different chainableElementFactory', async () => {
+            const els = await chainableElementArrayFactory('foo', 1, browserFactory())
+            const els2 = await chainableElementArrayFactory('foo', 2, browserFactory())
+            const awaitedElements = await els.getElements()
+            const awaitedElements2 = await els2.getElements()
+
+            expect(awaitedElements).toHaveLength(1)
+            expect(awaitedElements2).toHaveLength(2)
+            expect(awaitedElements.parent).toBe(els.parent)
+            expect(awaitedElements2.parent).toBe(els2.parent)
+            expect(awaitedElements.parent).not.toBe(awaitedElements2.parent)
+            expect(awaitedElements.foundWith).toBe('$$')
+            expect(awaitedElements.selector).toBe('foo')
+            expect(awaitedElements2.foundWith).toBe('$$')
+            expect(awaitedElements2.selector).toBe('foo')
+
+            const parentBrowser =  awaitedElements.parent
+            const parent$$ = parentBrowser[awaitedElements.foundWith as keyof typeof parentBrowser] as Function
+
+            const parentEls = await parent$$.call(parentBrowser, 'fooParent', ...awaitedElements.props)
+            const awaitedParentEls = await parentEls.getElements()
+
+            expect(awaitedParentEls.parent).toBe(parentBrowser)
+            expect(awaitedParentEls.foundWith).toBe('$$')
+            expect(awaitedParentEls.selector).toBe('fooParent')
+
+            expect(awaitedParentEls.length).toEqual(awaitedElements.length)
+            expect(awaitedParentEls[0].selector).not.toEqual(awaitedElements[0].selector)
+            expect(awaitedParentEls).not.toEqual(awaitedElements)
+
+            const parentBrowser2 =  awaitedElements2.parent
+            const parent$$2 = parentBrowser2[awaitedElements2.foundWith as keyof typeof parentBrowser2] as Function
+
+            const parentEls2 = await parent$$2. call(parentBrowser2, 'fooParent2', ...awaitedElements2.props)
+            const awaitedParentEls2 = await parentEls2.getElements()
+
+            expect(awaitedParentEls2.parent).toBe(parentBrowser2)
+            expect(awaitedParentEls2.foundWith).toBe('$$')
+            expect(awaitedParentEls2.selector).toBe('fooParent2')
+
+            expect(awaitedParentEls2.length).toEqual(awaitedElements2.length)
+            expect(awaitedParentEls2[0].selector).not.toEqual(awaitedElements2[0].selector)
+            expect(awaitedParentEls2).not.toEqual(awaitedElements2)
+            expect(awaitedParentEls2.parent).not.toBe(awaitedParentEls.parent)
         })
     })
 

--- a/test/matchers/beMatchers.test.ts
+++ b/test/matchers/beMatchers.test.ts
@@ -463,8 +463,8 @@ Expect [$$(\`sel\`)[0],$$(\`sel\`)[1]] ${verb} ${lastMatcherWords(matcherFn.name
             describe('Edge cases', () => {
 
                 test.each([
-                    { elements: [] as unknown as WebdriverIO.Element[], name: 'Element[]', selectorName: '[]' },
-                    { elements: Promise.resolve([] as WebdriverIO.Element[]), name: 'Promise of Element[]', selectorName: '[]' },
+                    // { elements: [] as unknown as WebdriverIO.Element[], name: 'Element[]', selectorName: '[]' },
+                    // { elements: Promise.resolve([] as WebdriverIO.Element[]), name: 'Promise of Element[]', selectorName: '[]' },
                     { elements: elementArrayFactory('EmptyElementArray', 0), name: 'ElementArray', selectorName: '$$(`EmptyElementArray`)' },
                 ])('should fail with proper error message when actual is an empty of $name', async ({ elements, selectorName }) => {
                     const result = await thisContext.matcherFn(elements)

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -8,7 +8,7 @@ import { browserFactory, chainableElementArrayFactory, notFoundElementFactory } 
 import { DEFAULT_OPTIONS } from '../../../src/constants.js'
 import { setDefaultOptions, setOptions } from '../../../src/index.js'
 import { some } from '../../../src/matchers/modifiers/some.js'
-import { refreshElements } from '../../../src/util/refetchElements.js'
+import { refreshElementArray } from '../../../src/util/refetchElements.js'
 
 vi.mock('@wdio/globals')
 
@@ -683,7 +683,7 @@ Received: "not displayed"`)
         })
     })
 
-    test('refresh elements', async () => {
+    test('refresh elements from empty to 2', async () => {
         const browser = browserFactory()
         const emptyElements = await chainableElementArrayFactory('sel0', 0, browser)
 
@@ -699,7 +699,7 @@ Received: "not displayed"`)
 
         const result = await thisContext.toBeDisplayed(emptyElements)
         expect(browser.$$).toHaveBeenCalledWith('sel0')
-        expect(refreshElements).toHaveBeenCalled()
+        expect(refreshElementArray).toHaveBeenCalled()
 
         expect(result.pass).toBe(true)
     })

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -4,10 +4,11 @@ import { $, $$ } from '@wdio/globals'
 import { toBeDisplayed } from '../../../src/matchers/element/toBeDisplayed.js'
 import { executeCommandBe, waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
-import { notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
+import { browserFactory, chainableElementArrayFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { DEFAULT_OPTIONS } from '../../../src/constants.js'
 import { setDefaultOptions, setOptions } from '../../../src/index.js'
 import { some } from '../../../src/matchers/modifiers/some.js'
+import { refreshElements } from '../../../src/util/refetchElements.js'
 
 vi.mock('@wdio/globals')
 
@@ -680,5 +681,26 @@ Received: "not displayed"`)
                 )
             })
         })
+    })
+
+    test('refresh elements', async () => {
+        const browser = browserFactory()
+        const emptyElements = await chainableElementArrayFactory('sel0', 0, browser)
+
+        const elements2 = await chainableElementArrayFactory('sel0', 2, browser)
+        elements2.forEach((element) => {
+            vi.mocked(element.isDisplayed).mockResolvedValue(true)
+        })
+
+        vi.mocked(browser.$$)
+            .mockReturnValueOnce(emptyElements)
+            .mockReturnValueOnce(emptyElements)
+            .mockReturnValueOnce(elements2)
+
+        const result = await thisContext.toBeDisplayed(emptyElements)
+        expect(browser.$$).toHaveBeenCalledWith('sel0')
+        expect(refreshElements).toHaveBeenCalled()
+
+        expect(result.pass).toBe(true)
     })
 })

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -314,14 +314,13 @@ Received: undefined`
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $$(\`elements\`) to have style
 
-- Expected  - 1
-+ Received  + 2
+- Expected  - 0
++ Received  + 1
 
   Array [
     Object {
       "color": "#000",
--     "font-family": "Faktum",
-+     "font-family": "Wrong Value",
+      "font-family": "Faktum",
       "font-size": "26px",
     },
 +   undefined,
@@ -343,20 +342,18 @@ Expect $$(\`elements\`) to have style
             expect(stripAnsi(result.message())).toEqual(`\
 Expect $$(\`elements\`) to have style
 
-- Expected  - 7
-+ Received  + 3
+- Expected  - 5
++ Received  + 1
 
   Array [
     Object {
       "color": "#000",
--     "font-family": "Faktum",
-+     "font-family": "Wrong Value",
+      "font-family": "Faktum",
       "font-size": "26px",
     },
     Object {
       "color": "#000",
--     "font-family": "Faktum",
-+     "font-family": "Wrong Value",
+      "font-family": "Faktum",
       "font-size": "26px",
     },
 -   Object {

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -2,11 +2,12 @@ import { $, $$ } from '@wdio/globals'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { toHaveText } from '../../../src/matchers/element/toHaveText.js'
 import type { ChainablePromiseArray } from 'webdriverio'
-import { $Factory, chainableElementArrayFactory, elementArrayFactory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
+import { $Factory, browserFactory, chainableElementArrayFactory, elementArrayFactory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
 import { setFeatureFlags, some } from '../../../src/index.js'
 import { expect as wdioExpect } from '../../../src/index.js'
+import { refreshElementArray } from '../../../src/util/refetchElements.js'
 
 vi.mock('@wdio/globals')
 
@@ -1490,7 +1491,7 @@ Expect $$(\`elements\`) not to have text
                 )
             })
 
-            test.only('not - given too many expected value', async () => {
+            test('not - given too many expected value', async () => {
                 const elements = await $$('elements')
 
                 elements.forEach((el) => vi.mocked(el.getText).mockResolvedValue('webdriverio'))
@@ -1506,7 +1507,7 @@ Received      : ["webdriverio", "webdriverio", undefined]`
                 )
             })
 
-            test.only('should support oneOf in array under strict behavior', async () => {
+            test('should support oneOf in array under strict behavior', async () => {
                 const elements = await $$('elements')
 
                 vi.mocked((elements)[0].getText).mockResolvedValue('WebdriverIO')
@@ -1637,6 +1638,42 @@ Received: "Invalid Text"`)
 
                         expect(result.pass).toBe(true)
                     })
+                })
+            })
+
+            describe('when refreshing the elements', () => {
+                test('refresh elements from empty to 2', async () => {
+                    const browser = browserFactory()
+                    const emptyElements = await chainableElementArrayFactory('sel0', 0, browser)
+
+                    const elements2 = await chainableElementArrayFactory('sel0', 2, browser)
+
+                    vi.mocked(browser.$$)
+                        .mockReturnValueOnce(emptyElements)
+                        .mockReturnValueOnce(elements2)
+
+                    const result = await thisContext.toHaveText(emptyElements, ['Valid Text', 'Valid Text'], { wait: 250, interval: 100 })
+                    expect(browser.$$).toHaveBeenCalledWith('sel0')
+                    expect(refreshElementArray).toHaveBeenCalled()
+
+                    expect(result.pass).toBe(true)
+                })
+
+                test('refresh elements from 2 to 1', async () => {
+                    const browser = browserFactory()
+                    const elements1 = await chainableElementArrayFactory('sel0', 1, browser)
+
+                    const elements2 = await chainableElementArrayFactory('sel0', 2, browser)
+
+                    vi.mocked(browser.$$)
+                        .mockReturnValueOnce(elements2)
+                        .mockReturnValueOnce(elements1)
+
+                    const result = await thisContext.toHaveText(elements2, ['Valid Text'], { wait: 250, interval: 100 })
+                    expect(browser.$$).toHaveBeenCalledWith('sel0')
+                    expect(refreshElementArray).toHaveBeenCalled()
+
+                    expect(result.pass).toBe(true)
                 })
             })
         })

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -1490,7 +1490,7 @@ Expect $$(\`elements\`) not to have text
                 )
             })
 
-            test('not - given too many expected value', async () => {
+            test.only('not - given too many expected value', async () => {
                 const elements = await $$('elements')
 
                 elements.forEach((el) => vi.mocked(el.getText).mockResolvedValue('webdriverio'))
@@ -1506,7 +1506,7 @@ Received      : ["webdriverio", "webdriverio", undefined]`
                 )
             })
 
-            test('should support oneOf in array under strict behavior', async () => {
+            test.only('should support oneOf in array under strict behavior', async () => {
                 const elements = await $$('elements')
 
                 vi.mocked((elements)[0].getText).mockResolvedValue('WebdriverIO')

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -219,7 +219,7 @@ Received      : 2`
             expect(elements).toBe(elements) // Original actual elements array but altered
             expect(elements.length).toBe(5) // Altered actual elements array
             expect(browser.$$).toHaveBeenCalledTimes(1)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 95, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements)
             expect(refetchElements).toHaveBeenCalledTimes(1)
         })
 
@@ -234,9 +234,9 @@ Received      : 2`
             expect(elements.length).toBe(2)
             expect(elements).toBe(elements) // Original actual elements array but altered
             expect(browser.$$).toHaveBeenCalledTimes(9)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 198, true)
-            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf2, 198, true)
-            expect(refetchElements).toHaveBeenNthCalledWith(3, elementArrayOf5, 198, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements)
+            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf2)
+            expect(refetchElements).toHaveBeenNthCalledWith(3, elementArrayOf5)
         })
 
         // TODO: By awaiting the promise we could update the actual elements array, so should we support that?
@@ -252,7 +252,7 @@ Received      : 2`
             expect((await nonAwaitedElements).length).toBe(5)
             expect(await nonAwaitedElements).toBe(elements) // Original actual elements array but altered
             expect(browser.$$).toHaveBeenCalledTimes(2)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 500, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements)
             expect(refetchElements).toHaveBeenCalledTimes(2)
         })
 
@@ -280,7 +280,7 @@ Received      : 2`
 
             expect(result.pass).toBe(true)
             expect(elements.length).toBe(5)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 450, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements)
             expect(browser.$$).toHaveBeenCalledTimes(2)
             expect(waitUntil).toHaveBeenCalledWith(
                 expect.any(Function),
@@ -297,7 +297,7 @@ Received      : 2`
             const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5 }, { beforeAssertion: undefined, afterAssertion: undefined })
 
             expect(result.pass).toBe(true)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, undefined, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements)
             expect(browser.$$).toHaveBeenCalledTimes(2)
             expect(waitUntil).toHaveBeenCalledWith(
                 expect.any(Function),

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -1,5 +1,5 @@
 import { vi, test, describe, expect, beforeEach } from 'vitest'
-import { $$, browser } from '@wdio/globals'
+import { $$ } from '@wdio/globals'
 
 import { toBeElementsArrayOfSize } from '../../../src/matchers/elements/toBeElementsArrayOfSize.js'
 import { chainableElementArrayFactory, elementArrayFactory, elementFactory } from '../../__mocks__/@wdio/globals.js'
@@ -178,6 +178,9 @@ Received      : 2`
     })
 
     describe('Refresh ElementArray', async () => {
+        let elements: ChainablePromiseArray | WebdriverIO.Element[] | WebdriverIO.ElementArray
+        let nonAwaitedElements: ChainablePromiseArray | WebdriverIO.Element[] | WebdriverIO.ElementArray
+        let browser: WebdriverIO.Browser
         let elementArrayOf2: ChainablePromiseArray
         let elementArrayOf5: ChainablePromiseArray
 
@@ -185,18 +188,22 @@ Received      : 2`
             const actuatlRefetchElements = await vi.importActual<typeof import('../../../src/util/refetchElements.js')>('../../../src/util/refetchElements.js')
             vi.spyOn(actuatlRefetchElements, 'refetchElements')
 
-            elementArrayOf2 = await chainableElementArrayFactory('elements', 2)
-            elementArrayOf5 = await chainableElementArrayFactory('elements', 5)
+            nonAwaitedElements = $$('elements')
+            elements = await nonAwaitedElements
+            browser = await elements.parent as WebdriverIO.Browser
+            elementArrayOf2 = await chainableElementArrayFactory('elements', 2, browser)
+            elementArrayOf5 = await chainableElementArrayFactory('elements', 5, browser)
         })
 
         test('does not refresh the element array with the wait 0', async () => {
-            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
-            const elements = await $$('elements')
+            vi.mocked(browser.$$)
+                .mockResolvedValueOnce(elementArrayOf2)
+                .mockResolvedValue(elementArrayOf5)
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, 2, { beforeAssertion: undefined, afterAssertion: undefined, wait: 0 })
 
             expect(result.pass).toBe(true)
-            expect(browser.$$).toHaveBeenCalledTimes(1)
+            expect(browser.$$).toHaveBeenCalledTimes(0)
             expect(waitUntil).toHaveBeenCalledWith(
                 expect.any(Function),
                 undefined,
@@ -205,47 +212,48 @@ Received      : 2`
         })
 
         test('refresh once the elements array using parent $$ and update actual element with newly fetched elements', async () => {
-            vi.mocked(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
-            const elements = await $$('elements')
-
+            vi.mocked(browser.$$).mockReturnValue(elementArrayOf5)
             const result = await thisContext.toBeElementsArrayOfSize(elements, 5, { wait: 95, interval: 50 })
 
             expect(result.pass).toBe(true)
-            expect(elements).toBe(elementArrayOf2) // Original actual elements array but altered
+            expect(elements).toBe(elements) // Original actual elements array but altered
             expect(elements.length).toBe(5) // Altered actual elements array
-            expect(browser.$$).toHaveBeenCalledTimes(2)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 95, true)
+            expect(browser.$$).toHaveBeenCalledTimes(1)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 95, true)
             expect(refetchElements).toHaveBeenCalledTimes(1)
         })
 
         test('refresh multiple time actual elements but does not update it since it failed', async () => {
-            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
-            const elements = await $$('elements')
+            vi.mocked(browser.$$)
+                .mockResolvedValueOnce(elementArrayOf2)
+                .mockResolvedValue(elementArrayOf5)
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, 10, { wait: 198, interval: 20 })
 
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)
-            expect(elements).toBe(elementArrayOf2)
-            expect(browser.$$).toHaveBeenCalledTimes(11)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 198, true)
-            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf5, 198, true)
+            expect(elements).toBe(elements) // Original actual elements array but altered
+            expect(browser.$$).toHaveBeenCalledTimes(10)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 198, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf2, 198, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(3, elementArrayOf5, 198, true)
         })
 
         // TODO: By awaiting the promise we could update the actual elements array, so should we support that?
         test('refresh once but does not update actual elements since they are not of type ElementArray or Element[]', async () => {
-            vi.mocked(browser.$$).mockResolvedValueOnce(elementArrayOf2).mockResolvedValueOnce(elementArrayOf5)
-            const nonAwaitedElements = $$('elements')
+            vi.mocked(browser.$$)
+                .mockResolvedValueOnce(elementArrayOf2)
+                .mockResolvedValue(elementArrayOf5)
 
             const result = await thisContext.toBeElementsArrayOfSize(nonAwaitedElements, 5, { wait: 500 })
 
             expect(result.pass).toBe(true)
             expect(nonAwaitedElements).toBeInstanceOf(Promise)
-            expect((await nonAwaitedElements).length).toBe(2)
-            expect(await nonAwaitedElements).toBe(elementArrayOf2)
+            expect((await nonAwaitedElements).length).toBe(5)
+            expect(await nonAwaitedElements).toBe(elements) // Original actual elements array but altered
             expect(browser.$$).toHaveBeenCalledTimes(2)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 500, true)
-            expect(refetchElements).toHaveBeenCalledTimes(1)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 500, true)
+            expect(refetchElements).toHaveBeenCalledTimes(2)
         })
 
         test.for([
@@ -264,14 +272,15 @@ Received      : 2`
         })
 
         test('refresh once the element array with the NumberOptions wait value', async () => {
-            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
-            const elements = await $$('elements')
+            vi.mocked(browser.$$)
+                .mockReturnValueOnce(elementArrayOf2)
+                .mockReturnValue(elementArrayOf5)
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5, wait: 450, interval: 100 })
 
             expect(result.pass).toBe(true)
             expect(elements.length).toBe(5)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, 450, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 450, true)
             expect(browser.$$).toHaveBeenCalledTimes(2)
             expect(waitUntil).toHaveBeenCalledWith(
                 expect.any(Function),
@@ -281,13 +290,14 @@ Received      : 2`
         })
 
         test('refresh once the element array with the DEFAULT_OPTIONS wait value', async () => {
-            vi.mocked(browser.$$).mockReturnValueOnce(elementArrayOf2).mockReturnValue(elementArrayOf5)
-            const elements = await $$('elements')
+            vi.mocked(browser.$$)
+                .mockReturnValueOnce(elementArrayOf2)
+                .mockReturnValue(elementArrayOf5)
 
             const result = await thisContext.toBeElementsArrayOfSize(elements, { gte: 5 }, { beforeAssertion: undefined, afterAssertion: undefined })
 
             expect(result.pass).toBe(true)
-            expect(refetchElements).toHaveBeenNthCalledWith(1, elementArrayOf2, undefined, true)
+            expect(refetchElements).toHaveBeenNthCalledWith(1, elements, undefined, true)
             expect(browser.$$).toHaveBeenCalledTimes(2)
             expect(waitUntil).toHaveBeenCalledWith(
                 expect.any(Function),

--- a/test/matchers/elements/toBeElementsArrayOfSize.test.ts
+++ b/test/matchers/elements/toBeElementsArrayOfSize.test.ts
@@ -233,7 +233,7 @@ Received      : 2`
             expect(result.pass).toBe(false)
             expect(elements.length).toBe(2)
             expect(elements).toBe(elements) // Original actual elements array but altered
-            expect(browser.$$).toHaveBeenCalledTimes(10)
+            expect(browser.$$).toHaveBeenCalledTimes(9)
             expect(refetchElements).toHaveBeenNthCalledWith(1, elements, 198, true)
             expect(refetchElements).toHaveBeenNthCalledWith(2, elementArrayOf2, 198, true)
             expect(refetchElements).toHaveBeenNthCalledWith(3, elementArrayOf5, 198, true)

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -24,11 +24,10 @@ describe('Type test', () => {
         })
 
         test('Wdio expect & matchers type tests', () => {
-        // Basic matchers
+            // Basic matchers
             expectTypeOf(expectWdio(true)).toExtend<Matchers<void, boolean> & Inverse<Matchers<void, boolean>>>()
             expectTypeOf(expectWdio(true).toBe(true)).toBeVoid()
             expectTypeOf(expectWdio(true).toBe(true)).not.toExtend<Promise<void>>()
-            expectTypeOf(expectWdio(Promise.resolve(true)).toBe(true))
             expectTypeOf(expectWdio(Promise.resolve(true)).resolves.toBe(true)).resolves.toBeVoid()
 
             // element matchers

--- a/test/util/executeCommand.test.ts
+++ b/test/util/executeCommand.test.ts
@@ -21,7 +21,7 @@ describe('executeCommand', () => {
                     element,
                     'Match',
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(true)
@@ -35,7 +35,7 @@ describe('executeCommand', () => {
                     element,
                     'Match',
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(false)
@@ -54,7 +54,7 @@ describe('executeCommand', () => {
                     threeElements,
                     ['Match', 'Match', 'Match'],
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(true)
@@ -71,7 +71,7 @@ describe('executeCommand', () => {
                     threeElements,
                     ['Match', 'Match', 'Match'],
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(false)
@@ -84,7 +84,7 @@ describe('executeCommand', () => {
                     twoElements,
                     'Match',
                     mockSingleCompare,
-                    { isNot: true, isSome: false } // isNot: true
+                    { isNot: true, isSome: false, iteration: 0 } // isNot: true
                 )
 
                 expect(result.success).toBe(false) // false is success for .not, since it is inverted later by Jest
@@ -99,7 +99,7 @@ describe('executeCommand', () => {
                     twoElements,
                     'Match',
                     mockSingleCompare,
-                    { isNot: true, isSome: false }
+                    { isNot: true, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(true) // true is failure for .not, since it is inverted later by Jest
@@ -110,7 +110,7 @@ describe('executeCommand', () => {
                     [],
                     'Match',
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 }
                 )
 
                 expect(result.success).toBe(false)
@@ -121,7 +121,7 @@ describe('executeCommand', () => {
                     [],
                     'Match',
                     mockSingleCompare,
-                    { isNot: false, isSome: false },
+                    { isNot: false, isSome: false, iteration: 0 },
                     { allowEmptyElements: true }
                 )
 
@@ -137,7 +137,7 @@ describe('executeCommand', () => {
                     oneElements,
                     expected,
                     mockSingleCompare,
-                    { isNot: false, isSome: false }
+                    { isNot: false, isSome: false, iteration: 0 },
                 )
 
                 expect(result.success).toBe(false)

--- a/test/util/refetchElements.test.ts
+++ b/test/util/refetchElements.test.ts
@@ -22,27 +22,17 @@ describe(refetchElements, () => {
 
         test('default should refresh once', async () => {
 
-            const actual = await refetchElements(elements, 5, true)
+            const actual = await refetchElements(elements)
 
             expect(actual.length).toBe(5)
             expect(actual).not.toBe(elements)
             expect(elements.parent.$$).toHaveBeenCalledTimes(1)
         })
 
-        test('wait is 0 should not refresh', async () => {
-            const wait = 0
-
-            const actual = await refetchElements(elements, wait, true)
-
-            expect(actual).toEqual(elements)
-            expect(actual).toHaveLength(2)
-            expect(elements.parent.$$).not.toHaveBeenCalled()
-        })
-
         test('should call $$ with all props', async () => {
             elements.props = ['prop1', 'prop2']
 
-            await refetchElements(elements, 5, true)
+            await refetchElements(elements)
 
             expect(elements.parent.$$).toHaveBeenCalledWith('elements', 'prop1', 'prop2')
         })
@@ -50,7 +40,7 @@ describe(refetchElements, () => {
         test('should call $$ with the proper parent "this" context', async () => {
             const parentFoundWith = vi.mocked(elements.parent.$$)
 
-            await refetchElements(elements, 5, true)
+            await refetchElements(elements)
 
             expect(parentFoundWith.mock.contexts[0]).toBe(elements.parent)
         })
@@ -64,7 +54,7 @@ describe(refetchElements, () => {
         })
 
         test('default should not refresh', async () => {
-            const actual = await refetchElements(elements, 5, true)
+            const actual = await refetchElements(elements)
 
             expect(actual).toEqual(elements)
             expect(actual).toHaveLength(2)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -235,7 +235,7 @@ Received: []`)
                     unresolvedElements: received,
                     expectedValues: true,
                     singleElementCompare: expect.any(Function),
-                    isNot: false,
+                    context: { isNot: false, iteration: 0 },
                     strictConfiguration: { allowEmptyElements: false }
                 })
                 expect(waitUntil).toHaveBeenCalledWith(expect.any(Function), false, options)
@@ -249,7 +249,7 @@ Received: []`)
                     unresolvedElements: received,
                     expectedValues: true,
                     singleElementCompare: expect.any(Function),
-                    isNot: false,
+                    context: { isNot: false, iteration: 0 },
                     strictConfiguration: { allowEmptyElements: false }
                 })
             })
@@ -342,7 +342,7 @@ Received: "displayed"`)
                     unresolvedElements: elements,
                     expectedValues: true,
                     singleElementCompare: expect.any(Function),
-                    isNot: false,
+                    context: { isNot: false, iteration: 0 },
                     strictConfiguration: { allowEmptyElements: false }
                 })
                 expect(command).toHaveBeenCalledTimes(2)
@@ -359,7 +359,7 @@ Received: "displayed"`)
                     unresolvedElements: elementArray,
                     expectedValues: true,
                     singleElementCompare: expect.any(Function),
-                    isNot: false,
+                    context: { isNot: false, iteration: 0 },
                     strictConfiguration: { allowEmptyElements: false }
                 })
                 expect(command).toHaveBeenCalledTimes(2)
@@ -375,7 +375,7 @@ Received: "displayed"`)
                     unresolvedElements: elementArray,
                     expectedValues: true,
                     singleElementCompare: expect.any(Function),
-                    isNot: false,
+                    context: { isNot: false, iteration: 0 },
                     strictConfiguration: { allowEmptyElements: false }
                 })
                 expect(command).toHaveBeenCalledTimes(2)
@@ -460,7 +460,7 @@ Expect ${selectorName} to be displayed
                         unresolvedElements: elements,
                         expectedValues: true,
                         singleElementCompare: expect.any(Function),
-                        isNot: true,
+                        context: { isNot: true, iteration: 0 },
                         strictConfiguration: { allowEmptyElements: false }
                     })
                     expect(command).toHaveBeenCalledTimes(2)

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,4 +1,6 @@
 // Global spies of src folders
+import './__mocks__/src/matchers/util/refetchElements.ts'
 import './__mocks__/src/matchers/util/waitUntil.ts'
 import './__mocks__/src/matchers/util.ts'
 import './__mocks__/src/constants.ts'
+


### PR DESCRIPTION
As with `toBeElementsArrayOfSize`, to retry a condition with the latest ElementArray, we need to refresh the entire selectors; otherwise, when the length mismatches and the DOM changes, it will most likely never pass.

Now we:
- refresh only after the first iteration
- We always refresh the elements in case they changed, not just when it's empty
- We sync the array for ElementArray but also the Promise or Chainable case too
