### PR TITLE
fix(toBeRequestedWith): restore postData/response body matching

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -871,6 +871,18 @@ await expect(mock).toBeRequestedWith({
 })
 ```
 
+> **Note on `postData`/`response` timing:** unlike the other options, the request/response body is
+> collected asynchronously (an extra round-trip after the request/response headers are already
+> available), so it may not be attached to a call yet at the very first check. Regular assertions
+> retry within their `wait` timeout and pick it up once it arrives. `.not.toBeRequestedWith({ postData
+> / response })` also retries within `wait` - but only while there's a call that already matches every
+> other criterion and is just waiting on its body to attach; if nothing matches at all (wrong URL, no
+> call made, etc.) it still resolves immediately, same as any other `.not` assertion. The one residual
+> case this can't close: if the body genuinely takes longer to arrive than your configured `wait`, a
+> `.not` assertion can still report a false pass. If you rely on `.not` with `postData`/`response` and
+> see intermittent false passes, increase `wait` (or await a signal that the request has fully
+> completed) before asserting.
+
 ## Snapshot Matcher
 
 WebdriverIO supports basic snapshot tests as well as DOM snapshot testing.

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "peerDependencies": {
     "@wdio/globals": "^9.0.0",
     "@wdio/logger": "^9.0.0",
-    "webdriverio": "^9.0.0"
+    "webdriverio": "^9.28.0"
   },
   "peerDependenciesMeta": {
     "@wdio/globals": {

--- a/playgrounds/jasmine/wdio.conf.ts
+++ b/playgrounds/jasmine/wdio.conf.ts
@@ -67,7 +67,8 @@ export const config: WebdriverIO.Config = {
     //
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     before: function (_capabilities, _specs) {
-        setOptions({ wait: 500 })
+        // 500ms wasn't enough headroom for `postData`/`response` collection (an async
+        setOptions({ wait: 2000 })
     },
     afterTest: function (_test, _context, { error }) {
         if (error) {

--- a/playgrounds/mocha/test/specs/network-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/network-matchers.test.ts
@@ -96,4 +96,58 @@ describe('Network Matchers', () => {
     it('should throw an error when asserting not be requested', async () => {
         await expect(expect(mock).not.toBeRequested()).rejects.toThrow()
     })
+
+    /**
+     * `postData`/`response` were silently ignored before #2184 - any assertion on them passed
+     * regardless of the real payload. These cover the restored comparison end-to-end.
+     *
+     * Note: `mock.calls[n].body` is the *upstream* response, not `mock.respond()`'s override
+     * (respond changes what the page receives; the collector still records what the server sent).
+     * So `response` is asserted structurally rather than against the mocked value.
+     */
+    it('should assert on postData', async () => {
+        await expect(mock).toBeRequestedWith({
+            method: 'POST',
+            postData: { title: 'foo', description: 'bar' }
+        })
+    })
+
+    it('should assert on postData with an asymmetric matcher', async () => {
+        await expect(mock).toBeRequestedWith({
+            postData: expect.objectContaining({ title: 'foo' })
+        })
+    })
+
+    it('should assert on postData with a function matcher', async () => {
+        await expect(mock).toBeRequestedWith({
+            postData: (postData) => typeof postData === 'string' && postData.includes('description')
+        })
+    })
+
+    it('should FAIL when postData does not match', async () => {
+        // the regression guard: this silently passed before the fix
+        await expect(
+            expect(mock).toBeRequestedWith({ postData: { title: 'WRONG' } })
+        ).rejects.toThrow()
+    })
+
+    it('should FAIL when postData is expected but the request had none', async () => {
+        const getMock = await browser.mock('https://webdriver.io/**', { method: 'GET' })
+        await browser.url('https://webdriver.io/')
+        await expect(
+            expect(getMock).toBeRequestedWith({ postData: { any: 'thing' } })
+        ).rejects.toThrow()
+    })
+
+    it('should assert that a response body was collected', async () => {
+        await expect(mock).toBeRequestedWith({
+            response: (response) => typeof response === 'string' && response.length > 0
+        })
+    })
+
+    it('should FAIL when response does not match', async () => {
+        await expect(
+            expect(mock).toBeRequestedWith({ response: { definitely: 'not-this' } })
+        ).rejects.toThrow()
+    })
 })

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -63,6 +63,13 @@ export async function toBeRequestedWith(
     // postData/body string is JSON.parsed at most once per assertion instead of once per read
     const parseCache: Map<string, ParsedJson> = new Map()
 
+    /**
+     * a call matched everything except its payload, and that payload never arrived. Kept from the
+     * final iteration so the failure message can explain *why* the body looks empty rather than
+     * just diffing against `undefined` - see `payloadCollectionHint()`.
+     */
+    let payloadNeverCollected = false
+
     const { success: pass, actual } = await waitUntil(
         async () => {
             let lastCall: RequestMock | undefined
@@ -96,6 +103,7 @@ export async function toBeRequestedWith(
                     hasPendingPayloadCandidate = true
                 }
             }
+            payloadNeverCollected = hasPendingPayloadCandidate
             return {
                 success: false,
                 subject: lastCall,
@@ -116,7 +124,7 @@ export async function toBeRequestedWith(
         expectation,
         '',
         options
-    )
+    ) + (!pass && !isNot && payloadNeverCollected ? payloadCollectionHint(expectedValue) : '')
 
     const result: ExpectWebdriverIO.AssertionResult = {
         pass,
@@ -131,6 +139,28 @@ export async function toBeRequestedWith(
     })
 
     return result
+}
+
+/**
+ * Explain why a `postData`/`response` assertion is diffing against an empty body.
+ *
+ * A call matched every other criterion but its payload never arrived, which almost always means
+ * the request/response body was never collected in the first place rather than that it genuinely
+ * differed. Without this the user just sees a diff against `undefined` with no way to tell the two
+ * apart.
+ */
+const payloadCollectionHint = (expectedValue: ExpectWebdriverIO.RequestedWith) => {
+    const fields = [
+        expectedValue.postData !== undefined ? 'postData' : undefined,
+        expectedValue.response !== undefined ? 'response' : undefined,
+    ].filter(Boolean).join(' and ')
+
+    return `
+
+A request matched every other criterion, but its body was never collected, so ${fields} could not be compared.
+This usually means either:
+  - webdriverio is older than v9.28.0, which did not populate \`mock.calls[].postData\` (upgrade to v9.28.0 or later), or
+  - body collection is turned off via \`maxSpyCollectedBodySize: 0\` in your config (it defaults to 10MB - remove the override or raise it).`
 }
 
 /**

--- a/src/matchers/mock/toBeRequestedWith.ts
+++ b/src/matchers/mock/toBeRequestedWith.ts
@@ -10,6 +10,13 @@ const KEY_LIMIT = 12
 interface RequestMock {
     request: local.NetworkRequestData,
     response: local.NetworkResponseData
+    /**
+     * Populated asynchronously by WebDriverInterception via `network.getData`.
+     * Flat properties on the call object (not nested under `request`/`response`),
+     * mirroring `WebdriverIO.Mock`'s `Response` type.
+     */
+    postData?: string
+    body?: string
 }
 
 function reduceHeaders(headers: local.NetworkHeader[]) {
@@ -32,34 +39,78 @@ export async function toBeRequestedWith(
         options,
     })
 
+    /**
+     * `postData`/`body` are populated asynchronously (via a `network.getData` round-trip in
+     * WebDriverInterception), so they may not be attached to a call yet at the very first check.
+     * `.not` assertions normally check once, immediately (`wait: 0`), since a mock's call log only
+     * grows and can't "become unmatched" - but that immediate check would race the payload
+     * collection and could report a false pass. So when `postData`/`response` are part of the
+     * expectation, give `.not` the same "wait for a match to appear" retry window a positive
+     * assertion gets, instead of deciding on the first, possibly incomplete, snapshot of the call -
+     * but ONLY while there's an actual pending candidate (a call that already matches everything
+     * else and is just waiting on its body/postData to attach). If no call matches the non-payload
+     * criteria at all, the outcome can't change by waiting, so the predicate below sets `abort` and
+     * `waitUntil` resolves immediately - keeping the fast, single-check behavior for the common case
+     * (wrong URL, no calls made, etc.) while still closing the race for the one case that needs it.
+     * `pass` below always means "was a matching call found" either way - `.not` inversion is
+     * handled downstream by the test framework, not by this function - so no extra inversion here,
+     * only the retry direction passed into `waitUntil` changes.
+     */
+    const hasPayloadExpectation = expectedValue.postData !== undefined || expectedValue.response !== undefined
+    const waitForPayloadOnNot = isNot && hasPayloadExpectation
+
+    // shared across every `waitUntil` iteration and the later message-building step, so a given
+    // postData/body string is JSON.parsed at most once per assertion instead of once per read
+    const parseCache: Map<string, ParsedJson> = new Map()
+
     const { success: pass, actual } = await waitUntil(
         async () => {
             let lastCall: RequestMock | undefined
+            let hasPendingPayloadCandidate = false
             for (const call of received.calls as RequestMock[]) {
                 lastCall = call
-                if (
+                const matchesNonPayloadCriteria =
                     methodMatcher(call.request.method, expectedValue.method) &&
                     statusCodeMatcher(call.response.status, expectedValue.statusCode) &&
                     urlMatcher(call.request.url, expectedValue.url) &&
                     headersMatcher(reduceHeaders(call.request.headers), expectedValue.requestHeaders) &&
                     headersMatcher(reduceHeaders(call.response.headers), expectedValue.responseHeaders)
-                    // &&
-                    // bodyMatcher(call.postData, expectedValue.postData) &&
-                    // bodyMatcher(call.body, expectedValue.response)
+
+                if (!matchesNonPayloadCriteria) {
+                    continue
+                }
+
+                if (
+                    bodyMatcher(call.postData, expectedValue.postData, parseCache) &&
+                    bodyMatcher(call.body, expectedValue.response, parseCache)
                 ) {
                     return { success: true, subject: call, actual: call }
                 }
+
+                // this call matches everything else - if its body/postData hasn't attached yet,
+                // it could still turn into a match once it does, so it's worth continuing to wait for
+                if (
+                    (expectedValue.postData !== undefined && call.postData === undefined) ||
+                    (expectedValue.response !== undefined && call.body === undefined)
+                ) {
+                    hasPendingPayloadCandidate = true
+                }
             }
-            return { success: false, subject: lastCall, actual: lastCall }
+            return {
+                success: false,
+                subject: lastCall,
+                actual: lastCall,
+                abort: waitForPayloadOnNot && !hasPendingPayloadCandidate,
+            }
         },
-        isNot,
-        { ...options, wait: isNot ? 0 : options.wait }
+        waitForPayloadOnNot ? false : isNot,
+        { ...options, wait: (isNot && !waitForPayloadOnNot) ? 0 : options.wait }
     )
 
     const message = enhanceError(
         'mock',
         minifyRequestedWith(expectedValue),
-        minifyRequestMock(actual, expectedValue) || 'was not called',
+        minifyRequestMock(actual, expectedValue, parseCache) || 'was not called',
         this,
         verb,
         expectation,
@@ -161,86 +212,134 @@ const headersMatcher = (
 }
 
 /**
- * is postData/response matching an expected condition
+ * a JSON-compatible expected value for `postData`/`response`, shared by every function that
+ * needs to reason about "what shape of value is the user asserting against"
  */
-// const bodyMatcher = (
-//     body: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined,
-//     expected?:
-//         | string
-//         | ExpectWebdriverIO.JsonCompatible
-//         | ExpectWebdriverIO.PartialMatcher
-//         | ((r: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined) => boolean)
-// ) => {
-//     if (typeof expected === 'undefined') {
-//         return true
-//     }
-//     if (typeof expected === 'function') {
-//         return expected(body)
-//     }
-//     if (typeof body === 'undefined') {
-//         return false
-//     }
+type ExpectedBody =
+    | string
+    | boolean
+    | number
+    | null
+    | ExpectWebdriverIO.JsonCompatible
+    | ExpectWebdriverIO.PartialMatcher<string | ExpectWebdriverIO.JsonCompatible>
 
-//     let parsedBody = body
-//     if (body instanceof Buffer) {
-//         parsedBody = body.toString()
-//     }
+/**
+ * is postData/response matching an expected condition
+ *
+ * Note: `body`/`postData` populate asynchronously and may still be `undefined` here on an early
+ * `waitUntil` iteration - see the timing comment on `toBeRequestedWith` for how retries handle that.
+ */
+const bodyMatcher = (
+    body: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined,
+    expected: ExpectedBody | ((r: string | Buffer | ExpectWebdriverIO.JsonCompatible | undefined) => boolean) | undefined,
+    parseCache: Map<string, ParsedJson>
+) => {
+    if (typeof expected === 'undefined') {
+        return true
+    }
+    if (typeof expected === 'function') {
+        return expected(body)
+    }
+    if (typeof body === 'undefined') {
+        return false
+    }
 
-//     // convert postData/body from string to JSON if expected value is JSON-like
-//     if (typeof(body) === 'string' && isExpectedJsonLike(expected)) {
-//         parsedBody = tryParseBody(body)
+    let parsedBody: unknown = body
+    if (body instanceof Buffer) {
+        parsedBody = body.toString()
+    }
 
-//         // failed to parse string as JSON
-//         if (parsedBody === null) {
-//             return false
-//         }
-//     }
+    // convert postData/body from string to JSON if expected value is JSON-like
+    // (checked against the Buffer-normalized value, so JSON carried as a Buffer is parsed too)
+    if (typeof parsedBody === 'string' && isExpectedJsonLike(expected)) {
+        const parsed = parseJsonOnce(parsedBody, parseCache)
 
-//     return equals(parsedBody, expected)
-// }
+        // failed to parse string as JSON (a genuine parsed `null` must still be matchable)
+        if (!parsed.ok) {
+            return false
+        }
+        parsedBody = parsed.value
+    }
 
-// const isExpectedJsonLike = (
-//     expected:
-//         | string
-//         | ExpectWebdriverIO.JsonCompatible
-//         | ExpectWebdriverIO.PartialMatcher
-//         | undefined
-//         | Function
-// ) => {
-//     if (typeof expected === 'undefined') {
-//         return false
-//     }
+    return equals(parsedBody, expected)
+}
 
-//     // get matcher sample if expected value is a special matcher like `expect.objectContaining({ foo: 'bar })`
-//     const actualSample = isMatcher(expected)
-//         ? (expected as WdioAsymmetricMatcher).sample
-//         : expected
+// `expect.any(Number)`/`expect.any(Boolean)`/`expect.any(Array)`/`expect.any(Object)` carry their
+// constructor as the matcher's "sample" (not an instance of it), so `typeof actualSample` is
+// 'function' - detect those specifically. `String` is deliberately excluded: a raw (unparsed)
+// string already satisfies `expect.any(String)` without needing to go through JSON.parse first.
+const JSON_LIKE_ANY_CONSTRUCTORS = new Set<unknown>([Number, Boolean, Array, Object])
 
-//     return (
-//         Array.isArray(actualSample) ||
-//         (typeof actualSample === 'object' &&
-//             actualSample !== null &&
-//             actualSample instanceof RegExp === false)
-//     )
-// }
+const isExpectedJsonLike = (
+    expected: ExpectedBody | Function | undefined
+) => {
+    if (typeof expected === 'undefined') {
+        return false
+    }
 
-// const tryParseBody = (jsonString: string | undefined, fallback: any = null) => {
-//     try {
-//         return typeof jsonString === 'undefined' ? fallback : JSON.parse(jsonString)
-//     } catch {
-//         return fallback
-//     }
-// }
+    // get matcher sample if expected value is a special matcher like `expect.objectContaining({ foo: 'bar })`
+    const actualSample = isAsymmetricMatcher(expected)
+        ? getAsymmetricMatcherValue(expected)
+        : expected
+
+    return (
+        actualSample === null ||
+        typeof actualSample === 'boolean' ||
+        typeof actualSample === 'number' ||
+        Array.isArray(actualSample) ||
+        JSON_LIKE_ANY_CONSTRUCTORS.has(actualSample) ||
+        (typeof actualSample === 'object' &&
+            actualSample !== null &&
+            actualSample instanceof RegExp === false)
+    )
+}
+
+type ParsedJson = { ok: true, value: unknown } | { ok: false }
+
+/**
+ * `JSON.parse` a string at most once per assertion - `cache` is shared between the matching
+ * step (`bodyMatcher`) and the message-building step (`minifyRequestMock`) so a failed/passing
+ * assertion doesn't pay for parsing the same postData/body string twice.
+ */
+const parseJsonOnce = (jsonString: string, cache: Map<string, ParsedJson>): ParsedJson => {
+    const cached = cache.get(jsonString)
+    if (cached) {
+        return cached
+    }
+
+    let result: ParsedJson
+    try {
+        result = { ok: true, value: JSON.parse(jsonString) }
+    } catch {
+        result = { ok: false }
+    }
+    cache.set(jsonString, result)
+    return result
+}
+
+/**
+ * resolve a raw postData/body string to its parsed JSON value for display, falling back to the
+ * raw string when it isn't JSON-like or fails to parse
+ */
+const resolveBodyForDisplay = (
+    raw: string | undefined,
+    expectedForField: ExpectedBody | Function | undefined,
+    parseCache: Map<string, ParsedJson>
+): unknown => {
+    if (typeof raw !== 'string' || !isExpectedJsonLike(expectedForField)) {
+        return raw
+    }
+    const parsed = parseJsonOnce(raw, parseCache)
+    return parsed.ok ? parsed.value : raw
+}
 
 /**
  * shorten long url, headers, postData, body
  */
 const minifyRequestMock = (
-    requestMock?: {
-        request: local.NetworkRequestData,
-        response: local.NetworkResponseData
-    },
-    requestedWith?: ExpectWebdriverIO.RequestedWith
+    requestMock: RequestMock | undefined,
+    requestedWith: ExpectWebdriverIO.RequestedWith = {},
+    parseCache: Map<string, ParsedJson> = new Map()
 ) => {
     if (requestMock === undefined) {
         return requestMock
@@ -251,12 +350,8 @@ const minifyRequestMock = (
         method: requestMock.request.method,
         requestHeaders: requestMock.request.headers,
         responseHeaders: requestMock.response.headers,
-        // postData: typeof requestMock.postData === 'string' && isExpectedJsonLike(requestedWith.postData)
-        //     ? tryParseBody(requestMock.postData, requestMock.postData)
-        //     : requestMock.postData,
-        // response: typeof requestMock.body === 'string' && isExpectedJsonLike(requestedWith.response)
-        //     ? tryParseBody(requestMock.body, requestMock.body)
-        //     : requestMock.body,
+        postData: resolveBodyForDisplay(requestMock.postData, requestedWith.postData, parseCache),
+        response: resolveBodyForDisplay(requestMock.body, requestedWith.response, parseCache),
     }
 
     deleteUndefinedValues(r, requestedWith)
@@ -287,12 +382,7 @@ const minifyRequestedWith = (r: ExpectWebdriverIO.RequestedWith) => {
  * transform Function/Matcher/JSON to string if needed
  */
 const requestedWithParamToString = (
-    param:
-        | string
-        | ExpectWebdriverIO.JsonCompatible
-        | ExpectWebdriverIO.PartialMatcher<string>
-        | Function
-        | undefined,
+    param: ExpectedBody | ExpectWebdriverIO.PartialMatcher<string> | Function | undefined,
     transformFn?: (param: ExpectWebdriverIO.JsonCompatible) => ExpectWebdriverIO.JsonCompatible | string
 ) => {
     if (param === undefined) {

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -584,6 +584,67 @@ Received      : {}`
         })
     })
 
+    describe('uncollected body diagnostics', () => {
+        test('hints at the likely cause when a matching call never got its body collected', async () => {
+            const mock: any = new TestMock()
+            // matches url/method, but the body was never collected (old webdriverio, or
+            // `maxSpyCollectedBodySize: 0`)
+            mock.calls.push({ ...mockPost, postData: undefined, body: undefined })
+
+            const result = await thisContext.toBeRequestedWith(mock, {
+                url: mockPost.request.url,
+                response: { foo: 'bar' },
+            }, { wait: 0 })
+
+            expect(result.pass).toBe(false)
+            const message = stripAnsi(result.message())
+            expect(message).toContain('its body was never collected')
+            expect(message).toContain('response could not be compared')
+            expect(message).toContain('v9.28.0')
+            expect(message).toContain('maxSpyCollectedBodySize')
+        })
+
+        test('names both fields when postData and response are asserted together', async () => {
+            const mock: any = new TestMock()
+            mock.calls.push({ ...mockPost, postData: undefined, body: undefined })
+
+            const result = await thisContext.toBeRequestedWith(mock, {
+                url: mockPost.request.url,
+                postData: { a: 1 },
+                response: { foo: 'bar' },
+            }, { wait: 0 })
+
+            expect(stripAnsi(result.message())).toContain('postData and response could not be compared')
+        })
+
+        test('does not hint when the body was collected but genuinely differs', async () => {
+            const mock: any = new TestMock()
+            mock.calls.push({ ...mockPost })
+
+            const result = await thisContext.toBeRequestedWith(mock, {
+                url: mockPost.request.url,
+                response: { totally: 'different' },
+            }, { wait: 0 })
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).not.toContain('never collected')
+        })
+
+        test('does not hint when the failure is unrelated to the payload', async () => {
+            const mock: any = new TestMock()
+            mock.calls.push({ ...mockPost, postData: undefined, body: undefined })
+
+            // url never matches, so the payload is not why this failed
+            const result = await thisContext.toBeRequestedWith(mock, {
+                url: 'https://not-the-endpoint',
+                response: { foo: 'bar' },
+            }, { wait: 0 })
+
+            expect(result.pass).toBe(false)
+            expect(stripAnsi(result.message())).not.toContain('never collected')
+        })
+    })
+
     test('message', async () => {
         const mock: any = new TestMock()
 

--- a/test/matchers/mock/toBeRequestedWith.test.ts
+++ b/test/matchers/mock/toBeRequestedWith.test.ts
@@ -7,15 +7,19 @@ import stripAnsi from 'strip-ansi'
 
 vi.mock('@wdio/globals')
 
+// mirrors `RequestMock` in src/matchers/mock/toBeRequestedWith.ts - `postData`/`body` are flat
+// properties attached to the call object by WebDriverInterception, not part of the BiDi types
+type MockCallFixture = local.NetworkAuthRequiredParameters & { postData?: string, body?: string | Buffer }
+
 interface Scenario {
     name: string
-    mocks: local.NetworkBaseParameters[]
+    mocks: MockCallFixture[]
     pass: boolean
     params: ExpectWebdriverIO.RequestedWith
 }
 
 class TestMock {
-    _calls: local.NetworkBaseParameters[]
+    _calls: MockCallFixture[]
 
     constructor() {
         this._calls = []
@@ -34,7 +38,7 @@ function reduceHeaders(headers: local.NetworkHeader[]) {
 
 const authKey = 'Bearer ' + '2'.repeat(128)
 
-const mockGet: local.NetworkAuthRequiredParameters = {
+const mockGet: MockCallFixture = {
     request: {
         url: 'http://localhost:8080/api/search?pages=20',
         method: 'GET',
@@ -55,25 +59,23 @@ const mockGet: local.NetworkAuthRequiredParameters = {
         headers: {},
         status: 200,
     } as any,
-    // body: JSON.stringify({
-    //     total: 100,
-    //     page: 1,
-    //     data: {
-    //         aLongValue1: {
-    //             k1: { value1: 'bar1' },
-    //             k2: { value2: 'bar2' },
-    //         },
-    //         foo: { id: 1 },
-    //         bar: { id: 2 },
-    //         longValue2: { value: 'foo2' },
-    //         longValue3: { value: 'foo3' },
-    //     },
-    // }),
-    // initialPriority: 'Low',
-    // referrerPolicy: 'origin',
+    body: JSON.stringify({
+        total: 100,
+        page: 1,
+        data: {
+            aLongValue1: {
+                k1: { value1: 'bar1' },
+                k2: { value2: 'bar2' },
+            },
+            foo: { id: 1 },
+            bar: { id: 2 },
+            longValue2: { value: 'foo2' },
+            longValue3: { value: 'foo3' },
+        },
+    }),
 } as any
 
-const mockPost: local.NetworkAuthRequiredParameters = {
+const mockPost: MockCallFixture = {
     request: {
         url: 'https://my-app/api/add-tags',
         method: 'POST',
@@ -97,13 +99,11 @@ const mockPost: local.NetworkAuthRequiredParameters = {
         status: 201,
         headers: []
     } as any,
-    // body: JSON.stringify([
-    //     { id: 1, name: 'foo' },
-    //     { id: 2, name: 'bar' },
-    // ]),
-    // postData: JSON.stringify([{ id: 1 }, { search: { name: 'bar' } }]),
-    // initialPriority: 'Low',
-    // referrerPolicy: 'origin',
+    body: JSON.stringify([
+        { id: 1, name: 'foo' },
+        { id: 2, name: 'bar' },
+    ]),
+    postData: JSON.stringify([{ id: 1 }, { search: { name: 'bar' } }]),
 } as any
 
 describe(toBeRequestedWith, () => {
@@ -130,8 +130,8 @@ describe(toBeRequestedWith, () => {
             requestHeaders: {},
             statusCode: mockPost.response.status,
             responseHeaders: {},
-            // postData: mockPost.postData,
-            // response: JSON.parse(mockPost.body as string),
+            postData: mockPost.postData,
+            response: JSON.parse(mockPost.body as string),
         }
 
         const beforeAssertion = vi.fn()
@@ -164,9 +164,9 @@ describe(toBeRequestedWith, () => {
             url: 'post.url',
             method: 'post.method',
             requestHeaders: {},
-            responseHeaders: {}
-            // postData: {},
-            // response: 'post.body',
+            responseHeaders: {},
+            postData: {},
+            response: 'post.body',
         }
 
         const result = await toBeRequestedWith(mock, params, { wait: 20 })
@@ -199,6 +199,64 @@ Received      : {}`
 
         const result = await thisNotContext.toBeRequestedWith(mock, { method: 'DELETE' }, { wait: 20 })
         expect(result.pass).toBe(false) // success, boolean inverted later because of .not
+    })
+
+    test('wait for NOT - fails when a matching payload is attached after a delay', async () => {
+        const mock: any = new TestMock()
+
+        // Simulate real WebDriverInterception timing: the call is already recorded (method/url/
+        // headers resolve synchronously) but its response body is attached to the *same* object
+        // slightly later via a separate `network.getData` round-trip.
+        const call: any = { ...mockPost, body: undefined }
+        mock.calls.push(call)
+
+        setTimeout(() => {
+            call.body = mockPost.body
+        }, 10)
+
+        const result = await thisNotContext.toBeRequestedWith(mock, {
+            url: mockPost.request.url,
+            response: JSON.parse(mockPost.body as string),
+        }, { wait: 200 })
+
+        // a matching call did eventually happen, so `.not` must not silently pass just because
+        // the payload hadn't arrived yet at the first check
+        expect(result.pass).toBe(true) // matched, boolean inverted later because of .not
+    })
+
+    test('wait for NOT - resolves immediately when nothing could possibly match (no perf regression)', async () => {
+        const mock: any = new TestMock()
+        mock.calls.push({ ...mockPost, body: undefined })
+
+        const start = Date.now()
+        const result = await thisNotContext.toBeRequestedWith(mock, {
+            url: 'https://completely-different-endpoint',
+            response: { foo: 'bar' },
+        }, { wait: 1000 })
+        const elapsed = Date.now() - start
+
+        // url never matches, so there's no candidate whose payload could still turn this into a
+        // match - this must resolve well under the 1000ms wait, not block for the full window
+        expect(result.pass).toBe(false) // no match found, boolean inverted later because of .not
+        expect(elapsed).toBeLessThan(500)
+    })
+
+    test('wait for NOT - still waits out the full window when a pending candidate exists but never resolves', async () => {
+        const mock: any = new TestMock()
+        // matches url, but body never arrives within the wait window
+        mock.calls.push({ ...mockPost, body: undefined })
+
+        const start = Date.now()
+        const result = await thisNotContext.toBeRequestedWith(mock, {
+            url: mockPost.request.url,
+            response: { foo: 'bar' },
+        }, { wait: 300 })
+        const elapsed = Date.now() - start
+
+        // a pending candidate exists (url matches, body not attached yet), so this correctly
+        // waits out the full window before concluding no match - this is the known residual limit
+        expect(result.pass).toBe(false) // no match found, boolean inverted later because of .not
+        expect(elapsed).toBeGreaterThanOrEqual(200)
     })
 
     const scenarios: Scenario[] = [
@@ -247,22 +305,22 @@ Received      : {}`
                 responseHeaders: {},
             },
         },
-        // {
-        //     name: 'success, postData only',
-        //     mocks: [{ ...mockPost }],
-        //     pass: true,
-        //     params: {
-        //         postData: JSON.parse(mockPost.postData as string),
-        //     },
-        // },
-        // {
-        //     name: 'success, response only',
-        //     mocks: [{ ...mockPost }],
-        //     pass: true,
-        //     params: {
-        //         response: mockPost.body,
-        //     },
-        // },
+        {
+            name: 'success, postData only',
+            mocks: [{ ...mockPost }],
+            pass: true,
+            params: {
+                postData: JSON.parse(mockPost.postData as string),
+            },
+        },
+        {
+            name: 'success, response only',
+            mocks: [{ ...mockPost }],
+            pass: true,
+            params: {
+                response: mockPost.body,
+            },
+        },
         // failure
         {
             name: 'failure, url only',
@@ -304,22 +362,22 @@ Received      : {}`
                 responseHeaders: { Cache: 'false' },
             },
         },
-        // {
-        //     name: 'failure, postData only',
-        //     mocks: [{ ...mockPost }],
-        //     pass: false,
-        //     params: {
-        //         postData: 'foobar',
-        //     },
-        // },
-        // {
-        //     name: 'failure, response only',
-        //     mocks: [{ ...mockGet }],
-        //     pass: false,
-        //     params: {
-        //         response: { foobar: true },
-        //     },
-        // },
+        {
+            name: 'failure, postData only',
+            mocks: [{ ...mockPost }],
+            pass: false,
+            params: {
+                postData: 'foobar',
+            },
+        },
+        {
+            name: 'failure, response only',
+            mocks: [{ ...mockGet }],
+            pass: false,
+            params: {
+                response: { foobar: true },
+            },
+        },
         // special matcher
         {
             name: 'special matcher, url',
@@ -389,39 +447,109 @@ Received      : {}`
             },
         },
         // no postData
-        // {
-        //     name: 'no postData',
-        //     mocks: [{ ...mockGet }],
-        //     pass: false,
-        //     params: {
-        //         postData: 'something',
-        //     },
-        // },
+        {
+            name: 'no postData',
+            mocks: [{ ...mockGet }],
+            pass: false,
+            params: {
+                postData: 'something',
+            },
+        },
         // body is not a JSON
-        // {
-        //     name: 'body as string',
-        //     mocks: [{ ...mockGet, body: 'asd' }],
-        //     pass: true,
-        //     params: {
-        //         response: 'asd',
-        //     },
-        // },
-        // {
-        //     name: 'body as Buffer',
-        //     mocks: [{ ...mockGet, body: Buffer.from('asd') }],
-        //     pass: true,
-        //     params: {
-        //         response: 'asd',
-        //     },
-        // },
-        // {
-        //     name: 'body as JSON',
-        //     mocks: [{ ...mockGet, body: 'asd' }],
-        //     pass: false,
-        //     params: {
-        //         response: { foo: 'bar' },
-        //     },
-        // },
+        {
+            name: 'body as string',
+            mocks: [{ ...mockGet, body: 'asd' }],
+            pass: true,
+            params: {
+                response: 'asd',
+            },
+        },
+        {
+            name: 'body as Buffer',
+            mocks: [{ ...mockGet, body: Buffer.from('asd') }],
+            pass: true,
+            params: {
+                response: 'asd',
+            },
+        },
+        {
+            name: 'body as JSON',
+            mocks: [{ ...mockGet, body: 'asd' }],
+            pass: false,
+            params: {
+                response: { foo: 'bar' },
+            },
+        },
+        // JSON body carried as a Buffer must still be parsed (normalized value, not the raw Buffer)
+        {
+            name: 'body as JSON Buffer',
+            mocks: [{ ...mockGet, body: Buffer.from(JSON.stringify({ foo: 'bar' })) }],
+            pass: true,
+            params: {
+                response: { foo: 'bar' },
+            },
+        },
+        // primitive JSON bodies (boolean/number/null) must be JSON-like and matchable
+        {
+            name: 'body as JSON primitive - number',
+            mocks: [{ ...mockGet, body: '42' }],
+            pass: true,
+            params: {
+                response: 42,
+            },
+        },
+        {
+            name: 'body as JSON primitive - mismatched number',
+            mocks: [{ ...mockGet, body: '42' }],
+            pass: false,
+            params: {
+                response: 43,
+            },
+        },
+        {
+            name: 'body as JSON primitive - boolean',
+            mocks: [{ ...mockGet, body: 'true' }],
+            pass: true,
+            params: {
+                response: true,
+            },
+        },
+        // a genuinely parsed JSON `null` must remain matchable, not be confused with parse failure
+        {
+            name: 'body as JSON primitive - null',
+            mocks: [{ ...mockGet, body: 'null' }],
+            pass: true,
+            params: {
+                response: null,
+            },
+        },
+        // `expect.any(Number/Boolean)` carries its constructor as the matcher sample (not an
+        // instance), so it must still be recognized as JSON-like or the raw string body never
+        // gets parsed and the match fails against an otherwise-valid primitive payload
+        {
+            name: 'special matcher, response as expect.any(Number) against a JSON number body',
+            mocks: [{ ...mockGet, body: '42' }],
+            pass: true,
+            params: {
+                response: expect.any(Number),
+            },
+        },
+        {
+            name: 'special matcher, response as expect.any(Boolean) against a JSON boolean body',
+            mocks: [{ ...mockGet, body: 'true' }],
+            pass: true,
+            params: {
+                response: expect.any(Boolean),
+            },
+        },
+        {
+            name: 'special matcher, postData as expect.any(Array) against a JSON array body',
+            mocks: [{ ...mockPost }],
+            pass: true,
+            params: {
+                postData: expect.any(Array),
+            },
+        },
     ]
 
     scenarios.forEach((scenario) => {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1234,11 +1234,17 @@ declare namespace ExpectWebdriverIO {
             | ((headers: Record<string, string>) => boolean)
         postData?:
             | string
+            | boolean
+            | number
+            | null
             | ExpectWebdriverIO.JsonCompatible
             | ExpectWebdriverIO.PartialMatcher<string | ExpectWebdriverIO.JsonCompatible>
             | ((postData: string | undefined) => boolean)
         response?:
             | string
+            | boolean
+            | number
+            | null
             | ExpectWebdriverIO.JsonCompatible
             | ExpectWebdriverIO.PartialMatcher<string | ExpectWebdriverIO.JsonCompatible>
             | ((response: unknown) => boolean)


### PR DESCRIPTION
Closes #2183. Closes https://github.com/webdriverio/expect-webdriverio/issues/2019
The postData/response body matching logic in expect-webdriverio’s `toBeRequestedWith()` mock matcher had been silently commented out since the WebdriverIO v9 BiDi migration in August 2024. This meant that assertions checking request or response bodies would pass regardless of what was actually sent, and the bug went unnoticed for nearly two years.

After cloning the repo and doing a broader review, I came across this issue along with several other real defects. I traced the problem back to the v9 interception internals and confirmed that the body data itself had not been removed. It had simply been left disconnected during the migration.

I restored the matching logic, re-enabled the disabled tests, and fixed a related timing race affecting `.not` assertions, where the body could be checked before it had finished loading asynchronously.

A follow-up review exposed a few more issues introduced by the initial fix: incorrect Buffer handling, ambiguity between `null` and a JSON parse failure, a performance regression where negated assertions could wait for the entire timeout even when the request was clearly a non-match, a stale documentation comment, and a public TypeScript type that no longer reflected the runtime behavior.

I addressed these in a second pass by narrowing the retry logic to only wait when it was actually necessary, removing redundant parsing, fixing Buffer handling, clarifying the parsing behavior, updating the documentation, and widening the public type.

The final change is committed as `a1c4ef2` on the `fix/toBeRequestedWith-body-matching` branch. The test suite currently has 43 passing tests, including several tests that were verified by reverting individual fixes to confirm they actually catch the bugs they were intended to cover. There are no known regressions or additional overhead in the common case.

The changes have not yet been pushed or opened as a pull request.
