### PR TITLE
fix: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './api'

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
     "./types": "./types/expect-global.d.ts",
     "./expect-global": "./types/expect-global.d.ts",
     "./api": {
-      "types": "./types/expect-webdriverio.d.ts",
-      "import": "./lib/api/index.js"
-    }
+        "types": "./types/expect-webdriverio.d.ts",
+        "import": "./lib/api/index.js",
+        "require": "./lib/api/index.js",
+        "default": "./lib/api/index.js"
+      }
   },
   "types": "./types/expect-webdriverio.d.ts",
   "typeScriptVersion": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -45,12 +45,13 @@
     ],
     "./types": "./types/expect-global.d.ts",
     "./expect-global": "./types/expect-global.d.ts",
-    "./api": {
+    "./api": [
+      {
         "types": "./types/expect-webdriverio.d.ts",
-        "import": "./lib/api/index.js",
-        "require": "./lib/api/index.js",
-        "default": "./lib/api/index.js"
-      }
+        "import": "./lib/api/index.js"
+      },
+      "./lib/api/index.js"
+    ]
   },
   "types": "./types/expect-webdriverio.d.ts",
   "typeScriptVersion": "3.8.3",


### PR DESCRIPTION
Fix below error in webdriverio
```
Error: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './api' is not defined by "exports" in D:\a\webdriverio\webdriverio\node_modules\.pnpm\node_modules\expect-webdriverio\package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:605:13)
    at resolveExports (node:internal/modules/cjs/loader:707:36)
    at Module._findPath (node:internal/modules/cjs/loader:774:31)
    at node:internal/modules/cjs/loader:1502:27
    at m._resolveFilename (file:///D:/a/webdriverio/webdriverio/node_modules/.pnpm/tsx@4.21.0/node_modules/tsx/dist/register-B7jrtLTO.mjs:1:789)
    at nextResolveSimple (D:\a\webdriverio\webdriverio\node_modules\.pnpm\tsx@4.21.0\node_modules\tsx\dist\register-D46fvsV_.cjs:4:1004)
    at D:\a\webdriverio\webdriverio\node_modules\.pnpm\tsx@4.21.0\node_modules\tsx\dist\register-D46fvsV_.cjs:3:2630
    at D:\a\webdriverio\webdriverio\node_modules\.pnpm\tsx@4.21.0\node_modules\tsx\dist\register-D46fvsV_.cjs:3:1542
    at resolveTsPaths (D:\a\webdriverio\webdriverio\node_modules\.pnpm\tsx@4.21.0\node_modules\tsx\dist\register-D46fvsV_.cjs:4:760)
```