### PR TITLE
fix(toHaveText): apply ignoreCase to RegExp and stringMatching expected values

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -169,7 +169,7 @@ This option can be applied in addition to the command options when strings are b
 
 | Name | Type | Details |
 | ---- | ---- | ------- |
-| <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values |
+| <code><var>ignoreCase</var></code> | boolean | apply `toLowerCase` to both actual and expected values. A RegExp expected value is matched case-insensitively instead (the `i` flag is applied), since a pattern cannot be lowercased safely. |
 | <code><var>trim</var></code> | boolean | apply `trim` to actual value |
 | <code><var>replace</var></code> | Replacer \| Replacer[] | replace parts of the actual value that match the string/RegExp. The replacer can be a string or a function.
 | <code><var>containing</var></code> | boolean | expect actual value to contain expected value, otherwise strict equal. |

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,17 @@ export function isInversedStringContainingMatcher(expected: unknown): expected i
     return isStringContainingMatcherLike(expected) && (expected as WdioAsymmetricMatcher<string>).inverse === true
 }
 
+export function isStringMatchingMatcherLike(expected: unknown): expected is WdioAsymmetricMatcher<string | RegExp> | JasmineStringMatchingAsymmetricMatcher<string | RegExp> {
+    return !!expected && expected.constructor.name === 'StringMatching'
+}
+
+/**
+ * Detect `not.stringMatching` matcher. Jasmine does not have an inverse stringMatching matcher.
+ */
+export function isInversedStringMatchingMatcher(expected: unknown): expected is WdioAsymmetricMatcher<string | RegExp> {
+    return isStringMatchingMatcherLike(expected) && (expected as WdioAsymmetricMatcher<string | RegExp>).inverse === true
+}
+
 export function getStringAsymmetricMatcherValue(
     expected: WdioAsymmetricMatcher<string> | JasmineStringAsymmetricMatcher<string>
 ): string | RegExp {
@@ -190,15 +201,36 @@ export const compareText = (
     if (Array.isArray(replace)) {
         actual = replaceActual(replace, actual)
     }
+
+    // a RegExp expected value (bare or wrapped in stringMatching) expresses case-insensitivity via
+    // its own `i` flag (added below), so `actual` is left in its original case for it - lowercasing
+    // first can corrupt characters with special casing (e.g. Turkish İ expands to two code points
+    // via toLowerCase()), silently breaking otherwise-correct matches.
     if (ignoreCase) {
-        actual = actual.toLowerCase()
         if (typeof expected === 'string') {
+            actual = actual.toLowerCase()
             expected = expected.toLowerCase()
+        } else if (expected instanceof RegExp) {
+            expected = withIgnoreCaseFlag(expected)
         } else if (isStringContainingMatcherLike(expected)) {
+            actual = actual.toLowerCase()
             const sample = getStringAsymmetricMatcherValue(expected).toString().toLocaleLowerCase()
             expected = (isInversedStringContainingMatcher(expected)
                 ? expect.not.stringContaining(sample)
                 : expect.stringContaining(sample)) as WdioAsymmetricMatcher<string>
+        } else if (isStringMatchingMatcherLike(expected)) {
+            // stringMatching's sample is regex source regardless of whether it was given as a
+            // string or a RegExp instance, so lowercasing it as if it were literal text would
+            // corrupt regex escapes (e.g. `\D` -> `\d` flips "non-digit" to "digit"). Build/extend
+            // a RegExp and add the `i` flag instead - `actual` stays in its original case, same as
+            // the bare RegExp branch above.
+            const sample = getStringAsymmetricMatcherValue(expected as WdioAsymmetricMatcher<string> | JasmineStringAsymmetricMatcher<string>)
+            const caseInsensitiveSample = withIgnoreCaseFlag(sample instanceof RegExp ? sample : new RegExp(sample))
+            expected = (isInversedStringMatchingMatcher(expected)
+                ? expect.not.stringMatching(caseInsensitiveSample)
+                : expect.stringMatching(caseInsensitiveSample)) as WdioAsymmetricMatcher<string>
+        } else {
+            actual = actual.toLowerCase()
         }
     }
 
@@ -285,11 +317,20 @@ export const compareTextWithArray = (
     if (Array.isArray(replace)) {
         actual = replaceActual(replace, actual)
     }
+
+    // Entries that carry their own RegExp - a bare RegExp, or one wrapped in stringMatching - carry
+    // their own case-insensitivity via the `i` flag (added below), so they are matched against
+    // `actualOriginalCase` instead of the lowercased `actual` - lowercasing it first can corrupt
+    // characters with special casing (e.g. Turkish İ), silently breaking otherwise-valid matches.
+    const actualOriginalCase = actual
     if (ignoreCase) {
         actual = actual.toLowerCase()
         expectedArray = expectedArray.map((item) => {
             if (typeof item === 'string') {
                 return item.toLowerCase()
+            }
+            if (item instanceof RegExp) {
+                return withIgnoreCaseFlag(item)
             }
             if (isStringContainingMatcherLike(item)) {
                 const sample = getStringAsymmetricMatcherValue(item).toString().toLocaleLowerCase()
@@ -297,13 +338,25 @@ export const compareTextWithArray = (
                     ? expect.not.stringContaining(sample)
                     : expect.stringContaining(sample)) as WdioAsymmetricMatcher<string>
             }
+            if (isStringMatchingMatcherLike(item)) {
+                // see the equivalent branch in compareText for why the sample is turned into a
+                // RegExp rather than lowercased as literal text
+                const sample = getStringAsymmetricMatcherValue(item as WdioAsymmetricMatcher<string> | JasmineStringAsymmetricMatcher<string>)
+                const caseInsensitiveSample = withIgnoreCaseFlag(sample instanceof RegExp ? sample : new RegExp(sample))
+                return (isInversedStringMatchingMatcher(item)
+                    ? expect.not.stringMatching(caseInsensitiveSample)
+                    : expect.stringMatching(caseInsensitiveSample)) as WdioAsymmetricMatcher<string>
+            }
             return item
         })
     }
 
     const hasFoundTextInArray = expectedArray.some((expected) => {
         if (expected instanceof RegExp) {
-            return !!actual.match(expected)
+            return !!actualOriginalCase.match(expected)
+        }
+        if (isStringMatchingMatcherLike(expected) && getStringAsymmetricMatcherValue(expected as WdioAsymmetricMatcher<string> | JasmineStringAsymmetricMatcher<string>) instanceof RegExp) {
+            return expected.asymmetricMatch(actualOriginalCase)
         }
         if (isAsymmetricMatcher(expected)) {
             return expected.asymmetricMatch(actual)
@@ -323,7 +376,7 @@ export const compareTextWithArray = (
         return actual === expected
     })
     return {
-        actual,
+        actual: actualOriginalCase,
         success: hasFoundTextInArray,
     }
 }
@@ -404,6 +457,27 @@ export const compareStyle = async (
 export {
     compareNumbers, enhanceError,
     executeCommandBe, waitUntil, wrapExpectedWithArray
+}
+
+/**
+ * Return an equivalent RegExp carrying the `i` (ignore case) flag.
+ *
+ * The actual value being compared is generally left untouched when it's matched against a RegExp
+ * (see the callers), since a RegExp pattern can't be lowercased without corrupting it (character
+ * classes, escapes, etc.) - the case-insensitivity has to be expressed on the pattern itself.
+ *
+ * Always returns a clone, even when `i` is already set, so matching never mutates a `lastIndex`
+ * the caller still holds a reference to. The clone's `lastIndex` is copied from the source - for a
+ * sticky (`y`) pattern this is the position the match is anchored to, and `String.prototype.match`
+ * honors it, so losing it (it would otherwise reset to 0 on the new instance) silently changes
+ * where the match is attempted.
+ */
+function withIgnoreCaseFlag(expected: RegExp): RegExp {
+    const cloned = expected.ignoreCase
+        ? new RegExp(expected.source, expected.flags)
+        : new RegExp(expected.source, `${expected.flags}i`)
+    cloned.lastIndex = expected.lastIndex
+    return cloned
 }
 
 function replaceActual(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -86,6 +86,86 @@ describe('utils', () => {
             expect(compareText(' FOO ', jasmine.stringMatching(/.*foo.*/i), {}).success).toBe(true)
         })
 
+        test('should apply ignoreCase to a RegExp expected value', () => {
+            // ignoreCase makes the pattern case-insensitive (via the `i` flag) instead of
+            // lowercasing `actual` - otherwise a matching text would be reported as not matching
+            expect(compareText('Hello', /Hello/, { ignoreCase: true }).success).toBe(true)
+            expect(compareText('HELLO', /hello/, { ignoreCase: true }).success).toBe(true)
+            expect(compareText('Hello', /^H/, { ignoreCase: true }).success).toBe(true)
+            // a genuine mismatch must still fail
+            expect(compareText('Hello', /Goodbye/, { ignoreCase: true }).success).toBe(false)
+        })
+
+        test('should preserve existing RegExp flags when applying ignoreCase', () => {
+            expect(compareText('Hello\nWorld', /^world$/m, { ignoreCase: true }).success).toBe(true)
+            // already case-insensitive patterns keep working
+            expect(compareText('Hello', /hello/i, { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should not apply ignoreCase to a RegExp when the option is off', () => {
+            expect(compareText('Hello', /Hello/, {}).success).toBe(true)
+            expect(compareText('Hello', /hello/, {}).success).toBe(false)
+        })
+
+        test('should match a RegExp against the original-case actual value, not a lowercased copy', () => {
+            // 'İ' (Turkish dotted capital I, U+0130) expands to two code points when lowercased
+            // ('i' + combining dot above), which would corrupt a length-sensitive pattern if
+            // `actual` were lowercased before matching. The RegExp's own `i` flag (applied by
+            // ignoreCase) already provides the case-insensitivity, so `actual` must stay as-is.
+            expect(compareText('İstanbul', /^.{8}$/i, { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should preserve a sticky RegExp lastIndex when applying ignoreCase', () => {
+            const pattern = /world/y
+            pattern.lastIndex = 6
+            // requires the ignoreCase-cloned regex to retain lastIndex 6 (String.prototype.match
+            // honors it for sticky patterns) and its own `i` flag to bridge the case difference
+            expect(compareText('hello WORLD', pattern, { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should not mutate the caller\'s RegExp lastIndex when the pattern already has `i`', () => {
+            // withIgnoreCaseFlag always clones, even when `i` is already set, so matching never
+            // mutates a `lastIndex` the caller still holds a reference to
+            const pattern = /world/giy
+            pattern.lastIndex = 6
+            compareText('hello world', pattern, { ignoreCase: true })
+            expect(pattern.lastIndex).toBe(6)
+        })
+
+        test('should apply ignoreCase to a stringMatching matcher wrapping a RegExp', () => {
+            // stringMatching(regex) was still lowercasing `actual` without adding `i` to the
+            // regex, so ignoreCase had no effect on it
+            expect(compareText('Hello', expect.stringMatching(/Hello/), { ignoreCase: true }).success).toBe(true)
+            expect(compareText('Hello', jasmine.stringMatching(/Hello/), { ignoreCase: true }).success).toBe(true)
+            expect(compareText('Hello', expect.stringMatching(/Goodbye/), { ignoreCase: true }).success).toBe(false)
+        })
+
+        test('should apply ignoreCase to a stringMatching matcher wrapping a string', () => {
+            // expect.stringMatching(string) treats the string as regex source (both `expect` and
+            // jasmine build a RegExp from it immediately), so this is exercising the same `i`-flag
+            // path as a bare RegExp, not a plain case-insensitive string comparison
+            expect(compareText('Hello', expect.stringMatching('HELLO'), { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should not corrupt regex escapes when a stringMatching-like matcher stores a raw string sample', () => {
+            // stringMatching's sample is regex source, never literal text - `\D` means "non-digit".
+            // A matcher that (per its type contract, JasmineStringMatchingAsymmetricMatcher<string
+            // | RegExp>) stores the sample as a string rather than a pre-built RegExp must still be
+            // treated as regex source: lowercasing it as literal text would turn it into `\d`
+            // ("digit"), inverting the match entirely.
+            const rawStringSampleMatcher = {
+                constructor: { name: 'StringMatching' },
+                sample: '\\D+',
+            }
+            expect(compareText('abc', rawStringSampleMatcher as any, { ignoreCase: true }).success).toBe(true)
+            expect(compareText('123', rawStringSampleMatcher as any, { ignoreCase: true }).success).toBe(false)
+        })
+
+        test('should apply ignoreCase to an inverted (not.stringMatching) matcher', () => {
+            expect(compareText('Hello', expect.not.stringMatching(/Hello/), { ignoreCase: true }).success).toBe(false)
+            expect(compareText('Hello', expect.not.stringMatching(/Goodbye/), { ignoreCase: true }).success).toBe(true)
+        })
+
         test('should support undefined/null expected value', () => {
             expect(compareText(' FOO ', undefined, {}).success).toBe(false)
             expect(compareText(' FOO ', null, {}).success).toBe(false)
@@ -110,6 +190,30 @@ describe('utils', () => {
             expect(compareTextWithArray(' foo ', ['foO', 'BAR'], { trim: true, ignoreCase: true }).success).toBe(true)
             expect(compareTextWithArray(' foo ', ['foOo', 'BAR'], { trim: true, ignoreCase: true }).success).toBe(false)
             expect(compareTextWithArray(' FOO ', ['foOO', 'bar'], { trim: true, ignoreCase: true }).success).toBe(false)
+        })
+
+        test('should apply ignoreCase to RegExp entries in the array', () => {
+            expect(compareTextWithArray('Hello', [/Hello/], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray('HELLO', ['nope', /hello/], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray('Hello', [/Goodbye/], { ignoreCase: true }).success).toBe(false)
+        })
+
+        test('should match RegExp entries against the original-case actual value, not a lowercased copy', () => {
+            // see the equivalent compareText test for why: lowercasing 'İ' expands it to two
+            // code points, corrupting a length-sensitive pattern
+            expect(compareTextWithArray('İstanbul', [/^.{8}$/i], { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should preserve a sticky RegExp lastIndex when applying ignoreCase', () => {
+            const pattern = /world/y
+            pattern.lastIndex = 6
+            expect(compareTextWithArray('hello WORLD', [pattern], { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should apply ignoreCase to a stringMatching entry wrapping a RegExp', () => {
+            expect(compareTextWithArray('Hello', [expect.stringMatching(/Hello/)], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray('HELLO', ['nope', expect.stringMatching(/hello/)], { ignoreCase: true }).success).toBe(true)
+            expect(compareTextWithArray('Hello', [expect.stringMatching(/Goodbye/)], { ignoreCase: true }).success).toBe(false)
         })
 
         test('should pass if string contains and using containing', () => {


### PR DESCRIPTION
closes #2198 