### PR TITLE
fix(utils): treat atIndex: 0 as a valid index instead of falsy

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,7 +237,7 @@ export const compareText = (
         }
     }
 
-    if (atIndex) {
+    if (atIndex !== undefined) {
         return {
             actual,
             success: actual.substring(atIndex, actual.length).startsWith(expected),
@@ -317,7 +317,7 @@ export const compareTextWithArray = (
         if (atEnd) {
             return actual.endsWith(expected)
         }
-        if (atIndex) {
+        if (atIndex !== undefined) {
             return actual.substring(atIndex, actual.length).startsWith(expected)
         }
         return actual === expected
@@ -387,7 +387,7 @@ export const compareStyle = async (
         } else if (atEnd) {
             matches = actualVal.endsWith(expectedVal)
             actual[key] = actualVal
-        } else if (atIndex) {
+        } else if (atIndex !== undefined) {
             matches = actualVal.substring(atIndex, actualVal.length).startsWith(expectedVal)
             actual[key] = actualVal
         } else if (replace){

--- a/test/matchers/element/toHaveStyle.test.ts
+++ b/test/matchers/element/toHaveStyle.test.ts
@@ -307,6 +307,20 @@ Received: {"0": "Wrong Value", "1": "Wrong Value", "10": "Wrong Value", "2": "Wr
             expect(result.pass).toBe(false)
         })
 
+        test('success if style matches with atIndex 0', async () => {
+            // regression: `atIndex` was checked with a plain truthy test, so `atIndex: 0` was
+            // silently ignored and fell through to a strict equality check instead. Using a
+            // prefix of the actual value ('Fak' of 'Faktum') means the strict-equality fallback
+            // would fail, so this only passes with atIndex actually applied.
+            const result = await thisContext.toHaveStyle(el,
+                {
+                    'font-family': 'Fak',
+                },
+                { atIndex: 0 })
+
+            expect(result.pass).toBe(true)
+        })
+
         test('fails with an array as expected', async () => {
 
             // @ts-expect-error testing invalid input

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -90,6 +90,13 @@ describe('utils', () => {
             expect(compareText(' FOO ', undefined, {}).success).toBe(false)
             expect(compareText(' FOO ', null, {}).success).toBe(false)
         })
+
+        test('should apply atIndex when it is 0', () => {
+            // regression: `if (atIndex)` treated 0 as falsy and silently fell through to a plain
+            // equality check instead of substring(0, len).startsWith(expected)
+            expect(compareText('hello world', 'hello', { atIndex: 0 }).success).toBe(true)
+            expect(compareText('hello world', 'world', { atIndex: 0 }).success).toBe(false)
+        })
     })
 
     describe(compareTextWithArray, () => {
@@ -153,6 +160,13 @@ describe('utils', () => {
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), jasmine.stringContaining('oobb')], { ignoreCase: true }).success).toBe(true)
             expect(compareTextWithArray(' foo ', [jasmine.stringContaining('FOO'), 'oobb'], { ignoreCase: true }).success).toBe(true)
             expect(compareTextWithArray('foo', [jasmine.stringContaining('FOOO'), 'FOO'], { ignoreCase: true }).success).toBe(true)
+        })
+
+        test('should apply atIndex when it is 0', () => {
+            // regression: `if (atIndex)` treated 0 as falsy and silently fell through to a plain
+            // equality check instead of substring(0, len).startsWith(expected)
+            expect(compareTextWithArray('hello world', ['hello'], { atIndex: 0 }).success).toBe(true)
+            expect(compareTextWithArray('hello world', ['world'], { atIndex: 0 }).success).toBe(false)
         })
     })
 


### PR DESCRIPTION
closes #2200 