### PR TITLE
feat: Expose `some` through `expect-webdriverio/api` to workaround double init problem

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1129,6 +1129,8 @@ since: v6.0.0
 The custom `some()` function (distinct syntax compared to `.not`) allows you to assert that at least one element from multiple elements meets the assertion.
 
 ```ts
+import { some } from 'expect-webdriverio/api'
+
 // Allow to succeed only if one element matches (or not match)
 // Succeeds if at least one element matches either 'optionA' or 'optionB'
 await expect(some($$('elements'))).toHaveText(expect.oneOf('optionA', 'optionB'));

--- a/docs/MultipleElements.md
+++ b/docs/MultipleElements.md
@@ -69,6 +69,8 @@ Example in Mocha:
 `useToHaveTextStrictMultiElementsCompareStrategy` is assumed to be enabled
 
 ```ts
+import { some } from 'expect-webdriverio/api'
+
 const elements = $$('myElements')
 
 // Single expected value

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       }
     ],
     "./types": "./types/expect-global.d.ts",
-    "./expect-global": "./types/expect-global.d.ts"
+    "./expect-global": "./types/expect-global.d.ts",
+    "./api": "./lib/api/index.js"
   },
   "types": "./types/expect-webdriverio.d.ts",
   "typeScriptVersion": "3.8.3",

--- a/playgrounds/browser-runner/test/specs/vue.test.ts
+++ b/playgrounds/browser-runner/test/specs/vue.test.ts
@@ -1,7 +1,7 @@
 import { $, expect } from '@wdio/globals'
 import { render } from '@testing-library/vue'
 import Component from '../../components/Component.vue'
-import { some } from 'expect-webdriverio'
+import { some } from 'expect-webdriverio/api'
 
 describe('Vue Component Testing', () => {
 

--- a/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
+++ b/playgrounds/jasmine/test/specs/globalImport/wdio-matchers.test.ts
@@ -1,5 +1,6 @@
 import { browser, $, $$ } from '@wdio/globals'
-import { expect, some } from 'expect-webdriverio'
+import { expect } from 'expect-webdriverio'
+import { some } from 'expect-webdriverio/api'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {

--- a/playgrounds/mocha/test/specs/wdio-matchers.test.ts
+++ b/playgrounds/mocha/test/specs/wdio-matchers.test.ts
@@ -1,5 +1,6 @@
 import { browser, $, $$ } from '@wdio/globals'
-import { setFeatureFlags, some } from 'expect-webdriverio'
+import { setFeatureFlags } from 'expect-webdriverio'
+import { some } from 'expect-webdriverio/api'
 
 describe('WebdriverIO Custom Matchers', () => {
     beforeEach(async () => {

--- a/playgrounds/package-lock.json
+++ b/playgrounds/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "..": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^4.1.10",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,6 @@
+import { some as wdioSome } from '../matchers/modifiers/some.js'
+
+/**
+ * API allowing to export some feature without the burden of all the initilizations
+ */
+export const some = wdioSome

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { DEFAULT_OPTIONS, defaultOptionsList } from './constants.js'
 import createSoftExpect from './softExpect.js'
 import { SoftAssertService } from './softAssert.js'
 import { oneOf } from './matchers/asymmetrics/oneOf.js'
-import { some as wdioSome } from './matchers/modifiers/some.js'
 
 /**
  * Contains the custom WDIO matchers, registered through `expect.extend()`.
@@ -70,7 +69,6 @@ Object.defineProperty(wdioExpect, 'clearSoftFailures', {
 
 // Fully configured global expect instance with all the custom WDIO matchers, asymmetric matchers, and soft assertions
 export const expect = wdioExpect
-export const some = wdioSome
 
 // Default options for the expect-webdriverio library
 export const getDefaultOptions = (): ExpectWebdriverIO.DefaultOptions => DEFAULT_OPTIONS

--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -1,6 +1,6 @@
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 import { expectTypeOf } from 'vitest'
-import { some } from 'expect-webdriverio'
+import { some } from 'expect-webdriverio/api'
 import type { SomeElementsWrapper } from '../../src/matchers/modifiers/some.js'
 
 describe('WebDriverIO Expect Type Assertions under Mocha', () => {

--- a/test/matchers/element/toBeDisplayed.test.ts
+++ b/test/matchers/element/toBeDisplayed.test.ts
@@ -7,8 +7,8 @@ import stripAnsi from 'strip-ansi'
 import { browserFactory, chainableElementArrayFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { DEFAULT_OPTIONS } from '../../../src/constants.js'
 import { setDefaultOptions, setOptions } from '../../../src/index.js'
-import { some } from '../../../src/matchers/modifiers/some.js'
 import { refreshElementArray } from '../../../src/util/refetchElements.js'
+import { some } from '../../../src/api/index.js'
 
 vi.mock('@wdio/globals')
 

--- a/test/matchers/element/toHaveText.test.ts
+++ b/test/matchers/element/toHaveText.test.ts
@@ -5,9 +5,10 @@ import type { ChainablePromiseArray } from 'webdriverio'
 import { $Factory, browserFactory, chainableElementArrayFactory, elementArrayFactory, elementFactory, notFoundElementFactory } from '../../__mocks__/@wdio/globals.js'
 import { waitUntil } from '../../../src/utils.js'
 import stripAnsi from 'strip-ansi'
-import { setFeatureFlags, some } from '../../../src/index.js'
+import { setFeatureFlags } from '../../../src/index.js'
 import { expect as wdioExpect } from '../../../src/index.js'
 import { refreshElementArray } from '../../../src/util/refetchElements.js'
+import { some } from '../../../src/api/index.js'
 
 vi.mock('@wdio/globals')
 

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -22,7 +22,6 @@ type ExpectLibExpectationResult = import('expect').ExpectationResult
 type ExpectLibMatcherContext = import('expect').MatcherContext
 type MatchersObject = Parameters<typeof import('expect').expect.extend>[0]
 type ExpectLibAnything = ReturnType<typeof expect.any> | ReturnType<typeof expect.anything>
-
 type WdioSome<T> = import('../src/matchers/modifiers/some.js').SomeElementsWrapper<T>
 
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
@@ -1264,7 +1263,17 @@ declare namespace ExpectWebdriverIO {
      * Allow to match one of the specified value.
      */
     type OneOfPartialMatcher<T> = ExpectWebdriverIO.PartialMatcher<T[]>
+}
 
+declare module 'expect-webdriverio' {
+    export = ExpectWebdriverIO
+}
+
+/**
+ * Expose the expect-wdio API without the burden of initialization.
+ * Required since importing from 'expect-webdriverio' can trigger double initialization.
+ */
+declare module 'expect-webdriverio/api' {
     /**
      * Quantifier modifier. Wraps a `$$()` result so that the matcher passes
      * when at least one element satisfies the condition (∃ semantics).
@@ -1274,11 +1283,7 @@ declare namespace ExpectWebdriverIO {
      * await expect(some($$('.items'))).not.toBeDisplayed() // at least one is NOT displayed
      * await expect(some($$('.items'))).toHaveText('foo')
      */
-    function some<T extends ElementArrayLike>(
+    export function some<T extends ElementArrayLike>(
         elements: T
     ): WdioSome<T>
-}
-
-declare module 'expect-webdriverio' {
-    export = ExpectWebdriverIO
 }


### PR DESCRIPTION
When importing from `expect-webdriverio`, we can trigger a double-initialization problem in a framework that already imports the module. By exposing it through  `expect-webdriverio/api`, we can still import from `expect-webdriverio` without triggering this double-initialization problem.