### PR TITLE
fix: bad import in typing from the not published `src` folder

### DIFF
--- a/test-types/mocha/mocha.test-d.ts
+++ b/test-types/mocha/mocha.test-d.ts
@@ -1,7 +1,6 @@
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 import { expectTypeOf } from 'vitest'
 import { some } from 'expect-webdriverio/api'
-import type { SomeElementsWrapper } from '../../src/matchers/modifiers/some.js'
 
 describe('WebDriverIO Expect Type Assertions under Mocha', () => {
     const chainableElement = {} as unknown as ChainablePromiseElement
@@ -1137,9 +1136,9 @@ describe('WebDriverIO Expect Type Assertions under Mocha', () => {
 
     describe('Wdio custom some modifier', () => {
         it('should have some work with elements what ever the type', async () => {
-            expectTypeOf(some([element])).toEqualTypeOf<SomeElementsWrapper<WebdriverIO.Element[]>>()
-            expectTypeOf(some(chainableArray)).toEqualTypeOf<SomeElementsWrapper<typeof chainableArray>>()
-            expectTypeOf(some(Promise.resolve([element]))).toEqualTypeOf<SomeElementsWrapper<Promise<WebdriverIO.Element[]>>>()
+            expectTypeOf(some([element])).toEqualTypeOf<WdioSome<WebdriverIO.Element[]>>()
+            expectTypeOf(some(chainableArray)).toEqualTypeOf<WdioSome<typeof chainableArray>>()
+            expectTypeOf(some(Promise.resolve([element]))).toEqualTypeOf<WdioSome<Promise<WebdriverIO.Element[]>>>()
         })
 
         it('should not work with element', () => {

--- a/types/expect-webdriverio.d.ts
+++ b/types/expect-webdriverio.d.ts
@@ -22,7 +22,7 @@ type ExpectLibExpectationResult = import('expect').ExpectationResult
 type ExpectLibMatcherContext = import('expect').MatcherContext
 type MatchersObject = Parameters<typeof import('expect').expect.extend>[0]
 type ExpectLibAnything = ReturnType<typeof expect.any> | ReturnType<typeof expect.anything>
-type WdioSome<T> = import('../src/matchers/modifiers/some.js').SomeElementsWrapper<T>
+type WdioSome<T> = import('expect-webdriverio/api').WdioSome<T>
 
 // Extracted from the expect library, this is the type of the matcher function used in the expect library.
 type RawMatcherFn<Context extends ExpectLibMatcherContext = ExpectLibMatcherContext> = {
@@ -1274,6 +1274,9 @@ declare module 'expect-webdriverio' {
  * Required since importing from 'expect-webdriverio' can trigger double initialization.
  */
 declare module 'expect-webdriverio/api' {
+    export interface WdioSome<T> {
+        readonly elements: T
+    }
     /**
      * Quantifier modifier. Wraps a `$$()` result so that the matcher passes
      * when at least one element satisfies the condition (∃ semantics).


### PR DESCRIPTION
Fixes https://github.com/webdriverio/expect-webdriverio/issues/2193 based on https://github.com/webdriverio/expect-webdriverio/pull/2194