### PR TITLE
Fix invalid import of `WdioSome`

### DIFF
--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -22,7 +22,7 @@ type ExpectLibExpectationResult = import('expect').ExpectationResult
 type ExpectLibMatcherContext = import('expect').MatcherContext
 type MatchersObject = Parameters<typeof import('expect').expect.extend>[0]
 type ExpectLibAnything = ReturnType<typeof expect.any> | ReturnType<typeof expect.anything>
-type WdioSome<T> = import('../src/matchers/modifiers/some.js').SomeElementsWrapper<T>
+type WdioSome<T> = import('expect-webdriverio/api').WdioSome<T>
 
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
@@ -1274,6 +1274,15 @@ declare module 'expect-webdriverio' {
  * Required since importing from 'expect-webdriverio' can trigger double initialization.
  */
 declare module 'expect-webdriverio/api' {
+    const SOME_SYMBOL: unique symbol
+
+    export {}
+    
+    export interface WdioSome<T> {
+        readonly [SOME_SYMBOL]: true
+        readonly elements: T
+    }
+
     /**
      * Quantifier modifier. Wraps a `$$()` result so that the matcher passes
      * when at least one element satisfies the condition (∃ semantics).

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -1277,7 +1277,7 @@ declare module 'expect-webdriverio/api' {
     const SOME_SYMBOL: unique symbol
 
     export {}
-    
+
     export interface WdioSome<T> {
         readonly [SOME_SYMBOL]: true
         readonly elements: T


### PR DESCRIPTION
The import of `WdioSome` in `types/expect-webdriverio.d.ts` points to a path that does not exist in the published package.

This inlines the type from `src/matchers/modifiers/some.ts` into the declaration file.

Fixes https://github.com/webdriverio/expect-webdriverio/issues/2193