### PR TITLE
feat: Make `some` & `oneOf` multi-module loaded compliant

### DIFF
--- a/src/matchers/asymmetrics/oneOf.ts
+++ b/src/matchers/asymmetrics/oneOf.ts
@@ -2,12 +2,16 @@ import type { HTMLOptions, StringOptions } from 'expect-webdriverio'
 import { compareTextWithArray } from '../../utils.js'
 import { WdioAsymmetricMatchers } from './asymmetricsUtils.js'
 
+const ONE_OF_TAG = 'expect-webdriverio.oneOf'
+const ONE_OF_SYMBOL = Symbol.for(ONE_OF_TAG)
+
 /**
  * oneOf matcher is used to check if a string matches any of the provided strings or regular expressions.
  * StringOptions is injected by the matcher for customization of the matching behavior.
  * @see oneOfWithContextMatcher
  */
 export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp | AsymmetricMatcher<string> | null>> {
+    readonly [ONE_OF_SYMBOL] = true
     // TODO support HTML options
     public options: StringOptions | HTMLOptions = {}
 
@@ -71,4 +75,8 @@ export class OneOfMatcher extends WdioAsymmetricMatchers<Array<string | RegExp |
 
 export function oneOf(...sample: Array<string | RegExp | AsymmetricMatcher<string> | null>): OneOfMatcher {
     return new OneOfMatcher(...sample)
+}
+
+export function isOneOfMatcher(oneOfMatcher: unknown): oneOfMatcher is OneOfMatcher {
+    return oneOfMatcher instanceof OneOfMatcher || (oneOfMatcher as OneOfMatcher)?.[ONE_OF_SYMBOL] === true
 }

--- a/src/matchers/element/toHaveAttribute.ts
+++ b/src/matchers/element/toHaveAttribute.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utils.js'
 import { expect as wdioExpect } from '../../index.js'
 import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
-import { OneOfMatcher } from '../asymmetrics/oneOf.js'
+import { isOneOfMatcher } from '../asymmetrics/oneOf.js'
 
 async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element, attribute: string, expectedValue: MaybeOneOf<string | RegExp | AsymmetricMatcher<string>> | undefined, options: ExpectWebdriverIO.StringOptions): Promise<CompareResult<string | null>> {
     const attributeValue = await el.getAttribute(attribute)
@@ -22,7 +22,7 @@ async function conditionAttributeValueMatchWithExpected(el: WebdriverIO.Element,
             return { success: expectedValue.asymmetricMatch(attributeValue), actual: attributeValue }
         }
         return { success: attributeValue === expectedValue, actual: attributeValue }
-    } else if ( expectedValue instanceof OneOfMatcher) {
+    } else if (isOneOfMatcher(expectedValue)) {
         return { success: expectedValue.asymmetricMatch(attributeValue), actual: attributeValue }
     }
 

--- a/src/matchers/element/toHaveElementProperty.ts
+++ b/src/matchers/element/toHaveElementProperty.ts
@@ -12,7 +12,7 @@ import {
     wrapExpectedWithArray
 } from '../../utils.js'
 import { buildWdioAsymmetricMatchersWithOptions } from '../asymmetrics/asymmetricsUtils.js'
-import { OneOfMatcher } from '../asymmetrics/oneOf.js'
+import { isOneOfMatcher } from '../asymmetrics/oneOf.js'
 
 async function condition(
     el: WebdriverIO.Element,
@@ -29,7 +29,7 @@ async function condition(
             return { success: expectedValue.asymmetricMatch(propertyValue), actual: propertyValue }
         }
         return { success: propertyValue === expectedValue, actual: propertyValue }
-    } else if ( expectedValue instanceof OneOfMatcher) {
+    } else if (isOneOfMatcher(expectedValue)) {
         return { success: expectedValue.asymmetricMatch(propertyValue), actual: propertyValue }
     }
 

--- a/src/matchers/modifiers/some.ts
+++ b/src/matchers/modifiers/some.ts
@@ -2,7 +2,6 @@ const SOME_TAG = 'expect-webdriverio.some'
 const SOME_SYMBOL = Symbol.for(SOME_TAG)
 
 export class SomeElementsWrapper<T> {
-    // Not used but keeping in case it is needed in the future for type checking
     readonly [SOME_SYMBOL] = true
     constructor(public readonly elements: T) {}
 }
@@ -12,5 +11,5 @@ export function some<T>(elements: T): SomeElementsWrapper<T> {
 }
 
 export function isSomeWrapper(value: unknown): value is SomeElementsWrapper<unknown> {
-    return value instanceof SomeElementsWrapper
+    return value instanceof SomeElementsWrapper || (value as SomeElementsWrapper<unknown>)?.[SOME_SYMBOL] === true
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ import { executeCommandWithStrategy } from './util/executeCommand.js'
 import { enhanceError, enhanceErrorBe } from './util/formatMessage.js'
 import { waitUntil } from './util/waitUntil.js'
 import { DEFAULT_FEATURE_FLAGS } from './constants.js'
-import { OneOfMatcher } from './matchers/asymmetrics/oneOf.js'
+import { isOneOfMatcher, OneOfMatcher } from './matchers/asymmetrics/oneOf.js'
 
 export function isJasmineStringAsymmetricMatcher<T>(expected: unknown): expected is JasmineAsymmetricMatcher<T> {
     return isAsymmetricMatcher(expected) && !('toAsymmetricMatcher' in expected) && 'jasmineToString' in expected && typeof expected.jasmineToString === 'function'
@@ -143,7 +143,7 @@ export const compareTextOrArray = (
      * Instead the `expect.oneOf()` asymmetric matcher should be used to compare against multiple expected values.
      */
     if (Array.isArray(expectedTexts)) {
-        if (expectedTexts.some((expected): expected is OneOfMatcher => expected instanceof OneOfMatcher)) {
+        if (expectedTexts.some((expected): expected is OneOfMatcher => isOneOfMatcher(expected))) {
             throw new Error('OneOf is not supported in array under legacy behavior. Please enable `useToHaveTextStrictMultiElementsCompareStrategy` feature flag to use the new strict index based matching strategy with `expect.oneOf()`.')
         } else {
             console.warn('Array of expected values is deprecated. Please use `expect.oneOf()` asymmetric matcher to compare against multiple expected values. This will be removed in v8.0.0.')
@@ -152,7 +152,7 @@ export const compareTextOrArray = (
         }
     }
 
-    if (expectedTexts instanceof OneOfMatcher) {
+    if (isOneOfMatcher(expectedTexts)) {
         return { success: expectedTexts.asymmetricMatch(actualText), actual: actualText }
     }
 

--- a/test/matchers/asymmetrics/oneOf.test.ts
+++ b/test/matchers/asymmetrics/oneOf.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { OneOfMatcher } from '../../../src/matchers/asymmetrics/oneOf'
+import { isOneOfMatcher, oneOf, OneOfMatcher } from '../../../src/matchers/asymmetrics/oneOf'
 
 describe('OneOfMatcher', () => {
     describe('asymmetricMatch', () => {
@@ -71,6 +71,46 @@ describe('OneOfMatcher', () => {
             const matcher = new OneOfMatcher('apple').withOptions({ atIndex: 1 })
 
             expect(matcher.toAsymmetricMatcher()).toBe('matchingAtIndex<1>OneOf<"apple">')
+        })
+    })
+
+    describe('isOneOfMatcher', () => {
+        it('should return true for a OneOfMatcher instance', () => {
+            const matcher = new OneOfMatcher('apple', 'banana')
+            expect(isOneOfMatcher(matcher)).toBe(true)
+        })
+
+        it('should return true for a OneOfMatcher created via oneOf()', () => {
+            expect(isOneOfMatcher(oneOf('apple', 'banana'))).toBe(true)
+        })
+
+        it('should return true for an object with the ONE_OF_SYMBOL set to true (cross-module scenario)', () => {
+            const fakeFromAnotherModule = {
+                [Symbol.for('expect-webdriverio.oneOf')]: true,
+            }
+            expect(isOneOfMatcher(fakeFromAnotherModule)).toBe(true)
+        })
+
+        it('should return false for null', () => {
+            expect(isOneOfMatcher(null)).toBe(false)
+        })
+
+        it('should return false for undefined', () => {
+            expect(isOneOfMatcher(undefined)).toBe(false)
+        })
+
+        it('should return false for a plain object without the symbol', () => {
+            expect(isOneOfMatcher({ sample: ['apple'] })).toBe(false)
+        })
+
+        it('should return false for a primitive', () => {
+            expect(isOneOfMatcher('apple')).toBe(false)
+            expect(isOneOfMatcher(42)).toBe(false)
+        })
+
+        it('should return false for an object with the symbol set to false', () => {
+            const obj = { [Symbol.for('expect-webdriverio.oneOf')]: false }
+            expect(isOneOfMatcher(obj)).toBe(false)
         })
     })
 })

--- a/test/matchers/modifiers/some.test.ts
+++ b/test/matchers/modifiers/some.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { $$ } from '@wdio/globals'
-import { SomeElementsWrapper } from '../../../src/matchers/modifiers/some'
+import { isSomeWrapper, SomeElementsWrapper, some } from '../../../src/matchers/modifiers/some'
 
 vi.mock('@wdio/globals')
 
@@ -11,10 +11,71 @@ describe('SomeElementsWrapper', () => {
 
         expect(wrapper).toBeInstanceOf(SomeElementsWrapper)
     })
+
     it('should have the elements property', () => {
         const elements = $$('div')
         const wrapper = new SomeElementsWrapper(elements)
 
         expect(wrapper.elements).toEqual(elements)
+    })
+
+    describe('some', () => {
+        it('should return a SomeElementsWrapper', () => {
+            const elements = $$('div')
+            expect(some(elements)).toBeInstanceOf(SomeElementsWrapper)
+        })
+    })
+
+    describe('isSomeWrapper', () => {
+        it('should return true for a SomeElementsWrapper instance (instanceof path)', () => {
+            const wrapper = new SomeElementsWrapper($$('div'))
+            expect(isSomeWrapper(wrapper)).toBe(true)
+        })
+
+        it('should return true for a plain object carrying the symbol (cross-module path)', () => {
+            // Simulates a SomeElementsWrapper created by a different module copy
+            const SOME_SYMBOL = Symbol.for('expect-webdriverio.some')
+            const crossModuleValue = { [SOME_SYMBOL]: true, elements: [] }
+            expect(isSomeWrapper(crossModuleValue)).toBe(true)
+        })
+
+        it('should return false when the symbol is present but set to false', () => {
+            const SOME_SYMBOL = Symbol.for('expect-webdriverio.some')
+            const value = { [SOME_SYMBOL]: false, elements: [] }
+            expect(isSomeWrapper(value)).toBe(false)
+        })
+
+        it('should return false for null', () => {
+            expect(isSomeWrapper(null)).toBe(false)
+        })
+
+        it('should return false for undefined', () => {
+            expect(isSomeWrapper(undefined)).toBe(false)
+        })
+
+        it('should return false for a plain object without the symbol', () => {
+            expect(isSomeWrapper({ elements: [] })).toBe(false)
+        })
+
+        it('should return false for a primitive value', () => {
+            expect(isSomeWrapper('some string')).toBe(false)
+        })
+    })
+
+    it('should return false for instanceof but true for symbol across module copies', async () => {
+        const { SomeElementsWrapper, isSomeWrapper } = await import('../../../src/matchers/modifiers/some')
+
+        // Clear the registry so the next import gets a fresh constructor
+        vi.resetModules()
+
+        const { SomeElementsWrapper: SomeElementsWrapperB } = await import('../../../src/matchers/modifiers/some')
+
+        const crossModuleWrapper = new SomeElementsWrapperB([])
+
+        // instanceof fails — different constructor across module copies
+        expect(crossModuleWrapper instanceof SomeElementsWrapper).toBe(false)
+
+        // isSomeWrapper still succeeds — Symbol.for() is global and shared
+        expect(isSomeWrapper(crossModuleWrapper)).toBe(true)
     })
 })


### PR DESCRIPTION
When using import from `expect-webdrierio` inside runners, we need to be cross-module compliant. `instanceOf` is not, but symbols are.