### PR TITLE
feat: Align `toHaveLocalStorageItem` with `expect.anything()`

### DIFF
--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -22,6 +22,16 @@ describe('WebdriverIO Custom Matchers', () => {
         it('should verify URL contains path', async () => {
             await expect(browser).toHaveUrl(expect.stringContaining('webdriver.io'))
         })
+
+        it('should verify not localStorage item', async () => {
+            await expect(browser).not.toHaveLocalStorageItem('key', 'value')
+        })
+
+        it('should verify not localStorage item with options', async () => {
+            await expect(browser).not.toHaveLocalStorageItem('key', expect.anything(), { wait: 0 })
+            await expect(browser).not.toHaveLocalStorageItem('key', undefined, { wait: 0 })
+            await expect(browser).not.toHaveLocalStorageItem('key', undefined)
+        })
     })
 
     describe('Element existence matchers', () => {

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -34,11 +34,14 @@ export async function toHaveLocalStorageItem(
     })
 
     const paramsCount = arguments.length
+    let expected: string | RegExp | AsymmetricMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything
     if (expectedValue === undefined) {
         if (paramsCount > 2) {
             console.warn('[DEPRECATION] Using toHaveLocalStorageItem with undefined is deprecated in favor of expect.anything().')
         }
-        expectedValue = expect.anything()
+        expected = expect.anything()
+    } else {
+        expected = expectedValue
     }
 
     const { actual, success: pass } = await waitUntil(
@@ -53,7 +56,7 @@ export async function toHaveLocalStorageItem(
                 return { actual, success: false, subject: browser }
             }
 
-            const compareResult = compareText(actual, expectedValue, options)
+            const compareResult = compareText(actual, expected, options)
 
             return { actual, success: compareResult.success, subject: browser }
         },
@@ -63,7 +66,7 @@ export async function toHaveLocalStorageItem(
 
     const message = enhanceError(
         'browser',
-        expectedValue !== undefined ? expectedValue : `localStorage item "${key}"`,
+        expected,
         actual,
         this,
         verb,
@@ -77,7 +80,7 @@ export async function toHaveLocalStorageItem(
     }
     await options.afterAssertion?.({
         matcherName,
-        expectedValue: expectedValue ? [key, expectedValue] : key,
+        expectedValue: expected ? [key, expected] : key,
         options,
         result
     })

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OPTIONS } from '../../constants.js'
 import { expect } from '../../index.js'
 
 /**
- * @deprecated use expect.anything() instead of undefined as expected value
+ * @deprecated since v6.0.0, use expect.anything() instead of undefined as expected value, will be removed in v8.0.0
  */
 export async function toHaveLocalStorageItem(
     browser: WebdriverIO.Browser,
@@ -33,8 +33,11 @@ export async function toHaveLocalStorageItem(
         options,
     })
 
-    if (expectedValue === undefined ) {
-        console.warn('[DEPRECATION] Using toHaveLocalStorageItem with undefined is deprecated in favor of expect.anything().')
+    const paramsCount = arguments.length
+    if (expectedValue === undefined) {
+        if (paramsCount > 2) {
+            console.warn('[DEPRECATION] Using toHaveLocalStorageItem with undefined is deprecated in favor of expect.anything().')
+        }
         expectedValue = expect.anything()
     }
 

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -1,12 +1,30 @@
 import { waitUntil, enhanceError, compareText } from '../../utils.js'
 import { DEFAULT_OPTIONS } from '../../constants.js'
+import { expect } from '../../index.js'
+
+/**
+ * @deprecated use expect.anything() instead of undefined as expected value
+ */
+export async function toHaveLocalStorageItem(
+    browser: WebdriverIO.Browser,
+    key: string,
+    expectedValue: undefined,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
 
 export async function toHaveLocalStorageItem(
     browser: WebdriverIO.Browser,
     key: string,
-    expectedValue?: string | RegExp | AsymmetricMatcher<string>,
+    expectedValue?: string | RegExp | AsymmetricMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
+    options?: ExpectWebdriverIO.StringOptions
+): Promise<ExpectWebdriverIO.AssertionResult>
+
+export async function toHaveLocalStorageItem(
+    browser: WebdriverIO.Browser,
+    key: string,
+    expectedValue?: string | RegExp | AsymmetricMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
     options: ExpectWebdriverIO.StringOptions = DEFAULT_OPTIONS
-) {
+): Promise<ExpectWebdriverIO.AssertionResult> {
     const { expectation = 'localStorage item', verb = 'have', isNot, matcherName = 'toHaveLocalStorageItem' } = this
 
     await options.beforeAssertion?.({
@@ -14,16 +32,19 @@ export async function toHaveLocalStorageItem(
         expectedValue: expectedValue ? [key, expectedValue] : key,
         options,
     })
+
+    if (expectedValue === undefined ) {
+        console.warn('[DEPRECATION] Using toHaveLocalStorageItem with undefined is deprecated in favor of expect.anything().')
+        expectedValue = expect.anything()
+    }
+
     const { actual, success: pass } = await waitUntil(
         async () => {
             const actual = await browser.execute(
                 (storageKey) => {
                     return localStorage.getItem(storageKey)
                 }, key)
-            // if no expected value is provided, we just check if the item exists
-            if (expectedValue === undefined) {
-                return { actual, success: actual !== null, subject: browser }
-            }
+
             // no localStorage item found
             if (actual === null) {
                 return { actual, success: false, subject: browser }

--- a/src/matchers/browser/toHaveLocalStorageItem.ts
+++ b/src/matchers/browser/toHaveLocalStorageItem.ts
@@ -80,7 +80,7 @@ export async function toHaveLocalStorageItem(
     }
     await options.afterAssertion?.({
         matcherName,
-        expectedValue: expected ? [key, expected] : key,
+        expectedValue: expectedValue ? [key, expectedValue] : key,
         options,
         result
     })

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -108,21 +108,24 @@ export async function toHaveAttribute(
     const matcherName = 'toHaveAttribute'
     const paramsCount = arguments.length
 
-    if (value === undefined) {
-        if (paramsCount > 2) {
-            // User have passed an explicit undefined or null value, which is deprecated. We will log a warning to inform the user about this deprecation.
-            console.warn('Using undefined or null as value for toHaveAttribute is deprecated and will be removed in v6.0.0. Please omit the third argument entirely or use toHaveAttribute(el, attribute, wdioExpect.anything(), options).')
-        }
-        value = wdioExpect.anything()
-    }
-
     await options.beforeAssertion?.({
         matcherName,
         expectedValue: [attribute, value],
         options,
     })
 
-    const result = await toHaveAttributeAndValue.call(this, received, attribute, value, options)
+    let expectedValue: MaybeArrayOrOneOf<string | RegExp | AsymmetricMatcher<string> | WdioAnythingAsymmetricMatcher>
+    if (value === undefined) {
+        if (paramsCount > 2) {
+            // User have passed an explicit undefined or null value, which is deprecated. We will log a warning to inform the user about this deprecation.
+            console.warn('Using undefined or null as value for toHaveAttribute is deprecated and will be removed in v6.0.0. Please omit the third argument entirely or use toHaveAttribute(el, attribute, wdioExpect.anything(), options).')
+        }
+        expectedValue = wdioExpect.anything()
+    } else {
+        expectedValue = value
+    }
+
+    const result = await toHaveAttributeAndValue.call(this, received, attribute, expectedValue, options)
 
     await options.afterAssertion?.({
         matcherName,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export function isJasmineStringAsymmetricMatcher<T>(expected: unknown): expected
     return isAsymmetricMatcher(expected) && !('toAsymmetricMatcher' in expected) && 'jasmineToString' in expected && typeof expected.jasmineToString === 'function'
 }
 
-export function isAsymmetricMatcher<T>(expected: unknown): expected is WdioAsymmetricMatcher<T> | JasmineAsymmetricMatcher<T> {
+export function isAsymmetricMatcher<T>(expected: unknown): expected is WdioAsymmetricMatcher<T> | JasmineAsymmetricMatcher<T> | ExpectWebdriverIO.PartialMatcherAnything {
     return (
         typeof expected === 'object' &&
         !!expected &&
@@ -50,7 +50,7 @@ export function getStringAsymmetricMatcherValue(
 }
 
 export function getAsymmetricMatcherValue<T>(
-    expected: AsymmetricMatcher<T>
+    expected: AsymmetricMatcher<T> | ExpectWebdriverIO.PartialMatcherAnything | JasmineAsymmetricMatcher<T>
 ): string | RegExp | T | undefined {
     if ('expected' in expected) {
         return expected.expected // Jasmine string containing asymmetric matcher
@@ -133,8 +133,6 @@ export const compareTextOrArray = (
     expectedTexts: MaybeArrayOrOneOf<string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string>> | undefined,
     options: ExpectWebdriverIO.StringOptions
 ): CompareResult<string> => {
-    const unchangedActualText = actualText
-
     if (expectedTexts === undefined) {
         return { actual: actualText, success: false }
     }
@@ -155,20 +153,20 @@ export const compareTextOrArray = (
     }
 
     if (expectedTexts instanceof OneOfMatcher) {
-        return { success: expectedTexts.asymmetricMatch(actualText), actual: unchangedActualText }
+        return { success: expectedTexts.asymmetricMatch(actualText), actual: actualText }
     }
 
     // TODO one day consolidate typing and internal of oneOf so we do not need the below casting!
     const compareResults = compareText(actualText, expectedTexts as string | RegExp, options)
 
-    return { success: compareResults.success, actual: unchangedActualText }
+    return { success: compareResults.success, actual: actualText }
 
 }
 
 // TODO one day turn this into at least a asymetrics class to better report in failure messages the string case we are in (containing, atStart, atEnd, atIndex, etc) and the expected value(s)
 export const compareText = (
     actual: string,
-    expected: string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string> | null | undefined,
+    expected: string | RegExp | WdioAsymmetricMatcher<string> | JasmineAsymmetricMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything | null | undefined,
     {
         ignoreCase = false,
         trim = true,

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -68,6 +68,28 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
                 expectTypeOf(expect(true).toHaveClipboardText).toBeNever()
             })
         })
+
+        describe('toHaveLocalStorageItem', () => {
+            it('should return Promise<void>', async () => {
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key')).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', 'value')).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(browser).not.toHaveLocalStorageItem('key', 'value')).toEqualTypeOf<Promise<void>>()
+                // Asymmetric matchers
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', expect.stringContaining('value'))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', expect.any(String))).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', expect.anything())).toEqualTypeOf<Promise<void>>()
+            })
+
+            it('should have ts errors when actual is not a Browser element', async () => {
+                expectTypeOf(expect(element).toHaveLocalStorageItem).toBeNever()
+                expectTypeOf(expect(true).toHaveLocalStorageItem).toBeNever()
+            })
+
+            it('should have deprecated when expected value is undefined', async () => {
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', undefined)).toEqualTypeOf<Promise<void>>()
+                expectTypeOf(expect(browser).toHaveLocalStorageItem('key', undefined, { wait: 0 })).toEqualTypeOf<Promise<void>>()
+            })
+        })
     })
 
     describe('element or elements', () => {

--- a/test/matchers/browser/toHaveLocalStorageItem.test.ts
+++ b/test/matchers/browser/toHaveLocalStorageItem.test.ts
@@ -91,6 +91,12 @@ Received      : "someLocalStorageValue"`
             expect.any(Function),
             'nonExistentKey'
         )
+        expect(stripAnsi(result.message())).toEqual(`\
+Expect browser to have localStorage item nonExistentKey
+
+Expected: "someValue"
+Received: null`
+        )
     })
 
     it('passes when only checking key existence', async () => {
@@ -101,6 +107,22 @@ Received      : "someLocalStorageValue"`
         const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey')
 
         expect(result.pass).toBe(true)
+    })
+
+    it('fails when only checking key existence', async () => {
+        // Mock browser.execute to return any non-null value
+        vi.mocked(browser.execute).mockResolvedValue(null)
+
+        // no expectedValue parameter
+        const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey')
+
+        expect(result.pass).toBe(false)
+        expect(stripAnsi(result.message())).toEqual(`\
+Expect browser to have localStorage item existingKey
+
+Expected: Anything
+Received: null`
+        )
     })
 
     it('passes when only checking key existence with undefined - deprecated', async () => {

--- a/test/matchers/browser/toHaveLocalStorageItem.test.ts
+++ b/test/matchers/browser/toHaveLocalStorageItem.test.ts
@@ -2,6 +2,7 @@ import { vi, expect, describe, it, beforeEach } from 'vitest'
 import { browser } from '@wdio/globals'
 import { toHaveLocalStorageItem } from '../../../src/matchers/browser/toHaveLocalStorageItem.js'
 import stripAnsi from 'strip-ansi'
+import  { expect as wdioExpect } from '../../../src/index.js'
 
 vi.mock('@wdio/globals')
 
@@ -98,6 +99,36 @@ Received      : "someLocalStorageValue"`
 
         // no expectedValue parameter
         const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey')
+
+        expect(result.pass).toBe(true)
+    })
+
+    it('passes when only checking key existence with undefined - deprecated', async () => {
+        // Mock browser.execute to return any non-null value
+        vi.mocked(browser.execute).mockResolvedValue('anyValue')
+
+        // no expectedValue parameter
+        const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey', undefined)
+
+        expect(result.pass).toBe(true)
+    })
+
+    it('passes when only checking key existence with undefined and options - deprecated', async () => {
+        // Mock browser.execute to return any non-null value
+        vi.mocked(browser.execute).mockResolvedValue('anyValue')
+
+        // no expectedValue parameter
+        const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey', undefined, { wait: 0 })
+
+        expect(result.pass).toBe(true)
+    })
+
+    it('passes when only checking key existence with anything() and options', async () => {
+        // Mock browser.execute to return any non-null value
+        vi.mocked(browser.execute).mockResolvedValue('anyValue')
+
+        // no expectedValue parameter
+        const result = await thisContext.toHaveLocalStorageItem(browser, 'existingKey', wdioExpect.anything(), { ignoreCase: true })
 
         expect(result.pass).toBe(true)
     })

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -122,11 +122,23 @@ interface WdioBrowserMatchers<_R, ActualT>{
     /**
      * `WebdriverIO.Browser` -> `execute`
      */
-    toHaveLocalStorageItem: FnWhenBrowser<ActualT, (
-        key: string,
-        expectedValue?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string>,
-        options?: ExpectWebdriverIO.StringOptions
-    ) => Promise<void>>
+    toHaveLocalStorageItem: FnWhenBrowser<ActualT, {
+        /**
+         * @deprecated since v6.0.0, removed in v10.0.0. Use `expect.anything()` instead of `undefined` as expected value.
+         */
+        (
+            key: string,
+            expectedValue: undefined,
+            options?: ExpectWebdriverIO.StringOptions
+        ): Promise<void>,
+
+        (
+            key: string,
+            expectedValue?: string | RegExp | ExpectWebdriverIO.PartialMatcher<string> | ExpectWebdriverIO.PartialMatcherAnything,
+            options?: ExpectWebdriverIO.StringOptions
+        ) : Promise<void>
+    }
+    >
 }
 
 /**


### PR DESCRIPTION
Align `toHaveLocalStorageItem` to use `expect.anything()` instead of an undefined expected value to validate if a storage item key exists