### PR TITLE
docs: update/review docs for v6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@
 
 ## Key Features
 
-- [waits](#default-options) for expectation to succeed
-- detailed [error messages](#error-messages)
-- works in Mocha, Cucumber, Jest, Jasmine
-- builtin [types](docs/Types.md) for TypeScript and JS autocompletion
+- [Waits](#default-options) for expectation to succeed
+- Support single element & multi-elements
+- Detailed [error messages](#error-messages)
+- Works in Mocha, Cucumber, Jest, Jasmine
+- Builtin [types](docs/Types.md) for TypeScript and JS autocompletion
 
 ## Installation
 
-1. `npm install expect` (**Jasmine** and **Jest** users should skip this step)
-2. `npm install expect-webdriverio`
+1. `npm install expect-webdriverio`
+2. `npm install @wdio/mocha-framework` -- Choose your framework mocha being the default one!
+   - **Jasmine**: `npm install @wdio/jasmine-framework`
+   - **Cucumber**: `npm install @wdio/cucumber-framework`
+   - **Jest**: None, manual configuration requires, see [Jest Framework section](docs/Framework.md#jest) 
+3. Configure you tsc configuration, see [Types](docs/Types.md#typescript)
 
 NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0` or higher is required!
 
@@ -26,15 +31,15 @@ NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0` or high
 If you run your tests through the [WDIO testrunner](https://webdriver.io/docs/clioptions) no additional setup is needed. WebdriverIO initialises `expect-webdriverio` and makes `expect` available in the global scope. So you can use it directly in your tests:
 
 ```js
-const $button = await $('button')
-await expect($button).toBeDisplayed()
+const button = await $('button')
+await expect(button).toBeDisplayed()
 ```
 
 See more [Examples](docs/Examples.md)
 
 ### Using in a standalone script
 
-If you embed WebdriverIO in a standalone script, make sure you import `expect-webdriverio` before you use it anywhere.
+If you embed WebdriverIO in a standalone (without `@wdio/globals`), make sure you import `expect-webdriverio` before you use it anywhere.
 
 ```js
 import { remote } from 'webdriverio'
@@ -77,8 +82,5 @@ First of all, **feel free to raise an issue with your suggestions or help with P
 
 ### Planned
 
-- css matcher
-- size matcher
-- cookie / localStorage matchers?
-- text regex matchers
-- multiremote support (if requested)
+- cookie
+- multiremote support (coming)

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@
 ## Installation
 
 1. `npm install expect-webdriverio`
-1. `npm install expect-webdriverio`
 2. Install your test framework adapter (if not already set up via WDIO testrunner):
    - **Mocha** (default): `npm install @wdio/mocha-framework`
    - **Jasmine**: `npm install @wdio/jasmine-framework`
    - **Cucumber**: `npm install @wdio/cucumber-framework`
    - **Jest**: No adapter needed — see [Jest Framework section](docs/Framework.md#jest)
-3. *(TypeScript only)* Configure your `tsconfig`, see [Types](docs/Types.md#typescript)
 
 NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0` or higher is required!
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@
 ## Installation
 
 1. `npm install expect-webdriverio`
-2. `npm install @wdio/mocha-framework` -- Choose your framework mocha being the default one!
+1. `npm install expect-webdriverio`
+2. Install your test framework adapter (if not already set up via WDIO testrunner):
+   - **Mocha** (default): `npm install @wdio/mocha-framework`
    - **Jasmine**: `npm install @wdio/jasmine-framework`
    - **Cucumber**: `npm install @wdio/cucumber-framework`
-   - **Jest**: None, manual configuration requires, see [Jest Framework section](docs/Framework.md#jest) 
-3. Configure you tsc configuration, see [Types](docs/Types.md#typescript)
+   - **Jest**: No adapter needed — see [Jest Framework section](docs/Framework.md#jest)
+3. *(TypeScript only)* Configure your `tsconfig`, see [Types](docs/Types.md#typescript)
 
 NOTE: [WebdriverIO](https://github.com/webdriverio/webdriverio) `v9.0.0` or higher is required!
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -757,6 +757,7 @@ All element matchers support arrays of elements returned from `$$()`:
 - **Using `.not`:** Every element must *not* meet the matcher condition. One match fails the assertion.
 - **Empty Arrays:** Empty element arrays will fail the assertion by default. 
   - *Note:* Only the `toExist`, `toBeExisting`, and `toBePresent` matchers succeed when using `.not` on an empty element array.
+- **Retry / Array Refresh:** On failure or stale references, the element array is automatically re-fetched until the matcher passes or times out.
 - **Legacy Behavior:** `toHaveText` retains its legacy behavior unless the `useToHaveTextStrictMultiElementsCompareStrategy` flag is enabled.
 - See [MultipleElements.md](MultipleElements.md) for more details.
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -59,4 +59,4 @@ more boilerplate projects coming soon, feel free to propose yours!
 
 ## Playgrounds
 
-Additional examples are available as internal playgrounds to the project. See [playgrounds folder](playgrounds)
+Additional examples are available as internal playgrounds to the project. See [playgrounds folder](../playgrounds)

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -56,3 +56,7 @@ Standalone
 - Jest https://github.com/erwinheitzman/jest-webdriverio-standalone-boilerplate
 
 more boilerplate projects coming soon, feel free to propose yours!
+
+## Playgrounds
+
+Additional examples are available as internal playgrounds to the project. See [playgrounds folder](playgrounds)

--- a/docs/MultipleElements.md
+++ b/docs/MultipleElements.md
@@ -9,6 +9,7 @@ Matchers support an element array returned from `$$()`:
 - Options like `StringOptions` or `HTMLOptions` apply to the whole array; `NumberMatcher` behaves like any expected provided value.
 - The assertion passes only if **all** elements match.
 - Using `.not` means all elements must **not** match.
+- On failures, the element array is automatically re-fetched until the matcher passes or times out, ensuring reliability against dynamic DOM changes.
 
 **Note:** To apply strict index-based matching to the `toHaveText` matcher, `useToHaveTextStrictMultiElementsCompareStrategy` must be enabled. Else legacy behavior applies.
 


### PR DESCRIPTION
Revisit docs for the version 6 release containing:

- Support of `$$()` for all matchers
- Provide a `some` modifier for multi-element cases to succeed when only one element matches
- Provide `expect.oneOf` asymmetric matcher, deprecating the `some` behaviour with expected array values to separate the new strict-index-based compare mechanism for multi-elements 
- Review of matcher doing presence check to leverage `expect.anything()` asymmetric matcher
- Deprecation of `NumberOptions` separating `NumberMatcher` and command options, allowing also a better failure message
- Deprecating `toHaveText` legacy behaviour for multi-elements but still backward compatible
   - New strict-index-based compare needs enabling `useToHaveTextStrictMultiElementsCompareStrategy`

No breaking changes are expected, only deprecations and new features!